### PR TITLE
feat: add Bun dev one-liner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ The pre-cutover tree is preserved in the signed `pre-typescript` tag.
 
 ## Setup
 
-- Bun 1.3+ (`bun install --frozen-lockfile`).
+- Bun 1.3+ (`bun run dev` performs a frozen install before serving).
 - Docker only if you are validating the container image.
 - No Rust, Elixir, Erlang, or Swift toolchain is required for mainline work.
 
@@ -48,6 +48,9 @@ The pre-cutover tree is preserved in the signed `pre-typescript` tag.
 Run from the repo root.
 
 ```sh
+# One-command local UI + startup sync
+bun run dev
+
 # Quality gates
 bun test
 bunx tsc --noEmit
@@ -55,18 +58,18 @@ bunx biome check .
 just check
 
 # CLI
-bun src/cli.ts sync
-bun src/cli.ts ls
-bun src/cli.ts search "auth bug"
-bun src/cli.ts stats --by model
-bun src/cli.ts files --group ext
-bun src/cli.ts distill script
-bun src/cli.ts recommendations ls
-bun src/cli.ts --db /tmp/decant.db ls
+bun run src/cli.ts sync
+bun run src/cli.ts ls
+bun run src/cli.ts search "auth bug"
+bun run src/cli.ts stats --by model
+bun run src/cli.ts files --group ext
+bun run src/cli.ts distill script
+bun run src/cli.ts recommendations ls
+bun run src/cli.ts --db /tmp/decant.db ls
 
 # Long-running local modes
-bun src/cli.ts watch
-bun src/cli.ts serve
+bun run src/cli.ts watch
+bun run src/cli.ts serve
 
 # Distribution
 bun run scripts/build-binaries.ts --target native
@@ -80,7 +83,7 @@ Config:
 - Source dirs: `DECANT_CLAUDE_DIR`, `DECANT_CODEX_DIR`, or command flags.
 - Settings dir: `DECANT_CONFIG_DIR`; settings default to
   `~/.config/decant/settings.json`.
-- `serve` binds `127.0.0.1:4577` by default; override with `--host`/`--port`.
+- `serve` binds `127.0.0.1:3000` by default; override with `--host`/`--port`.
 
 ## Definition of done
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,16 +16,16 @@ on-ramp.
 ```bash
 git clone https://github.com/dosu-ai/decant
 cd decant
-bun install --frozen-lockfile
-pre-commit install
+bun run dev
 ```
 
-Try it end to end:
+`bun run dev` installs dependencies with `bun install --frozen-lockfile`, starts the
+local UI, and runs the startup sync. Open `http://127.0.0.1:3000`.
+
+Install optional hooks after setup if you use pre-commit locally:
 
 ```bash
-bun src/cli.ts sync
-bun src/cli.ts ls
-bun src/cli.ts serve
+pre-commit install
 ```
 
 ## Make your change

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV DECANT_CLAUDE_DIR=/sources/claude
 ENV DECANT_CODEX_DIR=/sources/codex
 
 VOLUME ["/var/lib/decant"]
-EXPOSE 4577
+EXPOSE 3000
 
 ENTRYPOINT ["/usr/local/bin/decant"]
-CMD ["serve", "--host", "0.0.0.0", "--port", "4577", "--no-fs-watch", "--interval-ms", "45000"]
+CMD ["serve", "--host", "0.0.0.0", "--port", "3000", "--no-fs-watch", "--interval-ms", "45000"]

--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ transcripts never leave your machine.
 Use source during the pre-release TypeScript migration:
 
 ```bash
-bun install --frozen-lockfile
-bun src/cli.ts sync
-bun src/cli.ts ls
-bun src/cli.ts serve
+bun run dev
 ```
+
+Requires Bun 1.3+. `bun run dev` installs dependencies with the lockfile
+frozen, starts `decant serve`, runs the startup sync, and keeps watching your
+source logs. The UI runs at `http://127.0.0.1:3000`.
 
 After the first Release workflow publishes packages, install from npm without
 installing Bun:
@@ -49,7 +50,7 @@ After the first Release workflow publishes an image, run the GHCR image:
 
 ```bash
 docker run --rm \
-  -p 127.0.0.1:4577:4577 \
+  -p 127.0.0.1:3000:3000 \
   -v decant-data:/var/lib/decant \
   -v "$HOME/.claude/projects:/sources/claude:ro" \
   -v "$HOME/.codex:/sources/codex:ro" \
@@ -57,11 +58,9 @@ docker run --rm \
 ```
 
 Keep the `127.0.0.1:` host prefix on the Docker port publish. Publishing as
