### PR TITLE
[codex] restore path-scoped and streaming sync ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ decant completion zsh
 
 All read commands support `--json`. Use `--db /path/to/decant.db` or
 `DECANT_DB` for an alternate archive. Use `decant sync --path /path/to/log-or-dir`
-to ingest only specific source files or a temporary source tree; pass `--path`
-more than once to ingest multiple paths.
+to ingest only specific source files or a temporary source tree, including raw
+Claude `stream-json` logs; pass `--path` more than once to ingest multiple paths.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ decant completion zsh
 ```
 
 All read commands support `--json`. Use `--db /path/to/decant.db` or
-`DECANT_DB` for an alternate archive.
+`DECANT_DB` for an alternate archive. Use `decant sync --path /path/to/log-or-dir`
+to ingest only specific source files or a temporary source tree; pass `--path`
+more than once to ingest multiple paths.
 
 ## Configuration
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -186,12 +186,25 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
     return archive;
   };
 
-  const runSync = (commandOptions: { claudeDir?: string; codexDir?: string }): number => {
+  const runSync = (commandOptions: {
+    claudeDir?: string;
+    codexDir?: string;
+    path?: string[];
+  }): number => {
+    const missingPath = commandOptions.path?.find((path) => !existsSync(path));
+    if (missingPath != null) {
+      io.writeErr(`error: --path does not exist: ${missingPath}\n`);
+      return 2;
+    }
+
     const archive = openArchive(
       resolve({ claudeDir: commandOptions.claudeDir, codexDir: commandOptions.codexDir }),
     );
     try {
-      const report = ingestSync(archive.db, archive.config);
+      const report = ingestSync(archive.db, {
+        ...archive.config,
+        sourcePaths: commandOptions.path,
+      });
       const jsonReport = {
         scanned: report.scanned,
         ingested: report.ingested,
@@ -218,7 +231,13 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
     .description("scan session directories and upsert new or changed sessions")
     .option("--claude-dir <dir>", "override the Claude projects directory")
     .option("--codex-dir <dir>", "override the Codex home directory")
-    .action((commandOptions: { claudeDir?: string; codexDir?: string }) =>
+    .option(
+      "--path <path>",
+      "ingest only this source file or directory (repeatable)",
+      collectOption,
+      [] as string[],
+    )
+    .action((commandOptions: { claudeDir?: string; codexDir?: string; path?: string[] }) =>
       run(() => runSync(commandOptions)),
     );
 

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -18,6 +18,7 @@ import { resolveWorktreeRoots } from "./worktree.ts";
 export interface IngestConfig {
   claudeDir: string;
   codexDir: string;
+  sourcePaths?: string[];
 }
 
 export interface SyncReport {
@@ -51,23 +52,23 @@ interface ToolUseBlock {
 }
 
 export function discover(config: IngestConfig): SourceFile[] {
+  if (config.sourcePaths != null && config.sourcePaths.length > 0) {
+    return discoverSourcePaths(config.sourcePaths);
+  }
+
   const out: SourceFile[] = [];
   collect(config.claudeDir, "claude_code", false, (name) => name.endsWith(".jsonl"), out);
-  collect(
-    join(config.codexDir, "sessions"),
-    "codex",
-    false,
-    (name) => name.startsWith("rollout-") && name.endsWith(".jsonl"),
-    out,
-  );
-  collect(
-    join(config.codexDir, "archived_sessions"),
-    "codex",
-    true,
-    (name) => name.startsWith("rollout-") && name.endsWith(".jsonl"),
-    out,
-  );
+  collect(join(config.codexDir, "sessions"), "codex", false, isCodexRollout, out);
+  collect(join(config.codexDir, "archived_sessions"), "codex", true, isCodexRollout, out);
   return out;
+}
+
+export function discoverSourcePaths(paths: string[]): SourceFile[] {
+  const out: SourceFile[] = [];
+  for (const path of paths) {
+    collectSourcePath(path, out);
+  }
+  return dedupeSourceFiles(out);
 }
 
 export function sync(
@@ -673,6 +674,66 @@ function collect(
       out.push({ tool, path, archived });
     }
   }
+}
+
+function collectSourcePath(path: string, out: SourceFile[]): void {
+  let stats: Stats;
+  try {
+    stats = statSync(path);
+  } catch {
+    return;
+  }
+
+  if (stats.isFile()) {
+    const source = sourceFileForPath(path);
+    if (source != null) {
+      out.push(source);
+    }
+    return;
+  }
+
+  if (!stats.isDirectory()) {
+    return;
+  }
+
+  for (const child of walk(path)) {
+    const source = sourceFileForPath(child);
+    if (source != null) {
+      out.push(source);
+    }
+  }
+}
+
+function sourceFileForPath(path: string): SourceFile | null {
+  const name = pathBasename(path);
+  if (!name.endsWith(".jsonl") || name === "session_index.jsonl") {
+    return null;
+  }
+  if (isCodexRollout(name)) {
+    return { tool: "codex", path, archived: hasPathSegment(path, "archived_sessions") };
+  }
+  return { tool: "claude_code", path, archived: false };
+}
+
+function dedupeSourceFiles(files: SourceFile[]): SourceFile[] {
+  const seen = new Set<string>();
+  const unique: SourceFile[] = [];
+  for (const file of files) {
+    if (seen.has(file.path)) {
+      continue;
+    }
+    seen.add(file.path);
+    unique.push(file);
+  }
+  return unique;
+}
+
+function isCodexRollout(name: string): boolean {
+  return name.startsWith("rollout-") && name.endsWith(".jsonl");
+}
+
+function hasPathSegment(path: string, segment: string): boolean {
+  return path.split(/[\\/]+/).includes(segment);
 }
 
 function readClaudeSidecarMeta(path: string): Json | null {

--- a/src/sources/claude.ts
+++ b/src/sources/claude.ts
@@ -56,6 +56,8 @@ export function parseClaudeSession(
   let cwd: string | null = null;
   let gitBranch: string | null = null;
   let cliVersion: string | null = null;
+  let sessionModel: string | null = null;
+  let resultTotals: TokenUsage | null = null;
   let startedAt: string | null = null;
   let endedAt: string | null = null;
   let title: string | null = null;
@@ -78,22 +80,23 @@ export function parseClaudeSession(
       continue;
     }
 
-    const typ = asString(get(value, "type")) ?? "";
-    rootSourceSessionId ??= asString(get(value, "sessionId"));
+    const typ = stringAt(value, "type") ?? "";
+    rootSourceSessionId ??= stringAt(value, "sessionId", "session_id");
     if (asBoolean(get(value, "isSidechain")) === true) {
       sawSidechainRecord = true;
     } else if (typ === "user" || typ === "assistant" || typ === "system") {
       sawMainRecord = true;
     }
-    agentId ??= asString(get(value, "agentId"));
-    const timestamp = asString(get(value, "timestamp"));
+    agentId ??= stringAt(value, "agentId", "agent_id");
+    const timestamp = stringAt(value, "timestamp");
     if (timestamp != null) {
       startedAt ??= timestamp;
       endedAt = timestamp;
     }
-    cwd ??= asString(get(value, "cwd"));
-    gitBranch ??= asString(get(value, "gitBranch"));
-    cliVersion ??= asString(get(value, "version"));
+    cwd ??= stringAt(value, "cwd");
+    gitBranch ??= stringAt(value, "gitBranch", "git_branch");
+    cliVersion ??= stringAt(value, "version", "cli_version");
+    sessionModel ??= stringAt(get(value, "message"), "model") ?? stringAt(value, "model");
 
     if (typ === "user") {
       const message = parseUser(value, seq);
@@ -107,7 +110,7 @@ export function parseClaudeSession(
       seq += 1;
     } else if (typ === "assistant") {
       const message = parseAssistant(value, seq);
-      const requestId = asString(get(value, "requestId"));
+      const requestId = stringAt(value, "requestId", "request_id");
       const key = requestId ?? `\0seq${seq}`;
       const [output, visible, hasThinking] = lineReasoningInputs(message);
       const acc = turns.get(key) ?? { output: 0, visible: 0, hasThinking: false };
@@ -120,9 +123,11 @@ export function parseClaudeSession(
     } else if (typ === "system") {
       messages.push(simpleMessage(value, "system", seq));
       seq += 1;
+    } else if (typ === "result") {
+      resultTotals = parseUsage(get(value, "usage")) ?? resultTotals;
     } else if (KNOWN_META.has(typ)) {
       if (title == null) {
-        const metaTitle = asString(get(value, "summary")) ?? asString(get(value, "title"));
+        const metaTitle = stringAt(value, "summary", "title");
         if (metaTitle != null) {
           title = truncate(metaTitle, 120);
         }
@@ -133,17 +138,18 @@ export function parseClaudeSession(
     }
   }
 
-  const totals = emptyUsage();
+  const messageTotals = emptyUsage();
   for (const message of messages) {
     if (message.usage == null) {
       continue;
     }
-    totals.input += message.usage.input;
-    totals.output += message.usage.output;
-    totals.cacheRead += message.usage.cacheRead;
-    totals.cacheCreation += message.usage.cacheCreation;
-    totals.reasoning += message.usage.reasoning;
+    messageTotals.input += message.usage.input;
+    messageTotals.output += message.usage.output;
+    messageTotals.cacheRead += message.usage.cacheRead;
+    messageTotals.cacheCreation += message.usage.cacheCreation;
+    messageTotals.reasoning += message.usage.reasoning;
   }
+  const totals = resultTotals ?? messageTotals;
 
   let estReasoningTokens = 0;
   let anyThinking = false;
@@ -154,8 +160,11 @@ export function parseClaudeSession(
     anyThinking = true;
     estReasoningTokens += Math.max(0, turn.output - Math.trunc(turn.visible / CHARS_PER_TOKEN));
   }
+  if (resultTotals != null) {
+    estReasoningTokens = Math.min(estReasoningTokens, resultTotals.output);
+  }
 
-  const model = primaryModel(messages);
+  const model = primaryModel(messages) ?? sessionModel;
   const meta = isObject(options.sidecarMeta) ? options.sidecarMeta : {};
   const spawnToolUseId = asString(meta.toolUseId);
   const agentType =
@@ -261,12 +270,12 @@ function compareModelCandidate(
 function simpleMessage(value: Json, role: Role, seq: number): NormalizedMessage {
   return {
     seq,
-    sourceUuid: asString(get(value, "uuid")),
-    parentSourceUuid: asString(get(value, "parentUuid")),
+    sourceUuid: sourceUuid(value),
+    parentSourceUuid: stringAt(value, "parentUuid", "parent_uuid"),
     role,
     model: null,
     stopReason: null,
-    timestamp: asString(get(value, "timestamp")),
+    timestamp: stringAt(value, "timestamp"),
     usage: null,
     raw: value,
     blocks: [],
@@ -308,12 +317,12 @@ function parseUser(value: Json, seq: number): NormalizedMessage {
 
   return {
     seq,
-    sourceUuid: asString(get(value, "uuid")),
-    parentSourceUuid: asString(get(value, "parentUuid")),
+    sourceUuid: sourceUuid(value),
+    parentSourceUuid: stringAt(value, "parentUuid", "parent_uuid"),
     role: hasToolResult && !hasText ? "tool" : "user",
     model: null,
     stopReason: null,
-    timestamp: asString(get(value, "timestamp")),
+    timestamp: stringAt(value, "timestamp"),
     usage: null,
     raw: value,
     blocks,
@@ -359,12 +368,12 @@ function parseAssistant(value: Json, seq: number): NormalizedMessage {
 
   return {
     seq,
-    sourceUuid: asString(get(value, "uuid")),
-    parentSourceUuid: asString(get(value, "parentUuid")),
+    sourceUuid: sourceUuid(value),
+    parentSourceUuid: stringAt(value, "parentUuid", "parent_uuid"),
     role: "assistant",
     model: asString(get(message, "model")),
     stopReason: asString(get(message, "stop_reason")),
-    timestamp: asString(get(value, "timestamp")),
+    timestamp: stringAt(value, "timestamp"),
     usage: parseUsage(get(message, "usage")),
     raw: value,
     blocks,
@@ -382,6 +391,10 @@ function parseUsage(value: Json | undefined): TokenUsage | null {
     cacheCreation: asInteger(value.cache_creation_input_tokens) ?? 0,
     reasoning: 0,
   };
+}
+
+function sourceUuid(value: Json): string | null {
+  return stringAt(value, "uuid") ?? stringAt(get(value, "message"), "id");
 }
 
 function billAssistant(
@@ -468,6 +481,16 @@ function get(value: Json | undefined, key: string): Json | undefined {
     return undefined;
   }
   return value[key];
+}
+
+function stringAt(value: Json | undefined, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const got = asString(get(value, key));
+    if (got != null) {
+      return got;
+    }
+  }
+  return null;
 }
 
 function hasKey(value: Json, key: string): boolean {

--- a/test/claude.test.ts
+++ b/test/claude.test.ts
@@ -63,6 +63,49 @@ describe("parseClaudeSession", () => {
     expect(session.totals.output).toBe(500);
   });
 
+  test("stream-json result totals are used for raw Claude streams", () => {
+    const content = [
+      '{"type":"system","subtype":"init","session_id":"stream-1","cwd":"/repo","git_branch":"main","model":"claude-opus-4-7","timestamp":"2026-05-01T10:00:00.000Z"}',
+      '{"type":"user","session_id":"stream-1","message":{"role":"user","content":"Price this streaming run"}}',
+      '{"type":"assistant","session_id":"stream-1","message":{"id":"msg-1","role":"assistant","content":[{"type":"text","text":"Done"}]}}',
+      '{"type":"result","subtype":"success","session_id":"stream-1","usage":{"input_tokens":123,"output_tokens":45,"cache_read_input_tokens":6,"cache_creation_input_tokens":7},"total_cost_usd":0.01}',
+    ].join("\n");
+    const session = parseClaudeSession("stream-file", `${content}\n`).session;
+    expect(session.rootSourceSessionId).toBe("stream-1");
+    expect(session.rawMeta).toMatchObject({ sessionId: "stream-1" });
+    expect(session.title).toBe("Price this streaming run");
+    expect(session.cwd).toBe("/repo");
+    expect(session.gitBranch).toBe("main");
+    expect(session.model).toBe("claude-opus-4-7");
+    expect(session.totals).toMatchObject({
+      input: 123,
+      output: 45,
+      cacheRead: 6,
+      cacheCreation: 7,
+    });
+    expect(session.messages.map((message) => message.role)).toEqual([
+      "system",
+      "user",
+      "assistant",
+    ]);
+    expect(session.messages[2]?.sourceUuid).toBe("msg-1");
+    expect(session.messages[2]?.usage).toBeNull();
+  });
+
+  test("snake case streaming request ids de-dupe cumulative assistant usage", () => {
+    const content = [
+      '{"type":"assistant","request_id":"req-1","message":{"role":"assistant","model":"claude-opus-4-7","usage":{"input_tokens":100,"output_tokens":200,"cache_read_input_tokens":10,"cache_creation_input_tokens":5},"content":[{"type":"thinking","thinking":"","signature":"sig"}]}}',
+      '{"type":"assistant","request_id":"req-1","message":{"role":"assistant","model":"claude-opus-4-7","usage":{"input_tokens":100,"output_tokens":400,"cache_read_input_tokens":10,"cache_creation_input_tokens":5},"content":[{"type":"text","text":"done"}]}}',
+    ].join("\n");
+    const session = parseClaudeSession("s", `${content}\n`).session;
+    expect(session.totals.input).toBe(100);
+    expect(session.totals.output).toBe(400);
+    expect(session.totals.cacheRead).toBe(10);
+    expect(session.totals.cacheCreation).toBe(5);
+    expect(session.messages[0]?.usage).toBeNull();
+    expect(session.messages[1]?.usage?.output).toBe(400);
+  });
+
   test("reasoning is estimated by subtraction on thinking turns", () => {
     const content = [
       '{"type":"assistant","requestId":"req-e","message":{"role":"assistant","model":"claude-opus-4-7","usage":{"input_tokens":50,"output_tokens":300,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"content":[{"type":"thinking","thinking":"","signature":"sig"}]}}',

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -192,6 +192,31 @@ describe("runCli", () => {
     );
   });
 
+  test("sync --path ingests only the requested source files", async () => {
+    const fixtureCase = freshCase();
+    const targetDir = join(workDir, `case-${caseCounter}-targeted`);
+    const claudePath = join(targetDir, "claude-one.jsonl");
+    const codexPath = join(targetDir, "rollout-codex-one.jsonl");
+    mkdirSync(targetDir, { recursive: true });
+    copyFileSync(join(import.meta.dir, "..", "fixtures", "claude", "sample.jsonl"), claudePath);
+    copyFileSync(join(import.meta.dir, "..", "fixtures", "codex", "sample.jsonl"), codexPath);
+
+    const result = await runCli(
+      ["--db", fixtureCase.dbPath, "--json", "sync", "--path", claudePath, "--path", codexPath],
+      { homeDir: targetDir },
+    );
+    expect(result).toMatchObject({ code: 0, stderr: "" });
+    expect(JSON.parse(result.stdout)).toMatchObject({ scanned: 2, ingested: 2, issues: 0 });
+
+    const list = await runCli(["--db", fixtureCase.dbPath, "--json", "--no-sync", "ls"]);
+    expect(list.code).toBe(0);
+    expect(
+      (JSON.parse(list.stdout) as { source_session_id: string }[]).map(
+        (session) => session.source_session_id,
+      ),
+    ).toEqual(["sess-codex-1", "claude-one"]);
+  });
+
   test("invalid options return code 2 with an error", async () => {
     const { dbPath } = await syncedCase();
     const unknownOption = await runCli(["--definitely-not-real"]);
@@ -205,6 +230,10 @@ describe("runCli", () => {
     const result = await runCli(["--db", dbPath, "--no-sync", "stats", "--by", "nope"]);
     expect(result.code).toBe(2);
     expect(result.stderr).toContain("unknown --by value");
+
+    const missingPath = await runCli(["--db", dbPath, "sync", "--path", "/tmp/definitely-missing"]);
+    expect(missingPath.code).toBe(2);
+    expect(missingPath.stderr).toContain("--path does not exist");
 
     const badFormat = await runCli(["--format", "bogus", "ls"]);
     expect(badFormat.code).toBe(2);

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -284,6 +284,34 @@ describe("sync", () => {
     ]);
   });
 
+  test("discovers only explicitly requested source paths when sourcePaths is set", () => {
+    const dir = freshCase();
+    const config: IngestConfig = {
+      claudeDir: join(dir, "claude"),
+      codexDir: join(dir, "codex"),
+      sourcePaths: [join(dir, "selected"), join(dir, "selected", "claude", "one.jsonl")],
+    };
+    write(join(config.claudeDir, "ignored.jsonl"), "");
+    write(join(config.codexDir, "sessions", "rollout-ignored.jsonl"), "");
+    write(join(dir, "selected", "claude", "one.jsonl"), "");
+    write(join(dir, "selected", "codex", "sessions", "rollout-one.jsonl"), "");
+    write(join(dir, "selected", "codex", "archived_sessions", "rollout-old.jsonl"), "");
+    write(join(dir, "selected", "codex", "session_index.jsonl"), "");
+    write(join(dir, "selected", "notes.txt"), "");
+
+    expect(
+      discover(config).map((file) => ({
+        tool: file.tool,
+        name: basename(file.path),
+        archived: file.archived,
+      })),
+    ).toEqual([
+      { tool: "claude_code", name: "one.jsonl", archived: false },
+      { tool: "codex", name: "rollout-old.jsonl", archived: true },
+      { tool: "codex", name: "rollout-one.jsonl", archived: false },
+    ]);
+  });
+
   test("is idempotent, records parse issues, and refreshes issues on reingest", () => {
     const dir = freshCase();
     const config: IngestConfig = {


### PR DESCRIPTION
## Summary

Restores path-scoped sync and raw Claude stream-json ingestion so callers can ingest a specific AI coding-agent log file or temporary source tree through decant's normal archive, stats, and cost pipeline.

## Root Cause

The TypeScript mainline kept whole-root sync via `--claude-dir` and `--codex-dir`, but no CLI surface survived for targeted source paths. That forced downstream tooling either to reshape entire source roots or to consider out-of-band parsing/pricing shims.

That still was not enough for Michael's streaming-log case: raw Claude `stream-json` logs use snake_case identifiers such as `session_id` / `request_id` and carry authoritative aggregate token usage on the final `result.usage` line. The parser only understood the persisted session-log casing and assistant-message usage chunks, so raw streaming logs could ingest without reliable pricing.

## Changes

- Add repeatable `decant sync --path <path>` for targeted source files or directories.
- Route targeted paths through the normal decant ingest and cost pipeline.
- Keep Codex detection aligned with existing source discovery: `rollout-*.jsonl` files are Codex; other JSONL files are Claude; `session_index.jsonl` is ignored as metadata.
- Return exit code 2 when an explicitly requested `--path` does not exist.
- Teach the Claude parser to accept stream-json field aliases (`session_id`, `request_id`, `git_branch`, message `id`).
- Use stream-json `result.usage` as authoritative session totals when present.
- Document targeted sync and raw Claude `stream-json` path ingest in the README.

## PR-Style Review

Reviewed before publishing. One issue was found and fixed: explicit `--path` typos originally produced a silent zero-row sync, which would hide caller mistakes. The CLI now reports `--path does not exist` and exits 2.

Follow-up review after Michael's clarification found a second gap: targeted ingest accepted raw stream files, but the Claude parser still needed stream-json aliases and result-line totals to price those logs correctly. That is now covered by focused parser tests.

## Validation

- `bun test test/claude.test.ts test/ingest.test.ts test/cli.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bunx biome check .`
- `just check`
