### PR TITLE
[codex] Fix Codex activity bucket classification

### DIFF
--- a/src/buckets.ts
+++ b/src/buckets.ts
@@ -3,22 +3,23 @@ import type { Json } from "./model.ts";
 export const ACTIVITY_BUCKETS = ["planning", "communicating", "context", "code"] as const;
 export type ActivityBucket = (typeof ACTIVITY_BUCKETS)[number];
 
+const SHELL_TOOLS = new Set(["bash", "exec_command", "local_shell", "shell"]);
 const CONTEXT_TOOLS = new Set([
-  "Read",
-  "Grep",
-  "Glob",
-  "LS",
-  "NotebookRead",
-  "WebFetch",
-  "WebSearch",
-  "Task",
-  "ToolSearch",
-  "BashOutput",
-  "ListMcpResourcesTool",
-  "ReadMcpResourceTool",
+  "read",
+  "grep",
+  "glob",
+  "ls",
+  "notebookread",
+  "webfetch",
+  "websearch",
+  "task",
+  "toolsearch",
+  "bashoutput",
+  "listmcpresourcestool",
+  "readmcpresourcetool",
 ]);
-const CODE_TOOLS = new Set(["Edit", "Write", "NotebookEdit", "MultiEdit"]);
-const PLANNING_TOOLS = new Set(["TodoWrite", "ExitPlanMode", "EnterPlanMode"]);
+const CODE_TOOLS = new Set(["apply_patch", "edit", "write", "notebookedit", "multiedit"]);
+const PLANNING_TOOLS = new Set(["enterplanmode", "exitplanmode", "todowrite", "update_plan"]);
 const READONLY_BASH = new Set([
   "ls",
   "cat",
@@ -46,16 +47,18 @@ export function toolBucket(
   input?: string | Json,
 ): ActivityBucket {
   const name = toolName ?? "";
-  if (name === "Bash") {
+  const baseName = localToolName(name);
+  const normalized = baseName.toLowerCase();
+  if (SHELL_TOOLS.has(normalized)) {
     return bashBucket(commandFromInput(input));
   }
-  if (PLANNING_TOOLS.has(name)) {
+  if (PLANNING_TOOLS.has(normalized)) {
     return "planning";
   }
-  if (CODE_TOOLS.has(name)) {
+  if (CODE_TOOLS.has(normalized)) {
     return "code";
   }
-  if (CONTEXT_TOOLS.has(name) || name.startsWith("mcp__")) {
+  if (CONTEXT_TOOLS.has(normalized) || name.startsWith("mcp__")) {
     return "context";
   }
   return "context";
@@ -90,13 +93,24 @@ function commandFromInput(input: string | Json | undefined): string | null {
   if (input == null) {
     return null;
   }
-  const value = typeof input === "string" ? parseJson(input) : input;
+  let value = typeof input === "string" ? parseJson(input) : input;
+  if (typeof value === "string") {
+    const nested = parseJson(value);
+    if (nested !== value) {
+      value = nested;
+    }
+  }
   if (typeof value === "string") {
     return value;
   }
   if (typeof value === "object" && value !== null && !Array.isArray(value)) {
     const command = value.command ?? value.cmd;
-    return typeof command === "string" ? command : null;
+    if (typeof command === "string") {
+      return command;
+    }
+    if (Array.isArray(command)) {
+      return command.filter((part): part is string => typeof part === "string").join(" ");
+    }
   }
   return null;
 }
@@ -133,4 +147,8 @@ function splitCommand(command: string | null): string[] {
 function basename(value: string): string {
   const clean = value.replace(/^['"]|['"]$/g, "");
   return clean.split("/").filter(Boolean).at(-1) ?? clean;
+}
+
+function localToolName(name: string): string {
+  return name.split(".").filter(Boolean).at(-1) ?? name;
 }

--- a/src/token-economics.ts
+++ b/src/token-economics.ts
@@ -41,6 +41,7 @@ interface SessionRow {
 interface FastToolRow {
   session_id: number;
   tool_name: string | null;
+  input: string | null;
   calls: number;
   output_bytes: number | null;
 }
@@ -203,11 +204,10 @@ function fastTokenEconomicsForSession(db: Database, sessionId: number): TokenEco
   const toolRows = db
     .query(
       `${scopeCte}
-       SELECT t.session_id, t.tool_name, COUNT(*) AS calls,
-              SUM(COALESCE(t.output_bytes, 0)) AS output_bytes
+       SELECT t.session_id, t.tool_name, t.input, 1 AS calls,
+              COALESCE(t.output_bytes, 0) AS output_bytes
        FROM tool_call t
-       JOIN scoped_session fs ON fs.id = t.session_id
-       GROUP BY t.session_id, t.tool_name`,
+       JOIN scoped_session fs ON fs.id = t.session_id`,
     )
     .all(sessionId) as FastToolRow[];
 
@@ -243,7 +243,7 @@ function fastTokenEconomicsForSession(db: Database, sessionId: number): TokenEco
   }
 
   for (const row of toolRows) {
-    const bucket = toolBucket(row.tool_name, null);
+    const bucket = toolBucket(row.tool_name, row.input);
     const entry = buckets.get(bucket);
     if (entry == null) {
       continue;

--- a/test/buckets.test.ts
+++ b/test/buckets.test.ts
@@ -4,8 +4,10 @@ import { bashBucket, blockBucket, toolBucket } from "../src/buckets.ts";
 describe("activity bucket classifier", () => {
   test("classifies fixed tool families", () => {
     expect(toolBucket("TodoWrite")).toBe("planning");
+    expect(toolBucket("update_plan")).toBe("planning");
     expect(toolBucket("Edit")).toBe("code");
     expect(toolBucket("MultiEdit")).toBe("code");
+    expect(toolBucket("apply_patch")).toBe("code");
     expect(toolBucket("Read")).toBe("context");
     expect(toolBucket("Task")).toBe("context");
     expect(toolBucket("mcp__github__search_issues")).toBe("context");
@@ -24,6 +26,12 @@ describe("activity bucket classifier", () => {
   test("extracts Bash command from JSON input", () => {
     expect(toolBucket("Bash", { command: "ls -la" })).toBe("context");
     expect(toolBucket("Bash", '{"command":"npm install"}')).toBe("code");
+    expect(toolBucket("exec_command", JSON.stringify({ cmd: "cat docs/new.md" }))).toBe("context");
+    expect(toolBucket("shell", JSON.stringify({ cmd: "bun test" }))).toBe("code");
+    expect(toolBucket("functions.shell", JSON.stringify({ cmd: "git diff" }))).toBe("context");
+    expect(toolBucket("local_shell", JSON.stringify(JSON.stringify({ cmd: "bun test" })))).toBe(
+      "code",
+    );
   });
 
   test("classifies transcript block families", () => {

--- a/test/token-economics.test.ts
+++ b/test/token-economics.test.ts
@@ -65,6 +65,134 @@ describe("token economics", () => {
     db.close();
   });
 
+  test("classifies Codex patch edits as code and read-only shell as context", () => {
+    const db = freshDb();
+    const sessionId = upsertSession(
+      db,
+      parseCodexSession("sess-enr-codex", fixture("codex", "enriched.jsonl"), new Map()),
+      "/x/codex.jsonl",
+      1,
+      2,
+      "codex",
+    );
+
+    const aggregate = tokenEconomics(db);
+    expect(aggregate.buckets.find((row) => row.bucket === "code")).toMatchObject({
+      tool_calls: 1,
+      sessions: 1,
+    });
+    expect(
+      aggregate.buckets.find((row) => row.bucket === "code")?.generation_tokens,
+    ).toBeGreaterThan(0);
+    expect(aggregate.buckets.find((row) => row.bucket === "context")).toMatchObject({
+      tool_calls: 1,
+      sessions: 1,
+    });
+
+    const scoped = tokenEconomicsForSession(db, sessionId);
+    expect(scoped?.buckets.find((row) => row.bucket === "code")).toMatchObject({
+      tool_calls: 1,
+      sessions: 1,
+    });
+    expect(scoped?.buckets.find((row) => row.bucket === "context")).toMatchObject({
+      tool_calls: 1,
+      sessions: 1,
+    });
+    db.close();
+  });
+
+  test("classifies Codex shell build commands as code in aggregate and session economics", () => {
+    const db = freshDb();
+    const content = [
+      JSON.stringify({
+        type: "session_meta",
+        timestamp: "2026-05-05T09:00:00.000Z",
+        payload: { id: "sess-codex-shell", cwd: "/Users/dev/proj" },
+      }),
+      JSON.stringify({
+        type: "turn_context",
+        timestamp: "2026-05-05T09:00:01.000Z",
+        payload: { cwd: "/Users/dev/proj", model: "gpt-5.4" },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        timestamp: "2026-05-05T09:00:02.000Z",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Run tests" }],
+        },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        timestamp: "2026-05-05T09:00:03.000Z",
+        payload: {
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "Run validation." }],
+        },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        timestamp: "2026-05-05T09:00:04.000Z",
+        payload: {
+          type: "function_call",
+          name: "shell",
+          call_id: "call_shell",
+          arguments: JSON.stringify({ cmd: "bun test", workdir: "/Users/dev/proj" }),
+        },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        timestamp: "2026-05-05T09:00:05.000Z",
+        payload: { type: "function_call_output", call_id: "call_shell", output: "231 pass" },
+      }),
+      JSON.stringify({
+        type: "event_msg",
+        timestamp: "2026-05-05T09:00:06.000Z",
+        payload: {
+          type: "token_count",
+          info: {
+            total_token_usage: {
+              input_tokens: 800,
+              cached_input_tokens: 100,
+              output_tokens: 80,
+              reasoning_output_tokens: 20,
+              total_tokens: 880,
+            },
+          },
+        },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        timestamp: "2026-05-05T09:00:07.000Z",
+        payload: {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Tests pass." }],
+        },
+      }),
+    ].join("\n");
+    const sessionId = upsertSession(
+      db,
+      parseCodexSession("sess-codex-shell", `${content}\n`, new Map()),
+      "/x/codex-shell.jsonl",
+      1,
+      2,
+      "codex-shell",
+    );
+
+    const aggregateCode = tokenEconomics(db).buckets.find((row) => row.bucket === "code");
+    expect(aggregateCode).toMatchObject({ tool_calls: 1, sessions: 1 });
+    expect(aggregateCode?.generation_tokens).toBeGreaterThan(0);
+
+    const scopedCode = tokenEconomicsForSession(db, sessionId)?.buckets.find(
+      (row) => row.bucket === "code",
+    );
+    expect(scopedCode).toMatchObject({ tool_calls: 1, sessions: 1 });
+    expect(scopedCode?.generation_tokens).toBeGreaterThan(0);
+    db.close();
+  });
+
   test("date filters scope the economics rollup", () => {
     const db = freshDb();
     upsertSession(


### PR DESCRIPTION
## Summary

- classify Codex shell tool names (`shell`, `exec_command`, `local_shell`) with command inspection instead of defaulting to context
- classify Codex `apply_patch` as code and `update_plan` as planning
- preserve shell command input in the per-session token economics fast path so session detail matches aggregate bucket splits

## Root Cause

Codex tool calls were stored under Codex-specific names, while the activity bucket classifier only recognized Claude-style `Bash` and edit tool names. Unknown tools defaulted to context, so Codex file edits and build/test shell commands could leave the code bucket at zero.

## Validation

- `bun test`
- `bun run typecheck`
- `bun run lint`
- `just check`