-`-p 4577:4577` exposes the archive port on every host interface. The container
+`-p 3000:3000` exposes the archive port on every host interface. The container
 binds `0.0.0.0` only inside its own network namespace so Docker's host loopback
 publish can reach it.
-
-The UI runs at `http://127.0.0.1:4577`.
 
 ## CLI
 
@@ -93,7 +92,7 @@ All read commands support `--json`. Use `--db /path/to/decant.db` or
 - `DECANT_CODEX_DIR`: Codex home directory, default `~/.codex`.
 - `DECANT_CONFIG_DIR`: settings directory, default `~/.config/decant`.
 
-`decant serve` binds `127.0.0.1:4577` by default. Override with
+`decant serve` binds `127.0.0.1:3000` by default. Override with
 `--host`/`--port`.
 
 Archives older than schema v8 are rebuild-only. Delete the archive and re-run
@@ -122,6 +121,14 @@ Release automation is configured to publish npm packages and the GHCR image from
 the `Release` workflow once a version is dispatched.
 
 ## Development
+
+Run the local UI and watcher:
+
+```bash
+bun run dev
+```
+
+Run quality gates:
 
 ```bash
 bun test

--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -2,7 +2,7 @@
 
 `decant serve` runs the CLI, watcher, JSON routes, SSE stream, and React UI in
 one Bun process. These routes are internal app routes, not a versioned public
-contract.
+contract. By default, the server listens on `http://127.0.0.1:3000`.
 
 ## UI
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -67,7 +67,7 @@ Local run:
 
 ```sh
 docker run --rm \
-  -p 127.0.0.1:4577:4577 \
+  -p 127.0.0.1:3000:3000 \
   -v decant-data:/var/lib/decant \
   -v "$HOME/.claude/projects:/sources/claude:ro" \
   -v "$HOME/.codex:/sources/codex:ro" \
@@ -79,7 +79,7 @@ Release workflow publishes `ghcr.io/dosu-ai/decant:latest`.
 
 The container binds `0.0.0.0` inside the network namespace so Docker port
 publishing can reach it. Publish to `127.0.0.1` on the host, as shown above.
-Do not use `-p 4577:4577` unless you intentionally want to expose the archive
+Do not use `-p 3000:3000` unless you intentionally want to expose the archive
 port on every host interface.
 
 ## Source
@@ -87,9 +87,9 @@ port on every host interface.
 Source remains the contributor path and the fastest dev loop:
 
 ```sh
-bun install
-bun run src/cli.ts sync
-bun run src/cli.ts serve
+bun run dev
 ```
 
-Source installs require Bun. npm and Docker installs do not.
+`bun run dev` runs `bun install --frozen-lockfile`, starts `decant serve`, performs
+the startup sync, and keeps the archive current. Source installs require Bun.
+npm and Docker installs do not.

--- a/justfile
+++ b/justfile
@@ -4,6 +4,11 @@
 default:
     @just --list --unsorted
 
+# Local dev convenience wrappers
+[group('dev')]
+up *ARGS:
+    bun run dev -- {{ARGS}}
+
 # Quality gates
 [group('gates')]
 check: ts-check dist-check
@@ -58,38 +63,38 @@ docker-buildx *ARGS:
 # CLI
 [group('cli')]
 sync *ARGS:
-    bun src/cli.ts sync {{ARGS}}
+    bun run src/cli.ts sync {{ARGS}}
 
 [group('cli')]
 watch *ARGS:
-    bun src/cli.ts watch {{ARGS}}
+    bun run src/cli.ts watch {{ARGS}}
 
 [group('cli')]
 serve *ARGS:
-    bun src/cli.ts serve {{ARGS}}
+    bun run src/cli.ts serve {{ARGS}}
 
 [group('cli')]
 ls *ARGS:
-    bun src/cli.ts ls {{ARGS}}
+    bun run src/cli.ts ls {{ARGS}}
 
 [group('cli')]
 search QUERY *ARGS:
-    bun src/cli.ts search "{{QUERY}}" {{ARGS}}
+    bun run src/cli.ts search "{{QUERY}}" {{ARGS}}
 
 [group('cli')]
 stats *ARGS:
-    bun src/cli.ts stats {{ARGS}}
+    bun run src/cli.ts stats {{ARGS}}
 
 [group('cli')]
 db-info *ARGS:
-    bun src/cli.ts db info {{ARGS}}
+    bun run src/cli.ts db info {{ARGS}}
 
 # Data / maintenance
 [group('data')]
 [confirm("Delete ~/.decant/decant.db and re-ingest from ~/.claude + ~/.codex?")]
 db-rebuild:
     rm -f ~/.decant/decant.db ~/.decant/decant.db-wal ~/.decant/decant.db-shm
-    bun src/cli.ts sync
+    bun run src/cli.ts sync
 
 [group('data')]
 hooks:

--- a/npm/decant/README.md
+++ b/npm/decant/README.md
@@ -4,4 +4,4 @@ Node-compatible launcher for the Decant compiled binary.
 
 The package selects the matching optional platform package and executes its
 embedded Bun-compiled `decant` binary. Source development still uses Bun from
-the repository root.
+the repository root: `bun run dev`.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "bun": ">=1.3.0"
   },
   "scripts": {
+    "dev": "bun run scripts/dev.ts",
+    "up": "bun run dev",
+    "start": "bun run src/cli.ts serve",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,0 +1,33 @@
+const args = Bun.argv.slice(2);
+if (args[0] === "--") {
+  args.shift();
+}
+
+async function run(command: string[]): Promise<void> {
+  const proc = Bun.spawn(command, {
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    process.exit(exitCode);
+  }
+}
+
+await run(["bun", "install", "--frozen-lockfile"]);
+
+const serve = Bun.spawn(["bun", "run", "src/cli.ts", "serve", ...args], {
+  stdin: "inherit",
+  stdout: "inherit",
+  stderr: "inherit",
+});
+
+const forwardSignal = (signal: "SIGINT" | "SIGTERM"): void => {
+  serve.kill(signal);
+};
+
+process.once("SIGINT", () => forwardSignal("SIGINT"));
+process.once("SIGTERM", () => forwardSignal("SIGTERM"));
+
+process.exit(await serve.exited);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,7 +25,12 @@ import {
   markImplemented,
   parseStatusFilter,
 } from "./recommendations.ts";
-import { publishServerEvent, serve as serveApp } from "./server.ts";
+import {
+  DEFAULT_SERVE_HOST,
+  DEFAULT_SERVE_PORT,
+  publishServerEvent,
+  serve as serveApp,
+} from "./server.ts";
 import {
   byDimension,
   fileHotspots,
@@ -265,8 +270,8 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
   program
     .command("serve")
     .description("serve the in-process web UI and keep the archive current")
-    .option("--host <host>", "host to bind", "127.0.0.1")
-    .option("--port <n>", "port to bind", parseInteger, 4577)
+    .option("--host <host>", "host to bind", DEFAULT_SERVE_HOST)
+    .option("--port <n>", "port to bind", parseInteger, DEFAULT_SERVE_PORT)
     .option("--claude-dir <dir>", "override the Claude projects directory")
     .option("--codex-dir <dir>", "override the Codex home directory")
     .option("--interval-ms <ms>", "fallback sweep interval", parseInteger, DEFAULT_SYNC_INTERVAL_MS)
@@ -294,8 +299,8 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
           });
           const server = serveApp({
             config,
-            hostname: commandOptions.host ?? "127.0.0.1",
-            port: commandOptions.port ?? 4577,
+            hostname: commandOptions.host ?? DEFAULT_SERVE_HOST,
+            port: commandOptions.port ?? DEFAULT_SERVE_PORT,
           });
           const handle = startWatch({
             config,
@@ -305,7 +310,9 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
             onEvent: emitWatchEvent,
           });
           if (!isJson(globals()) && !globals().quiet) {
-            io.writeErr(`serving http://${commandOptions.host ?? "127.0.0.1"}:${server.port}\n`);
+            io.writeErr(
+              `serving http://${commandOptions.host ?? DEFAULT_SERVE_HOST}:${server.port}\n`,
+            );
           }
           try {
             await waitForProcessSignal();

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,9 @@ import {
 } from "./stats.ts";
 import uiBundle from "./ui/index.html";
 
+export const DEFAULT_SERVE_HOST = "127.0.0.1";
+export const DEFAULT_SERVE_PORT = 3000;
+
 export interface ServeOptions {
   config: Config;
   port?: number;
@@ -45,6 +48,8 @@ type Db = ReturnType<typeof openDb>;
 type ServerEvent = { type: string };
 interface RequestContext {
   db?: Db;
+  boundHostname?: string;
+  remoteAddress?: string | null;
 }
 
 const syncStatus = {
@@ -72,7 +77,7 @@ export async function handleRequest(
   context: RequestContext = {},
 ): Promise<Response> {
   const url = new URL(request.url);
-  const securityFailure = validateLocalRequest(request, url);
+  const securityFailure = validateLocalRequest(request, url, context);
   if (securityFailure != null) {
     return securityFailure;
   }
@@ -144,6 +149,10 @@ export async function handleRequest(
       });
     }
     if (request.method === "POST" && url.pathname === "/api/sync") {
+      const contentTypeFailure = requireJsonRequest(request);
+      if (contentTypeFailure != null) {
+        return contentTypeFailure;
+      }
       return syncNow(config);
     }
     if (request.method === "GET" && url.pathname === "/api/sessions") {
@@ -374,8 +383,8 @@ function formatSse(event: ServerEvent): string {
 }
 
 export function serve(options: ServeOptions): ReturnType<typeof Bun.serve> {
-  const hostname = options.hostname ?? "127.0.0.1";
-  const port = options.port ?? 4577;
+  const hostname = options.hostname ?? DEFAULT_SERVE_HOST;
+  const port = options.port ?? DEFAULT_SERVE_PORT;
   mkdirSync(dirname(options.config.dbPath), { recursive: true });
   const db = openDb(options.config.dbPath);
   const server = Bun.serve({
@@ -391,7 +400,12 @@ export function serve(options: ServeOptions): ReturnType<typeof Bun.serve> {
       "/files": uiBundle,
       "/settings": uiBundle,
     },
-    fetch: (request) => handleRequest(request, options.config, { db }),
+    fetch: (request, bunServer) =>
+      handleRequest(request, options.config, {
+        db,
+        boundHostname: hostname,
+        remoteAddress: bunServer.requestIP(request)?.address ?? null,
+      }),
   });
   const stop = server.stop.bind(server);
   let closed = false;
@@ -439,14 +453,22 @@ function json(value: unknown, status = 200): Response {
   });
 }
 
-function validateLocalRequest(request: Request, url: URL): Response | null {
+function validateLocalRequest(
+  request: Request,
+  url: URL,
+  context: RequestContext,
+): Response | null {
   if (!isProtectedPath(url.pathname)) {
     return null;
   }
   if (!isLoopbackHost(url.hostname)) {
     return json({ error: "forbidden host" }, 403);
   }
-  if (isMutatingMethod(request.method) && !isAllowedWriteRequest(request)) {
+  const boundToLoopback = isLoopbackHost(context.boundHostname ?? "127.0.0.1");
+  if (!boundToLoopback && !isLoopbackPeer(context.remoteAddress)) {
+    return json({ error: "forbidden remote" }, 403);
+  }
+  if (isMutatingMethod(request.method) && !isAllowedWriteRequest(request, boundToLoopback)) {
     return json({ error: "cross-origin writes are forbidden" }, 403);
   }
   return null;
@@ -460,12 +482,15 @@ function isMutatingMethod(method: string): boolean {
   return method !== "GET" && method !== "HEAD" && method !== "OPTIONS";
 }
 
-function isAllowedWriteRequest(request: Request): boolean {
+function isAllowedWriteRequest(request: Request, boundToLoopback: boolean): boolean {
   const origin = request.headers.get("origin");
   if (origin != null && !isLoopbackOrigin(origin)) {
     return false;
   }
   const site = request.headers.get("sec-fetch-site")?.toLowerCase();
+  if (!boundToLoopback && origin == null && site == null) {
+    return false;
+  }
   return site == null || site === "same-origin" || site === "same-site" || site === "none";
 }
 
@@ -481,8 +506,38 @@ function isLoopbackOrigin(origin: string): boolean {
 }
 
 function isLoopbackHost(hostname: string): boolean {
-  const normalized = hostname.toLowerCase();
-  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "[::1]";
+  const normalized = normalizeHost(hostname);
+  return normalized === "localhost" || normalized === "::1" || isIpv4Loopback(normalized);
+}
+
+function isLoopbackPeer(address: string | null | undefined): boolean {
+  if (address == null) {
+    return false;
+  }
+  const normalized = normalizeHost(address);
+  if (normalized.startsWith("::ffff:")) {
+    return isIpv4Loopback(normalized.slice("::ffff:".length));
+  }
+  return normalized === "::1" || isIpv4Loopback(normalized);
+}
+
+function normalizeHost(hostname: string): string {
+  const normalized = hostname.trim().toLowerCase();
+  return normalized.startsWith("[") && normalized.endsWith("]")
+    ? normalized.slice(1, -1)
+    : normalized;
+}
+
+function isIpv4Loopback(hostname: string): boolean {
+  const parts = hostname.split(".");
+  if (parts.length !== 4) {
+    return false;
+  }
+  const octets = parts.map((part) => Number.parseInt(part, 10));
+  return (
+    octets.every((octet, index) => String(octet) === parts[index] && octet >= 0 && octet <= 255) &&
+    octets[0] === 127
+  );
 }
 
 function requireJsonRequest(request: Request): Response | null {

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -145,6 +145,8 @@ type Recommendation = {
   trigger: string | null;
   evidence: string | null;
   success_metric: string | null;
+  note: string | null;
+  implemented_at: string | null;
 };
 
 type ConfigView = {
@@ -296,7 +298,7 @@ function App() {
       getJson<ToolRow[]>(withDateQuery("/api/tools/usage?limit=100", dateQuery)),
       getJson<McpRow[]>(withDateQuery("/api/tools/mcp-usage?limit=100", dateQuery)),
       getJson<FileRow[]>(withDateQuery("/api/files?group=path&limit=100", dateQuery)),
-      getJson<Recommendation[]>("/api/recommendations?status=open"),
+      getJson<Recommendation[]>("/api/recommendations?status=all"),
       getJson<ConfigView>("/api/config"),
       getJson<SettingsInfo>("/api/settings"),
       getJson<Activity>(withDateQuery("/api/analytics/activity", dateQuery)),
@@ -350,7 +352,7 @@ function App() {
       )
       .catch((err: unknown) => {
         if (!cancelled) {
-          setError(err instanceof Error ? err.message : String(err));
+          setError(errorMessage(err));
         }
       })
       .finally(() => {
@@ -379,6 +381,12 @@ function App() {
   const activeKey = activeRouteKey(path);
   const metrics = data.summary;
   const lastActivity = latestSessionDay(data.sessions);
+  const runSync = () => {
+    setError(null);
+    void getJson<unknown>("/api/sync", { method: "POST", body: "{}" })
+      .then(() => setReloadKey((key) => key + 1))
+      .catch((err: unknown) => setError(errorMessage(err)));
+  };
 
   return (
     <div className="app-shell">
@@ -463,6 +471,10 @@ function App() {
             <span>Search...</span>
             <kbd>/</kbd>
           </a>
+          <button className="secondary-button" onClick={runSync} type="button">
+            <Icon name="upload" />
+            Sync
+          </button>
           <a
             aria-label="Settings"
             className="icon-button"
@@ -2214,14 +2226,25 @@ function InsightsView({
   onMarked: () => void;
 }) {
   const [pending, setPending] = useState<string | null>(null);
-  const signals = rows
+  const [error, setError] = useState<string | null>(null);
+  const openRows = rows.filter((row) => row.status === "open");
+  const implementedRows = rows
+    .filter((row) => row.status === "implemented")
+    .slice()
+    .sort(
+      (left, right) =>
+        implementedTimestamp(right) - implementedTimestamp(left) || right.score - left.score,
+    );
+  const signals = openRows
     .filter((row) => row.kind === "signal")
     .slice()
     .sort((left, right) => right.score - left.score);
   const [hero, ...rest] = signals;
-  const catalogGroups = groupByCategory(rows.filter((row) => row.kind === "catalog"));
+  const catalogGroups = groupByCategory(openRows.filter((row) => row.kind === "catalog"));
+  const canLaunch = settingsInfo?.can_launch === true;
   const completeRecommendation = (row: Recommendation) => {
-    if (row.prompt != null && row.prompt.trim() !== "" && settingsInfo?.can_launch === true) {
+    setError(null);
+    if (isPresent(row.prompt) && canLaunch && settingsInfo != null) {
       setPending(row.key);
       void getJson<{ ok: boolean }>("/api/launch/agent", {
         method: "POST",
@@ -2232,10 +2255,11 @@ function InsightsView({
         }),
       })
         .then(() => onMarked())
+        .catch((err: unknown) => setError(errorMessage(err)))
         .finally(() => setPending(null));
       return;
     }
-    if (row.prompt != null && row.prompt.trim() !== "") {
+    if (isPresent(row.prompt)) {
       void navigator.clipboard?.writeText(handoffPrompt(row));
       return;
     }
@@ -2245,6 +2269,7 @@ function InsightsView({
       body: JSON.stringify({ key: row.key, source: "ui" }),
     })
       .then(onMarked)
+      .catch((err: unknown) => setError(errorMessage(err)))
       .finally(() => setPending(null));
   };
 
@@ -2254,6 +2279,8 @@ function InsightsView({
         <h1>Insights</h1>
         <p>What could make your coding agents better, drawn from your archive.</p>
       </header>
+
+      {error != null ? <div className="notice danger inline-notice">{error}</div> : null}
 
       <section className="view-stack">
         <div className="section-title-row">
@@ -2277,7 +2304,7 @@ function InsightsView({
             pending={pending}
             row={hero}
             onComplete={completeRecommendation}
-            canLaunch={settingsInfo?.can_launch === true}
+            canLaunch={canLaunch}
           />
         ) : null}
 
@@ -2289,7 +2316,7 @@ function InsightsView({
                 pending={pending}
                 row={row}
                 onComplete={completeRecommendation}
-                canLaunch={settingsInfo?.can_launch === true}
+                canLaunch={canLaunch}
               />
             ))}
           </div>
@@ -2315,7 +2342,7 @@ function InsightsView({
                     pending={pending}
                     row={row}
                     onComplete={completeRecommendation}
-                    canLaunch={settingsInfo?.can_launch === true}
+                    canLaunch={canLaunch}
                   />
                 ))}
               </div>
@@ -2323,7 +2350,46 @@ function InsightsView({
           ))}
         </section>
       ) : null}
+
+      {implementedRows.length > 0 ? (
+        <section className="view-stack insights-history-heading">
+          <div className="section-title-row">
+            <div>
+              <h2>Implemented</h2>
+              <p>Recommendations already marked complete</p>
+            </div>
+            <span>{formatInt(implementedRows.length)} saved</span>
+          </div>
+          <div className="catalog-grid">
+            {implementedRows.map((row) => (
+              <ImplementedRecommendationCard key={row.key} row={row} />
+            ))}
+          </div>
+        </section>
+      ) : null}
     </div>
+  );
+}
+
+function ImplementedRecommendationCard({ row }: { row: Recommendation }) {
+  const implementedLabel =
+    row.implemented_at == null ? "Implemented" : `Implemented ${shortDate(row.implemented_at)}`;
+  return (
+    <article className="catalog-card">
+      <div>
+        <span className={`signal-icon tone-${toneName(row.tone)}`}>
+          <Icon name={recommendationIcon(row)} />
+        </span>
+        <h4>{row.title}</h4>
+      </div>
+      <p className="settings-note">
+        {implementedLabel}
+        {isPresent(row.note) ? `: ${row.note}` : ""}
+      </p>
+      {row.detail != null ? <p>{row.detail}</p> : null}
+      {row.suggestion != null ? <p>{row.suggestion}</p> : null}
+      <PromotionPanel compact row={row} />
+    </article>
   );
 }
 
@@ -2743,18 +2809,34 @@ function SettingsView({
   settingsInfo: SettingsInfo | null;
 }) {
   const [settings, setSettings] = useState<UserSettings | null>(settingsInfo?.settings ?? null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     setSettings(settingsInfo?.settings ?? null);
+    setSaveError(null);
   }, [settingsInfo]);
 
   const save = (patch: Partial<UserSettings>) => {
-    const next = { ...(settings ?? settingsInfo?.settings), ...patch } as UserSettings;
+    const base = settings ?? settingsInfo?.settings;
+    if (base == null) {
+      return;
+    }
+    const previous = settings;
+    const next = { ...base, ...patch };
     setSettings(next);
+    setSaveError(null);
+    setSaving(true);
     void getJson<SettingsInfo>("/api/settings", {
       method: "POST",
       body: JSON.stringify(next),
-    }).then((response) => setSettings(response.settings));
+    })
+      .then((response) => setSettings(response.settings))
+      .catch((err: unknown) => {
+        setSettings(previous ?? base);
+        setSaveError(errorMessage(err));
+      })
+      .finally(() => setSaving(false));
   };
 
   return (
@@ -2791,12 +2873,15 @@ function SettingsView({
             onChange={(ide) => save({ ide })}
           />
         </div>
-      </section>
-      {settingsInfo?.can_launch !== true ? (
+        {saveError != null ? <div className="notice danger inline-notice">{saveError}</div> : null}
         <p className="settings-note">
-          Opening terminals and editors works on macOS only. Your choices are still saved.
+          {saving
+            ? "Saving preferences..."
+            : settingsInfo?.can_launch === true
+              ? "Native launcher is available on this Mac."
+              : "Native launcher is unavailable on this platform."}
         </p>
-      ) : null}
+      </section>
     </div>
   );
 }
@@ -2836,12 +2921,35 @@ function SettingSelect({
 
 function SessionDetailView({ id }: { id: number }) {
   const [detail, setDetail] = useState<SessionDetailData | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (Number.isFinite(id)) {
-      void getJson<SessionDetailData>(`/api/sessions/${id}`).then(setDetail);
+    let cancelled = false;
+    setDetail(null);
+    setError(null);
+    if (!Number.isFinite(id)) {
+      setError("Invalid session id.");
+      return;
     }
+    void getJson<SessionDetailData>(`/api/sessions/${id}`)
+      .then((next) => {
+        if (!cancelled) {
+          setDetail(next);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(errorMessage(err));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [id]);
+
+  if (error != null) {
+    return <div className="notice danger">Unable to load session: {error}</div>;
+  }
 
   if (detail == null) {
     return <div className="notice">Preparing session...</div>;
@@ -3161,6 +3269,10 @@ function formatDateLabel(value: string): string {
   return date.toLocaleDateString(undefined, { month: "short", day: "2-digit", year: "numeric" });
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function activeRoute(path: string): string {
   const pathname = pathOnly(path);
   if (pathname.startsWith("/sessions/")) {
@@ -3186,6 +3298,23 @@ function activeRouteKey(path: string): string {
 
 function titleFor(active: string): string {
   return active === "Sessions" ? "Session Archive" : active;
+}
+
+function shortDate(value: string): string {
+  const time = Date.parse(value);
+  if (!Number.isFinite(time)) {
+    return value;
+  }
+  return new Date(time).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function implementedTimestamp(row: Recommendation): number {
+  const time = Date.parse(row.implemented_at ?? "");
+  return Number.isFinite(time) ? time : 0;
 }
 
 function prettyJson(value: string | null): string {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1495,6 +1495,10 @@ mark {
   gap: 12px;
 }
 
+.insights-history-heading {
+  margin-top: 20px;
+}
+
 .catalog-card {
   display: flex;
   flex-direction: column;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -272,5 +272,6 @@ describe("runCli", () => {
     expect(serve.stdout).toContain("in-process web UI");
     expect(serve.stdout).toContain("--host");
     expect(serve.stdout).toContain("--port");
+    expect(serve.stdout).toContain("(default: 3000)");
   });
 });

--- a/test/distill.test.ts
+++ b/test/distill.test.ts
@@ -108,8 +108,8 @@ describe("distill pure helpers", () => {
     expect(url).toContain("https://alice:<REDACTED>@github.com");
     expect(url).not.toContain("supersecretpw");
 
-    const [gluedUrl] = redact("echo abc9postgres://alice:supersecretpw@db.local/app");
-    expect(gluedUrl).toContain("abc9postgres://alice:<REDACTED>@db.local/app");
+    const [gluedUrl] = redact("echo x_postgres://alice:supersecretpw@db.local/app");
+    expect(gluedUrl).toContain("x_postgres://alice:<REDACTED>@db.local/app");
     expect(gluedUrl).not.toContain("supersecretpw");
 
     const [header] = redact("curl -H 'X-Api-Key: abcdef1234567890'");

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -77,7 +77,7 @@ async function route(
   if (init.body != null && !headers.has("content-type")) {
     headers.set("content-type", "application/json");
   }
-  const request = new Request(`http://127.0.0.1:4577${path}`, { ...init, headers });
+  const request = new Request(`http://127.0.0.1:3000${path}`, { ...init, headers });
   const response = await handleRequest(request, config);
   const contentType = response.headers.get("content-type");
   const body = contentType?.startsWith("application/json")
@@ -126,7 +126,7 @@ describe("server routes", () => {
 
   test("events route streams hello and published updates", async () => {
     const config = freshConfig();
-    const response = await handleRequest(new Request("http://127.0.0.1:4577/api/events"), config);
+    const response = await handleRequest(new Request("http://127.0.0.1:3000/api/events"), config);
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe("text/event-stream; charset=utf-8");
 
@@ -153,11 +153,53 @@ describe("server routes", () => {
     expect(await response.json()).toEqual({ error: "forbidden host" });
   });
 
+  test("rejects protected routes from non-loopback peers on broad binds", async () => {
+    const config = freshConfig();
+
+    const spoofedHost = await handleRequest(
+      new Request("http://127.0.0.1:3000/api/config"),
+      config,
+      { boundHostname: "0.0.0.0", remoteAddress: "192.168.1.20" },
+    );
+    expect(spoofedHost.status).toBe(403);
+    expect(await spoofedHost.json()).toEqual({ error: "forbidden remote" });
+
+    const loopbackRead = await handleRequest(
+      new Request("http://127.0.0.1:3000/api/config"),
+      config,
+      { boundHostname: "0.0.0.0", remoteAddress: "::ffff:127.0.0.1" },
+    );
+    expect(loopbackRead.status).toBe(200);
+
+    const bareLocalWrite = await handleRequest(
+      new Request("http://127.0.0.1:3000/api/sync", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }),
+      config,
+      { boundHostname: "0.0.0.0", remoteAddress: "127.0.0.1" },
+    );
+    expect(bareLocalWrite.status).toBe(403);
+    expect(await bareLocalWrite.json()).toEqual({ error: "cross-origin writes are forbidden" });
+
+    const browserLocalWrite = await handleRequest(
+      new Request("http://127.0.0.1:3000/api/sync", {
+        method: "POST",
+        headers: { "content-type": "application/json", "sec-fetch-site": "same-origin" },
+        body: "{}",
+      }),
+      config,
+      { boundHostname: "0.0.0.0", remoteAddress: "127.0.0.1" },
+    );
+    expect(browserLocalWrite.status).toBe(200);
+  });
+
   test("rejects cross-origin and non-json mutating requests", async () => {
     const config = freshConfig();
 
     const crossSite = await handleRequest(
-      new Request("http://127.0.0.1:4577/api/launch/agent", {
+      new Request("http://127.0.0.1:3000/api/launch/agent", {
         method: "POST",
         headers: {
           "content-type": "text/plain",
@@ -172,7 +214,7 @@ describe("server routes", () => {
     expect(await crossSite.json()).toEqual({ error: "cross-origin writes are forbidden" });
 
     const textPlain = await handleRequest(
-      new Request("http://127.0.0.1:4577/api/search", {
+      new Request("http://127.0.0.1:3000/api/search", {
         method: "POST",
         headers: { "content-type": "text/plain" },
         body: JSON.stringify({ query: "auth" }),
@@ -181,6 +223,15 @@ describe("server routes", () => {
     );
     expect(textPlain.status).toBe(415);
     expect(await textPlain.json()).toEqual({ error: "content-type must be application/json" });
+
+    const syncWithoutJson = await handleRequest(
+      new Request("http://127.0.0.1:3000/api/sync", { method: "POST" }),
+      config,
+    );
+    expect(syncWithoutJson.status).toBe(415);
+    expect(await syncWithoutJson.json()).toEqual({
+      error: "content-type must be application/json",
+    });
   });
 
   test("settings routes read options and persist sanitized choices", async () => {
@@ -369,7 +420,7 @@ describe("server routes", () => {
   test("sync route ingests configured source directories", async () => {
     const config = freshConfig();
 
-    const result = await route(config, "/api/sync", { method: "POST" });
+    const result = await route(config, "/api/sync", { method: "POST", body: "{}" });
     expect(result.status).toBe(200);
     expect(result.body).toMatchObject({
       scanned: 0,


### PR DESCRIPTION
## Summary
- add Bun-native `bun run dev` / `bun run up` one-liner that performs a frozen install, starts `decant serve`, and forwards serve args
- move local serve, Docker, tests, and docs to Bun default port `3000`
- apply audit follow-ups for broad-bind peer protection, JSON-only sync writes, UI error states, implemented recommendation history, and redactor regression coverage
- refresh README, CONTRIBUTING, AGENTS, distribution, routes, npm README, and command examples

## Review
- PR-style review pass found no remaining blockers after the rebase conflict resolution
- left `docs/superpowers/...` historical plan/spec files untouched because they are ignored and marked “Never commit”

## Tests
- `bun run dev -- --help`
- `bun run dev -- --port 4000 --help`
- `bun test test/cli.test.ts test/server.test.ts`
- `bunx tsc --noEmit`
- `bunx biome check .`
- `just check`