### PR TITLE
perf(serve): sub-100ms pages via batched titles, economics cache, and off-loop ingest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ The pre-cutover tree is preserved in the signed `pre-typescript` tag.
 | `src/query.ts`, `src/stats.ts`, `src/export.ts` | Read/query/render surfaces. |
 | `src/distill.ts`, `src/recommendations.ts` | Deterministic artifact and recommendation generation. |
 | `src/watch.ts`, `src/server.ts` | Watch loop, local JSON routes, SSE, and UI serving. |
+| `src/economics-cache.ts`, `src/stats-worker.ts` | Precomputed token-economics vectors served from memory; heavy scans run in a worker thread off the request loop. |
 | `src/ui/` | React UI bundled by Bun HTML imports. |
 | `src/settings.ts`, `src/launcher.ts` | Local settings and native launcher helpers. |
 | `fixtures/` | Tiny synthetic Claude/Codex session files. |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,6 @@ import {
   DEFAULT_SERVE_HOST,
   DEFAULT_SERVE_PORT,
   parsePeerList,
-  publishServerEvent,
   serve as serveApp,
 } from "./server.ts";
 import {
@@ -241,8 +240,11 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
       run(() => runSync(commandOptions)),
     );
 
+  // Terminal rendering only. Under `serve`, server.ts's applyWatchEvent already
+  // publishes each event to SSE clients exactly once; publishing again here
+  // would double every /api/events frame. Under `watch`, there is no HTTP
+  // server or SSE client to publish to at all.
   const emitWatchEvent = (event: WatchEvent): void => {
-    publishServerEvent(event);
     if (isJson(globals())) {
       io.writeOut(`${JSON.stringify(event)}\n`);
     } else if (!globals().quiet) {
@@ -311,6 +313,12 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
       DEFAULT_DEBOUNCE_MS,
     )
     .option("--no-fs-watch", "disable native filesystem watching and rely on sweeps")
+    .option(
+      "--trusted-peer <peer>",
+      "allow API requests from this peer IP/CIDR when bound broadly (repeatable or comma-separated)",
+      collectOption,
+      [] as string[],
+    )
     .action(
       (commandOptions: {
         host?: string;
@@ -331,7 +339,13 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
             config,
             hostname: commandOptions.host ?? DEFAULT_SERVE_HOST,
             port: commandOptions.port ?? DEFAULT_SERVE_PORT,
-            trustedPeers: trustedPeers(commandOptions.trustedPeer),
+            // Omit entirely (rather than passing []) when no --trusted-peer was
+            // given, so serve()'s `options.trustedPeers ?? parsePeerList(env)`
+            // can still fall through to DECANT_TRUSTED_PEERS.
+            trustedPeers:
+              commandOptions.trustedPeer != null && commandOptions.trustedPeer.length > 0
+                ? trustedPeers(commandOptions.trustedPeer)
+                : undefined,
             watch: {
               intervalMs: commandOptions.intervalMs,
               debounceMs: commandOptions.debounceMs,
@@ -347,7 +361,12 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
           try {
             await waitForProcessSignal();
           } finally {
-            await server.stop();
+            // Force-close: a graceful stop() never resolves while a browser
+            // tab's /api/events SSE connection is open (Bun waits for active
+            // connections to end on their own), which would hang shutdown
+            // indefinitely on Ctrl-C. This is a local dev server being
+            // intentionally torn down, so dropping open connections is fine.
+            await server.stop(true);
           }
         }),
     );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -332,13 +332,12 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
             hostname: commandOptions.host ?? DEFAULT_SERVE_HOST,
             port: commandOptions.port ?? DEFAULT_SERVE_PORT,
             trustedPeers: trustedPeers(commandOptions.trustedPeer),
-          });
-          const handle = startWatch({
-            config,
-            intervalMs: commandOptions.intervalMs,
-            debounceMs: commandOptions.debounceMs,
-            enableWatch: commandOptions.fsWatch !== false,
-            onEvent: emitWatchEvent,
+            watch: {
+              intervalMs: commandOptions.intervalMs,
+              debounceMs: commandOptions.debounceMs,
+              enableWatch: commandOptions.fsWatch !== false,
+              onEvent: emitWatchEvent,
+            },
           });
           if (!isJson(globals()) && !globals().quiet) {
             io.writeErr(
@@ -348,8 +347,7 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
           try {
             await waitForProcessSignal();
           } finally {
-            server.stop();
-            await handle.stop();
+            await server.stop();
           }
         }),
     );

--- a/src/db.ts
+++ b/src/db.ts
@@ -18,6 +18,9 @@ export function openDb(path: string): Database {
   db.exec("PRAGMA foreign_keys = ON;");
   db.exec("PRAGMA synchronous = NORMAL;");
   db.exec("PRAGMA journal_mode = WAL;");
+  // Memory-map reads: archives grow to multiple GB and large scans (FTS, block
+  // aggregation) measure 2-7x faster via mmap than via pread on such files.
+  db.exec("PRAGMA mmap_size = 1073741824;");
   try {
     ensureSchema(db);
   } catch (error) {

--- a/src/economics-cache.ts
+++ b/src/economics-cache.ts
@@ -1,0 +1,132 @@
+import type { Database } from "bun:sqlite";
+import type { DateFilter } from "./date-filter.ts";
+import {
+  aggregateEconomicsVectors,
+  economicsVectorMatchesFilter,
+  type SessionEconomicsVector,
+  type TokenEconomics,
+} from "./token-economics.ts";
+
+/**
+ * Serves /api/analytics/token-economics from precomputed per-session vectors.
+ *
+ * Recomputing token economics from the archive walks every block row, which
+ * takes seconds on multi-GB archives — far beyond any per-request budget. The
+ * cache computes per-session vectors once, off the request thread, and then
+ * answers any date filter by summing vectors in memory. `PRAGMA data_version`
+ * cheaply detects archive writes from other connections (sync workers, CLI
+ * runs); a stale cache serves the previous model while a rebuild runs in the
+ * background, and onRebuilt lets the server nudge clients to refetch.
+ */
+export interface EconomicsCacheOptions {
+  dbPath: string;
+  db: Database;
+  computeVectors?: (dbPath: string) => Promise<SessionEconomicsVector[]>;
+  onRebuilt?: () => void;
+}
+
+export class EconomicsCache {
+  #vectors: SessionEconomicsVector[] | null = null;
+  #builtDataVersion: number | null = null;
+  #building: Promise<void> | null = null;
+  #disposed = false;
+  readonly #options: EconomicsCacheOptions;
+
+  constructor(options: EconomicsCacheOptions) {
+    this.#options = options;
+  }
+
+  async get(filter?: DateFilter | null): Promise<TokenEconomics> {
+    if (this.#vectors == null) {
+      await (this.#building ?? this.#rebuild());
+    } else if (this.#dataVersion() !== this.#builtDataVersion) {
+      // Stale-while-revalidate: answer from the previous model immediately and
+      // refresh in the background; onRebuilt tells clients to refetch.
+      void this.#rebuild().catch(() => {});
+    }
+    const vectors = this.#vectors ?? [];
+    return aggregateEconomicsVectors(
+      vectors.filter((vector) => economicsVectorMatchesFilter(vector, filter)),
+    );
+  }
+
+  /** Kick a background rebuild, e.g. right after a sync ingests new sessions. */
+  invalidate(): void {
+    void this.#rebuild().catch(() => {});
+  }
+
+  prewarm(): void {
+    void this.#rebuild().catch(() => {});
+  }
+
+  /** Resolves once any in-flight rebuild has finished (success or failure). */
+  async settled(): Promise<void> {
+    while (this.#building != null) {
+      await this.#building.catch(() => {});
+    }
+  }
+
+  dispose(): void {
+    this.#disposed = true;
+  }
+
+  #dataVersion(): number | null {
+    try {
+      // data_version only reflects other connections' commits after this
+      // connection takes a fresh read snapshot, so touch a tiny table first.
+      this.#options.db.query("SELECT 1 FROM schema_migrations LIMIT 1").get();
+      const row = this.#options.db.query("PRAGMA data_version").get() as {
+        data_version: number;
+      } | null;
+      return row?.data_version ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  #rebuild(): Promise<void> {
+    if (this.#building != null) {
+      return this.#building;
+    }
+    const compute = this.#options.computeVectors ?? computeVectorsInWorker;
+    const version = this.#dataVersion();
+    this.#building = compute(this.#options.dbPath)
+      .then((vectors) => {
+        if (this.#disposed) {
+          return;
+        }
+        const replacedModel = this.#vectors != null;
+        this.#vectors = vectors;
+        this.#builtDataVersion = version;
+        if (replacedModel) {
+          this.#options.onRebuilt?.();
+        }
+      })
+      .finally(() => {
+        this.#building = null;
+      });
+    return this.#building;
+  }
+}
+
+function computeVectorsInWorker(dbPath: string): Promise<SessionEconomicsVector[]> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(new URL("./stats-worker.ts", import.meta.url), { type: "module" });
+    worker.addEventListener("message", (event) => {
+      const data = event.data as
+        | { ok: true; vectors: SessionEconomicsVector[] }
+        | { ok: false; error: string };
+      worker.terminate();
+      if (data.ok) {
+        resolve(data.vectors);
+      } else {
+        reject(new Error(data.error));
+      }
+    });
+    worker.addEventListener("error", (event) => {
+      worker.terminate();
+      reject(event.error instanceof Error ? event.error : new Error(String(event.error)));
+    });
+    worker.postMessage({ dbPath });
+  });
+}

--- a/src/economics-cache.ts
+++ b/src/economics-cache.ts
@@ -18,10 +18,17 @@ import {
  * runs); a stale cache serves the previous model while a rebuild runs in the
  * background, and onRebuilt lets the server nudge clients to refetch.
  */
+export interface ComputeVectorsOptions {
+  signal: AbortSignal;
+}
+
 export interface EconomicsCacheOptions {
   dbPath: string;
   db: Database;
-  computeVectors?: (dbPath: string) => Promise<SessionEconomicsVector[]>;
+  computeVectors?: (
+    dbPath: string,
+    options: ComputeVectorsOptions,
+  ) => Promise<SessionEconomicsVector[]>;
   onRebuilt?: () => void;
 }
 
@@ -29,6 +36,8 @@ export class EconomicsCache {
   #vectors: SessionEconomicsVector[] | null = null;
   #builtDataVersion: number | null = null;
   #building: Promise<void> | null = null;
+  #buildAbort: AbortController | null = null;
+  #pendingRebuild = false;
   #disposed = false;
   readonly #options: EconomicsCacheOptions;
 
@@ -42,7 +51,7 @@ export class EconomicsCache {
     } else if (this.#dataVersion() !== this.#builtDataVersion) {
       // Stale-while-revalidate: answer from the previous model immediately and
       // refresh in the background; onRebuilt tells clients to refetch.
-      void this.#rebuild().catch(() => {});
+      void this.#rebuild();
     }
     const vectors = this.#vectors ?? [];
     return aggregateEconomicsVectors(
@@ -52,22 +61,27 @@ export class EconomicsCache {
 
   /** Kick a background rebuild, e.g. right after a sync ingests new sessions. */
   invalidate(): void {
-    void this.#rebuild().catch(() => {});
+    void this.#rebuild();
   }
 
   prewarm(): void {
-    void this.#rebuild().catch(() => {});
+    void this.#rebuild();
   }
 
-  /** Resolves once any in-flight rebuild has finished (success or failure). */
+  /** Resolves once any in-flight rebuild (including chained follow-ups) has
+   * finished (success or failure). */
   async settled(): Promise<void> {
     while (this.#building != null) {
-      await this.#building.catch(() => {});
+      await this.#building;
     }
   }
 
+  /** Aborts any in-flight rebuild (killing its worker immediately, rather than
+   * leaving shutdown waiting out a multi-second archive scan) and stops
+   * scheduling new ones. */
   dispose(): void {
     this.#disposed = true;
+    this.#buildAbort?.abort();
   }
 
   #dataVersion(): number | null {
@@ -85,12 +99,23 @@ export class EconomicsCache {
   }
 
   #rebuild(): Promise<void> {
+    if (this.#disposed) {
+      return Promise.resolve();
+    }
     if (this.#building != null) {
+      // A build is already in flight and may not reflect writes that land
+      // after it started (e.g. an ingest completing mid-prewarm-scan). Flag
+      // it so the in-flight build schedules an immediate follow-up instead of
+      // silently serving stale data until some unrelated future request
+      // happens to notice via #dataVersion().
+      this.#pendingRebuild = true;
       return this.#building;
     }
     const compute = this.#options.computeVectors ?? computeVectorsInWorker;
     const version = this.#dataVersion();
-    this.#building = compute(this.#options.dbPath)
+    const abort = new AbortController();
+    this.#buildAbort = abort;
+    this.#building = compute(this.#options.dbPath, { signal: abort.signal })
       .then((vectors) => {
         if (this.#disposed) {
           return;
@@ -102,21 +127,46 @@ export class EconomicsCache {
           this.#options.onRebuilt?.();
         }
       })
+      .catch(() => {
+        // Aborted (dispose) or a genuine compute failure: keep serving
+        // whatever model (possibly none) is already cached.
+      })
       .finally(() => {
         this.#building = null;
+        this.#buildAbort = null;
+        if (this.#pendingRebuild && !this.#disposed) {
+          this.#pendingRebuild = false;
+          void this.#rebuild();
+        }
       });
     return this.#building;
   }
 }
 
-function computeVectorsInWorker(dbPath: string): Promise<SessionEconomicsVector[]> {
+function computeVectorsInWorker(
+  dbPath: string,
+  { signal }: ComputeVectorsOptions,
+): Promise<SessionEconomicsVector[]> {
   return new Promise((resolve, reject) => {
     const worker = new Worker(new URL("./stats-worker.ts", import.meta.url), { type: "module" });
+    const onAbort = (): void => {
+      worker.terminate();
+      reject(new Error("aborted"));
+    };
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+    const settle = (): void => {
+      signal.removeEventListener("abort", onAbort);
+      worker.terminate();
+    };
     worker.addEventListener("message", (event) => {
       const data = event.data as
         | { ok: true; vectors: SessionEconomicsVector[] }
         | { ok: false; error: string };
-      worker.terminate();
+      settle();
       if (data.ok) {
         resolve(data.vectors);
       } else {
@@ -124,7 +174,7 @@ function computeVectorsInWorker(dbPath: string): Promise<SessionEconomicsVector[
       }
     });
     worker.addEventListener("error", (event) => {
-      worker.terminate();
+      settle();
       reject(event.error instanceof Error ? event.error : new Error(String(event.error)));
     });
     worker.postMessage({ dbPath });

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -146,6 +146,9 @@ export function sync(
   if (report.ingested > 0) {
     resolveWorktreeRoots(db);
     regenerateRecommendations(db);
+    // Refresh planner statistics after write bursts; without ANALYZE data the
+    // query planner picks pathological join orders on multi-GB archives.
+    db.exec("PRAGMA optimize;");
   }
 
   return report;

--- a/src/query.ts
+++ b/src/query.ts
@@ -179,16 +179,6 @@ export function getSession(
   id: number,
   options: SessionReadOptions = {},
 ): SessionDetail | null {
-  return readSession(db, id, 0, true, options);
-}
-
-function readSession(
-  db: Database,
-  id: number,
-  depth: number,
-  includeMessages: boolean,
-  options: SessionReadOptions = {},
-): SessionDetail | null {
   const summaryRow = db
     .query(
       `SELECT s.id, s.tool, s.source_session_id, s.title, p.path AS project_path,
@@ -218,76 +208,134 @@ function readSession(
   const messageLimit =
     options.messageLimit != null && options.messageLimit > 0 ? options.messageLimit : null;
   const messageOffset = normalizeOffset(options.messageOffset);
-  if (includeMessages) {
-    const rows =
-      messageLimit == null
-        ? (db
-            .query(
-              `SELECT m.id AS message_id, m.role, m.timestamp, m.model,
-                      b.ordinal AS block_ordinal, b.type AS block_type, b.text,
-                      b.tool_name, b.tool_use_id, b.tool_input, b.tool_result
-               FROM message m
-               LEFT JOIN block b ON b.message_id = m.id
-               WHERE m.session_id = ?1
-               ORDER BY m.seq, b.ordinal`,
-            )
-            .all(id) as MessageBlockRow[])
-        : (db
-            .query(
-              `WITH page_message AS (
-                 SELECT id
-                 FROM message
-                 WHERE session_id = ?1
-                 ORDER BY seq
-                 LIMIT ?2 OFFSET ?3
-               )
-               SELECT m.id AS message_id, m.role, m.timestamp, m.model,
-                      b.ordinal AS block_ordinal, b.type AS block_type, b.text,
-                      b.tool_name, b.tool_use_id, b.tool_input, b.tool_result
-               FROM page_message pm
-               JOIN message m ON m.id = pm.id
-               LEFT JOIN block b ON b.message_id = m.id
-               ORDER BY m.seq, b.ordinal`,
-            )
-            .all(id, messageLimit, messageOffset) as MessageBlockRow[]);
+  const rows =
+    messageLimit == null
+      ? (db
+          .query(
+            `SELECT m.id AS message_id, m.role, m.timestamp, m.model,
+                    b.ordinal AS block_ordinal, b.type AS block_type, b.text,
+                    b.tool_name, b.tool_use_id, b.tool_input, b.tool_result
+             FROM message m
+             LEFT JOIN block b ON b.message_id = m.id
+             WHERE m.session_id = ?1
+             ORDER BY m.seq, b.ordinal`,
+          )
+          .all(id) as MessageBlockRow[])
+      : (db
+          .query(
+            `WITH page_message AS (
+               SELECT id
+               FROM message
+               WHERE session_id = ?1
+               ORDER BY seq
+               LIMIT ?2 OFFSET ?3
+             )
+             SELECT m.id AS message_id, m.role, m.timestamp, m.model,
+                    b.ordinal AS block_ordinal, b.type AS block_type, b.text,
+                    b.tool_name, b.tool_use_id, b.tool_input, b.tool_result
+             FROM page_message pm
+             JOIN message m ON m.id = pm.id
+             LEFT JOIN block b ON b.message_id = m.id
+             ORDER BY m.seq, b.ordinal`,
+          )
+          .all(id, messageLimit, messageOffset) as MessageBlockRow[]);
 
-    let currentMessageId: number | null = null;
-    for (const row of rows) {
-      if (currentMessageId !== row.message_id) {
-        currentMessageId = row.message_id;
-        messages.push({
-          role: row.role ?? "unknown",
-          timestamp: row.timestamp,
-          model: row.model,
-          blocks: [],
-        });
-      }
-      if (row.block_type != null) {
-        messages.at(-1)?.blocks.push({
-          ordinal: row.block_ordinal ?? 0,
-          block_type: row.block_type,
-          text: row.text,
-          tool_name: row.tool_name,
-          tool_use_id: row.tool_use_id,
-          tool_input: row.tool_input,
-          tool_result: row.tool_result,
-        });
-      }
+  let currentMessageId: number | null = null;
+  for (const row of rows) {
+    if (currentMessageId !== row.message_id) {
+      currentMessageId = row.message_id;
+      messages.push({
+        role: row.role ?? "unknown",
+        timestamp: row.timestamp,
+        model: row.model,
+        blocks: [],
+      });
+    }
+    if (row.block_type != null) {
+      messages.at(-1)?.blocks.push({
+        ordinal: row.block_ordinal ?? 0,
+        block_type: row.block_type,
+        text: row.text,
+        tool_name: row.tool_name,
+        tool_use_id: row.tool_use_id,
+        tool_input: row.tool_input,
+        tool_result: row.tool_result,
+      });
+    }
+  }
+
+  // Titles for the root and its whole descendant tree resolve in one batch so a
+  // session with many subagents costs two queries, not two per subagent.
+  const descendantRows = db
+    .query(
+      `${SESSION_SUMMARY_SELECT}
+       WHERE s.id IN (
+         WITH RECURSIVE subtree(id, depth) AS (
+           SELECT id, 1 FROM session WHERE parent_session_id = ?1
+           UNION ALL
+           SELECT child.id, subtree.depth + 1
+           FROM session child
+           JOIN subtree ON subtree.id = child.parent_session_id
+           WHERE subtree.depth < 5
+         )
+         SELECT id FROM subtree
+       )
+       ORDER BY COALESCE(s.spawn_depth, 0), s.started_at, s.id`,
+    )
+    .all(id) as SessionSummaryRow[];
+  const titled = withDisplayTitles(db, [summaryRow, ...descendantRows].map(mapSessionSummary));
+  const rootSummary = titled[0] ?? mapSessionSummary(summaryRow);
+  const childrenByParent = new Map<number, SessionSummary[]>();
+  for (const child of titled.slice(1)) {
+    if (child.parent_session_id == null) {
+      continue;
+    }
+    const siblings = childrenByParent.get(child.parent_session_id);
+    if (siblings == null) {
+      childrenByParent.set(child.parent_session_id, [child]);
+    } else {
+      siblings.push(child);
     }
   }
 
   return {
-    summary:
-      withDisplayTitles(db, [mapSessionSummary(summaryRow)])[0] ?? mapSessionSummary(summaryRow),
+    summary: rootSummary,
     messages,
-    subagents: depth >= 5 ? [] : readSubagents(db, id, depth + 1),
-    message_offset: includeMessages && messageLimit != null ? messageOffset : undefined,
-    message_limit: includeMessages ? messageLimit : undefined,
+    subagents: buildSubagentDetails(childrenByParent, id, 0, new Set([id])),
+    message_offset: messageLimit != null ? messageOffset : undefined,
+    message_limit: messageLimit,
     has_more_messages:
-      includeMessages && messageLimit != null
-        ? messageOffset + messages.length < summaryRow.message_count
-        : undefined,
+      messageLimit != null ? messageOffset + messages.length < summaryRow.message_count : undefined,
   };
+}
+
+function buildSubagentDetails(
+  childrenByParent: Map<number, SessionSummary[]>,
+  parentId: number,
+  depth: number,
+  seen: Set<number>,
+): SubagentDetail[] {
+  if (depth >= 5) {
+    return [];
+  }
+  const details: SubagentDetail[] = [];
+  for (const summary of childrenByParent.get(parentId) ?? []) {
+    if (seen.has(summary.id)) {
+      continue;
+    }
+    const nextSeen = new Set(seen);
+    nextSeen.add(summary.id);
+    details.push({
+      summary,
+      messages: [],
+      subagents: buildSubagentDetails(childrenByParent, summary.id, depth + 1, nextSeen),
+      spawn_tool_use_id: summary.spawn_tool_use_id,
+      agent_id: summary.agent_id,
+      agent_type: summary.agent_type,
+      spawn_depth: summary.spawn_depth,
+    });
+  }
+  return details;
 }
 
 export interface ProjectSummary {
@@ -350,28 +398,75 @@ function withDisplayTitles(db: Database, sessions: SessionSummary[]): SessionSum
     return sessions;
   }
   const placeholders = sessions.map(() => "?").join(", ");
-  const rows = db
+  const ids = sessions.map((session) => session.id);
+  // Pass 1: fetch only the first plausibly-usable candidate text per session.
+  // The correlated subquery stops at the first hit instead of walking every
+  // user message, and CROSS JOIN + INDEXED BY pin the plan to messages ->
+  // blocks; left to its own devices SQLite starts from every text block in the
+  // archive, which turns each title lookup into a multi-hundred-ms full scan.
+  //
+  // AGENT_CONTEXT_SQL must skip a subset (never a superset) of what
+  // isAgentContextText skips: anything it wrongly lets through is re-checked in
+  // JS and handled by pass 2, but anything it wrongly skips would silently
+  // change which prompt becomes the title. That is why the case-sensitive JS
+  // rules use GLOB here and the \b in the teammate rule is narrowed to the two
+  // separators that occur in practice.
+  const firstCandidates = db
     .query(
-      `SELECT s.id AS session_id, b.text
+      `SELECT s.id AS session_id,
+              (SELECT b.text
+               FROM message m
+               CROSS JOIN block b INDEXED BY idx_block_message ON b.message_id = m.id
+               WHERE m.session_id = s.id
+                 AND m.role = 'user'
+                 AND b.type = 'text'
+                 AND b.text IS NOT NULL
+                 AND TRIM(b.text) != ''
+                 AND NOT (${AGENT_CONTEXT_SQL})
+               ORDER BY m.seq, b.ordinal
+               LIMIT 1) AS text
        FROM session s
-       JOIN message m ON m.session_id = s.id
-       JOIN block b ON b.message_id = m.id
-       WHERE s.id IN (${placeholders})
-         AND m.role = 'user'
-         AND b.type = 'text'
-         AND b.text IS NOT NULL
-         AND TRIM(b.text) != ''
-       ORDER BY s.id, m.seq, b.ordinal`,
+       WHERE s.id IN (${placeholders})`,
     )
-    .all(...sessions.map((session) => session.id)) as { session_id: number; text: string }[];
+    .all(...ids) as { session_id: number; text: string | null }[];
   const titleBySession = new Map<number, string>();
-  for (const row of rows) {
-    if (titleBySession.has(row.session_id)) {
+  const needFullScan: number[] = [];
+  for (const row of firstCandidates) {
+    if (row.text == null) {
       continue;
     }
     const title = readableUserTitle(row.text);
     if (title != null) {
       titleBySession.set(row.session_id, title);
+    } else {
+      needFullScan.push(row.session_id);
+    }
+  }
+  // Pass 2, only for sessions whose first candidate was agent context: walk all
+  // their user text blocks in order, exactly like the single-pass version did.
+  if (needFullScan.length > 0) {
+    const scanPlaceholders = needFullScan.map(() => "?").join(", ");
+    const rows = db
+      .query(
+        `SELECT m.session_id AS session_id, b.text
+         FROM message m
+         CROSS JOIN block b INDEXED BY idx_block_message ON b.message_id = m.id
+         WHERE m.session_id IN (${scanPlaceholders})
+           AND m.role = 'user'
+           AND b.type = 'text'
+           AND b.text IS NOT NULL
+           AND TRIM(b.text) != ''
+         ORDER BY m.session_id, m.seq, b.ordinal`,
+      )
+      .all(...needFullScan) as { session_id: number; text: string }[];
+    for (const row of rows) {
+      if (titleBySession.has(row.session_id)) {
+        continue;
+      }
+      const title = readableUserTitle(row.text);
+      if (title != null) {
+        titleBySession.set(row.session_id, title);
+      }
     }
   }
   return sessions.map((session) => {
@@ -428,6 +523,28 @@ function readableFallbackTitle(text: string | null | undefined): string | null {
   }
   return null;
 }
+
+// SQL twin of isAgentContextText, used to early-exit title candidate scans.
+// Keep the two in sync when adding rules, and keep this side conservative:
+// LIKE mirrors the case-insensitive /^.../i prefixes, GLOB mirrors the
+// case-sensitive includes/startsWith rules, and JS stripAnsi/trimStart nuances
+// intentionally fall through to the JS check (pass 2) rather than being
+// approximated here.
+const AGENT_CONTEXT_SQL = `
+  LTRIM(b.text) LIKE '<permissions instructions>%'
+  OR LTRIM(b.text) LIKE '<local-command-caveat>%'
+  OR LTRIM(b.text) LIKE '<local-command-stdout>%'
+  OR LTRIM(b.text) LIKE '<local-command-stderr>%'
+  OR LTRIM(b.text) LIKE '<local-command-output>%'
+  OR LTRIM(b.text) LIKE '<command-name>%'
+  OR LTRIM(b.text) LIKE '<teammate-message %'
+  OR LTRIM(b.text) LIKE '<teammate-message>%'
+  OR b.text GLOB '*<environment_context>*'
+  OR LTRIM(b.text) GLOB '# AGENTS.md instructions*'
+  OR b.text GLOB '*<INSTRUCTIONS>*'
+  OR LTRIM(b.text) LIKE 'The following is the Codex agent history%'
+  OR LTRIM(b.text) LIKE 'Use prior reviews as context%'
+`;
 
 function isAgentContextText(text: string): boolean {
   const trimmed = text.trimStart();
@@ -511,31 +628,6 @@ function withNestedSubagents(db: Database, sessions: SessionSummary[]): SessionS
   };
 
   return sessions.map((session) => attach(session, 0, new Set()));
-}
-
-function readSubagents(db: Database, parentId: number, depth: number): SubagentDetail[] {
-  const rows = db
-    .query(
-      `SELECT id FROM session
-       WHERE parent_session_id = ?1
-       ORDER BY COALESCE(spawn_depth, 0), started_at, id`,
-    )
-    .all(parentId) as { id: number }[];
-  return rows.flatMap((row) => {
-    const detail = readSession(db, row.id, depth, false);
-    if (detail == null) {
-      return [];
-    }
-    return [
-      {
-        ...detail,
-        spawn_tool_use_id: detail.summary.spawn_tool_use_id,
-        agent_id: detail.summary.agent_id,
-        agent_type: detail.summary.agent_type,
-        spawn_depth: detail.summary.spawn_depth,
-      },
-    ];
-  });
 }
 
 function normalizeLimit(value: number | null | undefined, fallback: number): number {

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import type { Config } from "./config.ts";
 import { dateFilterFromSearch } from "./date-filter.ts";
 import { openDb } from "./db.ts";
 import { refreshDerivedMetadata } from "./derived.ts";
+import { EconomicsCache } from "./economics-cache.ts";
 import type { Operation } from "./enrich.ts";
 import type { sync as ingestSync } from "./ingest.ts";
 import { canLaunch, launchAgent, command as launchCommand, openIde } from "./launcher.ts";
@@ -36,21 +37,34 @@ import {
 } from "./stats.ts";
 import { tokenEconomics, tokenEconomicsForSession } from "./token-economics.ts";
 import uiBundle from "./ui/index.html";
+import { type SyncStatusStore, startWatch, type WatchEvent, type WatchHandle } from "./watch.ts";
 
 export const DEFAULT_SERVE_HOST = "127.0.0.1";
 export const DEFAULT_SERVE_PORT = 3000;
+
+export interface ServeWatchOptions {
+  intervalMs?: number;
+  debounceMs?: number;
+  enableWatch?: boolean;
+  onEvent?: (event: WatchEvent) => void;
+}
 
 export interface ServeOptions {
   config: Config;
   port?: number;
   hostname?: string;
   trustedPeers?: string[];
+  /** When set, serve() runs the source watcher itself with a worker-backed
+   * sync runner so ingests never block the request event loop, and republishes
+   * watcher events to SSE clients. */
+  watch?: ServeWatchOptions;
 }
 
 type Db = ReturnType<typeof openDb>;
 type ServerEvent = { type: string };
 interface RequestContext {
   db?: Db;
+  economics?: EconomicsCache;
   boundHostname?: string;
   remoteAddress?: string | null;
   trustedPeers?: string[];
@@ -158,7 +172,7 @@ export async function handleRequest(
       if (contentTypeFailure != null) {
         return contentTypeFailure;
       }
-      return await syncNow(config);
+      return await syncNow(config, context.economics);
     }
     if (request.method === "GET" && url.pathname === "/api/sessions") {
       return withDb(config, context, (db) =>
@@ -234,6 +248,9 @@ export async function handleRequest(
       return withDb(config, context, (db) => json(modelSparklines(db, dateFilter)));
     }
     if (request.method === "GET" && url.pathname === "/api/analytics/token-economics") {
+      if (context.economics != null) {
+        return json(await context.economics.get(dateFilter));
+      }
       return withDb(config, context, (db) => json(tokenEconomics(db, dateFilter)));
     }
     if (request.method === "GET" && url.pathname === "/api/analytics/now") {
@@ -324,7 +341,7 @@ function settingsResponse(settings = getSettings()): Record<string, unknown> {
   };
 }
 
-async function syncNow(config: Config): Promise<Response> {
+async function syncNow(config: Config, economics?: EconomicsCache): Promise<Response> {
   syncStatus.in_progress = true;
   syncStatus.last_error = null;
   try {
@@ -337,6 +354,7 @@ async function syncNow(config: Config): Promise<Response> {
     syncStatus.ingested_count = report.ingested;
     publishServerEvent({ type: "sync", reason: "manual", report, status: { ...syncStatus } });
     if (report.ingested > 0) {
+      economics?.invalidate();
       publishServerEvent({
         type: "archive_updated",
         ingested: report.ingested,
@@ -435,6 +453,32 @@ export function serve(options: ServeOptions): ReturnType<typeof Bun.serve> {
   mkdirSync(dirname(options.config.dbPath), { recursive: true });
   const db = openDb(options.config.dbPath);
   ensureDerivedMetadata(db);
+  const economics = new EconomicsCache({
+    dbPath: options.config.dbPath,
+    db,
+    onRebuilt: () =>
+      publishServerEvent({
+        type: "archive_updated",
+        reason: "stats",
+        last_sync_at: syncStatus.last_sync_at,
+      }),
+  });
+  economics.prewarm();
+  let watchHandle: WatchHandle | null = null;
+  if (options.watch != null) {
+    const onEvent = options.watch.onEvent;
+    watchHandle = startWatch({
+      config: options.config,
+      intervalMs: options.watch.intervalMs,
+      debounceMs: options.watch.debounceMs,
+      enableWatch: options.watch.enableWatch,
+      runner: workerSyncRunner,
+      onEvent: (event) => {
+        applyWatchEvent(event, economics);
+        onEvent?.(event);
+      },
+    });
+  }
   const server = Bun.serve({
     hostname,
     port,
@@ -453,6 +497,7 @@ export function serve(options: ServeOptions): ReturnType<typeof Bun.serve> {
     fetch: (request, bunServer) =>
       handleRequest(request, options.config, {
         db,
+        economics,
         boundHostname: hostname,
         remoteAddress: bunServer.requestIP(request)?.address ?? null,
         trustedPeers,
@@ -462,15 +507,53 @@ export function serve(options: ServeOptions): ReturnType<typeof Bun.serve> {
   let closed = false;
   server.stop = async (closeActiveConnections?: boolean): Promise<void> => {
     try {
+      await watchHandle?.stop();
       await stop(closeActiveConnections);
     } finally {
       if (!closed) {
         closed = true;
+        economics.dispose();
         db.close();
       }
     }
   };
   return server;
+}
+
+/** Runs one watcher-triggered sync in a worker thread, keeping request
+ * handling responsive while multi-second ingests run. */
+async function workerSyncRunner(
+  config: Config,
+  status: SyncStatusStore,
+): Promise<ReturnType<typeof ingestSync>> {
+  status.start();
+  try {
+    const report = await runSyncWorker(config);
+    status.finishOk(report);
+    return report;
+  } catch (error) {
+    status.finishErr(error instanceof Error ? error.message : String(error));
+    throw error;
+  }
+}
+
+function applyWatchEvent(event: WatchEvent, economics: EconomicsCache): void {
+  if ("status" in event && event.status != null) {
+    syncStatus.last_sync_at = event.status.last_sync_at;
+    syncStatus.in_progress = event.status.in_progress;
+    syncStatus.last_report = event.status.last_report;
+    syncStatus.last_error = event.status.last_error;
+    syncStatus.ingested_count = event.status.ingested_count;
+  }
+  publishServerEvent(event);
+  if (event.type === "sync" && event.report.ingested > 0) {
+    economics.invalidate();
+    publishServerEvent({
+      type: "archive_updated",
+      ingested: event.report.ingested,
+      last_sync_at: syncStatus.last_sync_at,
+    });
+  }
 }
 
 function withDb(config: Config, context: RequestContext, callback: (db: Db) => Response): Response {

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@ import type { Config } from "./config.ts";
 import { dateFilterFromSearch } from "./date-filter.ts";
 import { openDb } from "./db.ts";
 import { refreshDerivedMetadata } from "./derived.ts";
-import { EconomicsCache } from "./economics-cache.ts";
+import { EconomicsCache, type EconomicsCacheOptions } from "./economics-cache.ts";
 import type { Operation } from "./enrich.ts";
 import type { sync as ingestSync } from "./ingest.ts";
 import { canLaunch, launchAgent, command as launchCommand, openIde } from "./launcher.ts";
@@ -58,6 +58,9 @@ export interface ServeOptions {
    * sync runner so ingests never block the request event loop, and republishes
    * watcher events to SSE clients. */
   watch?: ServeWatchOptions;
+  /** Test seam: override how the economics cache computes vectors, e.g. to
+   * simulate a rebuild that is still in flight when the server is stopped. */
+  economicsComputeVectors?: EconomicsCacheOptions["computeVectors"];
 }
 
 type Db = ReturnType<typeof openDb>;
@@ -370,14 +373,25 @@ async function syncNow(config: Config, economics?: EconomicsCache): Promise<Resp
   }
 }
 
-function runSyncWorker(config: Config): Promise<ReturnType<typeof ingestSync>> {
+function runSyncWorker(
+  config: Config,
+  cancel?: { aborted: boolean },
+): Promise<ReturnType<typeof ingestSync>> {
   return new Promise((resolve, reject) => {
     const worker = new Worker(new URL("./sync-worker.ts", import.meta.url), { type: "module" });
+    let cancelPoll: Timer | null = null;
+    const settle = (): void => {
+      if (cancelPoll != null) {
+        clearInterval(cancelPoll);
+        cancelPoll = null;
+      }
+      worker.terminate();
+    };
     worker.addEventListener("message", (event) => {
       const data = event.data as
         | { ok: true; report: ReturnType<typeof ingestSync> }
         | { ok: false; error: string };
-      worker.terminate();
+      settle();
       if (data.ok) {
         resolve(data.report);
       } else {
@@ -385,9 +399,20 @@ function runSyncWorker(config: Config): Promise<ReturnType<typeof ingestSync>> {
       }
     });
     worker.addEventListener("error", (event) => {
-      worker.terminate();
+      settle();
       reject(event.error instanceof Error ? event.error : new Error(String(event.error)));
     });
+    if (cancel != null) {
+      // The in-process runner aborts between files; a worker cannot observe the
+      // flag, so poll it and terminate, resolving with the same cancelled-report
+      // shape so shutdown stays prompt instead of waiting out a long ingest.
+      cancelPoll = setInterval(() => {
+        if (cancel.aborted) {
+          settle();
+          resolve({ scanned: 0, ingested: 0, skipped: 0, issues: 0, failed: 0, cancelled: true });
+        }
+      }, 150);
+    }
     worker.postMessage(config);
   });
 }
@@ -456,6 +481,7 @@ export function serve(options: ServeOptions): ReturnType<typeof Bun.serve> {
   const economics = new EconomicsCache({
     dbPath: options.config.dbPath,
     db,
+    computeVectors: options.economicsComputeVectors,
     onRebuilt: () =>
       publishServerEvent({
         type: "archive_updated",
@@ -508,12 +534,20 @@ export function serve(options: ServeOptions): ReturnType<typeof Bun.serve> {
   server.stop = async (closeActiveConnections?: boolean): Promise<void> => {
     try {
       await watchHandle?.stop();
-      await stop(closeActiveConnections);
     } finally {
-      if (!closed) {
-        closed = true;
-        economics.dispose();
-        db.close();
+      // Abort any in-flight economics rebuild BEFORE awaiting the native
+      // stop(): forcing TCP connections closed doesn't make an in-flight
+      // request handler's own awaited Promise settle, so a request still
+      // awaiting a multi-second rebuild would otherwise block native stop()
+      // from ever resolving, even with closeActiveConnections=true.
+      economics.dispose();
+      try {
+        await stop(closeActiveConnections);
+      } finally {
+        if (!closed) {
+          closed = true;
+          db.close();
+        }
       }
     }
   };
@@ -525,10 +559,11 @@ export function serve(options: ServeOptions): ReturnType<typeof Bun.serve> {
 async function workerSyncRunner(
   config: Config,
   status: SyncStatusStore,
+  cancel: { aborted: boolean },
 ): Promise<ReturnType<typeof ingestSync>> {
   status.start();
   try {
-    const report = await runSyncWorker(config);
+    const report = await runSyncWorker(config, cancel);
     status.finishOk(report);
     return report;
   } catch (error) {

--- a/src/stats-worker.ts
+++ b/src/stats-worker.ts
@@ -1,0 +1,17 @@
+import { Database } from "bun:sqlite";
+import { computeSessionEconomicsVectors } from "./token-economics.ts";
+
+self.addEventListener("message", (event) => {
+  const { dbPath } = event.data as { dbPath: string };
+  let db: Database | null = null;
+  try {
+    db = new Database(dbPath, { readonly: true, strict: true });
+    db.exec("PRAGMA busy_timeout = 5000;");
+    db.exec("PRAGMA mmap_size = 1073741824;");
+    self.postMessage({ ok: true, vectors: computeSessionEconomicsVectors(db) });
+  } catch (error) {
+    self.postMessage({ ok: false, error: error instanceof Error ? error.message : String(error) });
+  } finally {
+    db?.close();
+  }
+});

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -108,16 +108,19 @@ export function toolUsage(
   const limit = normalizeLimit(limitValue, 50);
   const date = sessionDatePredicate("s", filter);
   const having = errorsOnly ? "HAVING errors > 0" : "";
+  // Every tool_call row references a session, so the session join exists only
+  // to apply the date filter; skip it (and its per-row lookup cost) otherwise.
+  const scope =
+    date.sql === ""
+      ? ""
+      : `JOIN (SELECT id FROM session s ${whereClause(date)}) fs ON fs.id = t.session_id`;
   const rows = db
     .query(
-      `WITH filtered_session AS (
-         SELECT id, started_at FROM session s ${whereClause(date)}
-       )
-       SELECT t.tool_name, t.tool_kind, t.mcp_server,
+      `SELECT t.tool_name, t.tool_kind, t.mcp_server,
               COUNT(*) AS calls,
               COALESCE(SUM(CASE WHEN t.is_error = 1 THEN 1 ELSE 0 END), 0) AS errors
        FROM tool_call t
-       JOIN filtered_session s ON s.id = t.session_id
+       ${scope}
        GROUP BY t.tool_name, t.tool_kind, t.mcp_server
        ${having}
        ORDER BY calls DESC

--- a/src/token-economics.ts
+++ b/src/token-economics.ts
@@ -29,6 +29,7 @@ export interface TokenEconomics {
 
 interface SessionRow {
   id: number;
+  started_at: string | null;
   model: string | null;
   total_input_tokens: number;
   total_output_tokens: number;
@@ -52,17 +53,16 @@ interface BlockRow {
   role: string | null;
   output_tokens: number | null;
   type: string | null;
-  text: string | null;
   tool_name: string | null;
   tool_input: string | null;
+  text_bytes: number;
 }
 
 interface ResultRow {
   session_id: number;
   tool_name: string | null;
   input: string | null;
-  tool_result: string | null;
-  output_bytes: number | null;
+  bytes: number;
 }
 
 interface MutableBucket {
@@ -75,93 +75,79 @@ interface MutableBucket {
 
 type QueryParam = string | number;
 
+export interface SessionEconomicsVector {
+  id: number;
+  started_at: string | null;
+  input_cost: number;
+  output_cost: number;
+  buckets: Record<
+    ActivityBucket,
+    { generation: number; context_window: number; tool_calls: number; touched: boolean }
+  >;
+}
+
 export function tokenEconomics(db: Database, filter?: DateFilter | null): TokenEconomics {
   const date = sessionDatePredicate("s", filter);
-  return tokenEconomicsForScope(
-    db,
-    `WITH scoped_session AS (
-       SELECT s.id FROM session s ${whereClause(date)}
-     )`,
-    date.params,
+  return aggregateEconomicsVectors(
+    vectorsForScope(
+      db,
+      `WITH scoped_session AS (
+         SELECT s.id FROM session s ${whereClause(date)}
+       )`,
+      date.params,
+    ),
   );
 }
 
-export function tokenEconomicsForSession(db: Database, sessionId: number): TokenEconomics | null {
-  return fastTokenEconomicsForSession(db, sessionId);
+/**
+ * Per-session activity vectors for the whole archive. Sums of these vectors
+ * reproduce tokenEconomics() exactly for any date scope, so a caller can
+ * compute them once (off the request path) and answer arbitrary date filters
+ * from memory via aggregateEconomicsVectors().
+ */
+export function computeSessionEconomicsVectors(db: Database): SessionEconomicsVector[] {
+  return vectorsForScope(db, "WITH scoped_session AS (SELECT id FROM session)", []);
 }
 
-function tokenEconomicsForScope(
-  db: Database,
-  scopeCte: string,
-  params: QueryParam[],
+/** Mirrors sessionDatePredicate: string-compare on the YYYY-MM-DD prefix. */
+export function economicsVectorMatchesFilter(
+  vector: SessionEconomicsVector,
+  filter?: DateFilter | null,
+): boolean {
+  const from = filter?.from ?? null;
+  const to = filter?.to ?? null;
+  if (from == null && to == null) {
+    return true;
+  }
+  if (vector.started_at == null) {
+    return false;
+  }
+  const day = vector.started_at.slice(0, 10);
+  return (from == null || day >= from) && (to == null || day <= to);
+}
+
+export function aggregateEconomicsVectors(
+  vectors: Iterable<SessionEconomicsVector>,
 ): TokenEconomics {
-  const sessions = db
-    .query(
-      `${scopeCte}
-       SELECT s.id, s.model, s.total_input_tokens, s.total_output_tokens,
-              s.total_cache_read_tokens, s.total_cache_creation_tokens,
-              s.total_reasoning_tokens, s.est_reasoning_tokens
-       FROM session s
-       JOIN scoped_session fs ON fs.id = s.id`,
-    )
-    .all(...params) as SessionRow[];
-  const sessionIds = sessions.map((session) => session.id);
   const buckets = emptyBuckets();
-
-  if (sessionIds.length === 0) {
-    return finish(buckets, 0, 0);
-  }
-
-  const blocks = db
-    .query(
-      `${scopeCte}
-       SELECT b.session_id, m.id AS message_id, m.role, m.output_tokens, b.type,
-              b.text, b.tool_name, b.tool_input
-       FROM block b
-       JOIN message m ON m.id = b.message_id
-       JOIN scoped_session fs ON fs.id = b.session_id
-       ORDER BY b.session_id, m.seq, b.ordinal`,
-    )
-    .all(...params) as BlockRow[];
-  allocateGeneration(sessions, blocks, buckets);
-
-  const results = db
-    .query(
-      `${scopeCte}
-       SELECT t.session_id, t.tool_name, t.input, rb.tool_result, t.output_bytes
-       FROM tool_call t
-       JOIN scoped_session fs ON fs.id = t.session_id
-       LEFT JOIN block rb ON rb.id = t.result_block_id`,
-    )
-    .all(...params) as ResultRow[];
-  for (const row of results) {
-    const bucket = toolBucket(row.tool_name, row.input);
-    const size = row.output_bytes ?? byteLength(row.tool_result ?? "");
-    const entry = buckets.get(bucket);
-    if (entry == null) {
-      continue;
-    }
-    entry.contextWindow += size / CHARS_PER_TOKEN;
-    entry.toolCalls += 1;
-    entry.sessions.add(row.session_id);
-  }
-
   let inputCost = 0;
   let outputCost = 0;
-  for (const session of sessions) {
-    const parts = estimateCostParts(
-      session.model,
-      {
-        input: session.total_input_tokens,
-        output: session.total_output_tokens,
-        cacheRead: session.total_cache_read_tokens,
-        cacheCreation: session.total_cache_creation_tokens,
-        reasoning: session.total_reasoning_tokens,
-      },
-      defaultPricing(),
-    );
-    inputCost += parts.input + parts.cacheRead + parts.cacheCreation;
-    outputCost += parts.output;
+  for (const vector of vectors) {
+    inputCost += vector.input_cost;
+    outputCost += vector.output_cost;
+    for (const bucket of ACTIVITY_BUCKETS) {
+      const entry = buckets.get(bucket);
+      const part = vector.buckets[bucket];
+      if (entry == null || part == null) {
+        continue;
+      }
+      entry.generation += part.generation;
+      entry.contextWindow += part.context_window;
+      entry.toolCalls += part.tool_calls;
+      if (part.touched) {
+        entry.sessions.add(vector.id);
+      }
+    }
   }
 
   const totalGeneration = sumBuckets(buckets, "generation");
@@ -177,6 +163,119 @@ function tokenEconomicsForScope(
   }
   return finish(buckets, inputCost, outputCost);
 }
+
+export function tokenEconomicsForSession(db: Database, sessionId: number): TokenEconomics | null {
+  return fastTokenEconomicsForSession(db, sessionId);
+}
+
+function vectorsForScope(
+  db: Database,
+  scopeCte: string,
+  params: QueryParam[],
+): SessionEconomicsVector[] {
+  const sessions = db
+    .query(
+      `${scopeCte}
+       SELECT s.id, s.started_at, s.model, s.total_input_tokens, s.total_output_tokens,
+              s.total_cache_read_tokens, s.total_cache_creation_tokens,
+              s.total_reasoning_tokens, s.est_reasoning_tokens
+       FROM session s
+       JOIN scoped_session fs ON fs.id = s.id`,
+    )
+    .all(...params) as SessionRow[];
+  if (sessions.length === 0) {
+    return [];
+  }
+
+  const vectorBySession = new Map<number, { session: SessionRow; buckets: PerSessionBuckets }>();
+  for (const session of sessions) {
+    vectorBySession.set(session.id, { session, buckets: emptyBuckets() });
+  }
+
+  // Ship byte lengths, not text: bucket math only needs sizes, plus the tool
+  // input for the block types whose bucket depends on the command being run.
+  // Row order is irrelevant to the math, so no ORDER BY.
+  const blocks = db
+    .query(
+      `${scopeCte}
+       SELECT b.session_id, b.message_id, m.role, m.output_tokens, b.type,
+              b.tool_name,
+              CASE WHEN b.type IN ('tool_use', 'tool_result', 'web_search')
+                   THEN b.tool_input END AS tool_input,
+              COALESCE(length(CAST(b.text AS BLOB)), 0) AS text_bytes
+       FROM block b
+       JOIN message m ON m.id = b.message_id
+       JOIN scoped_session fs ON fs.id = b.session_id`,
+    )
+    .all(...params) as BlockRow[];
+  const blocksBySession = groupBy(blocks, (block) => block.session_id);
+  for (const [sessionId, sessionBlocks] of blocksBySession) {
+    const vector = vectorBySession.get(sessionId);
+    if (vector != null) {
+      allocateGeneration([vector.session], sessionBlocks, vector.buckets);
+    }
+  }
+  for (const vector of vectorBySession.values()) {
+    if (!blocksBySession.has(vector.session.id)) {
+      allocateGeneration([vector.session], [], vector.buckets);
+    }
+  }
+
+  const results = db
+    .query(
+      `${scopeCte}
+       SELECT t.session_id, t.tool_name, t.input,
+              COALESCE(t.output_bytes, length(CAST(rb.tool_result AS BLOB)), 0) AS bytes
+       FROM tool_call t
+       JOIN scoped_session fs ON fs.id = t.session_id
+       LEFT JOIN block rb ON rb.id = t.result_block_id`,
+    )
+    .all(...params) as ResultRow[];
+  for (const row of results) {
+    const vector = vectorBySession.get(row.session_id);
+    const entry = vector?.buckets.get(toolBucket(row.tool_name, row.input));
+    if (entry == null) {
+      continue;
+    }
+    entry.contextWindow += row.bytes / CHARS_PER_TOKEN;
+    entry.toolCalls += 1;
+    entry.sessions.add(row.session_id);
+  }
+
+  return sessions.map((session) => {
+    const mutable = vectorBySession.get(session.id);
+    const parts = estimateCostParts(
+      session.model,
+      {
+        input: session.total_input_tokens,
+        output: session.total_output_tokens,
+        cacheRead: session.total_cache_read_tokens,
+        cacheCreation: session.total_cache_creation_tokens,
+        reasoning: session.total_reasoning_tokens,
+      },
+      defaultPricing(),
+    );
+    const buckets = {} as SessionEconomicsVector["buckets"];
+    for (const bucket of ACTIVITY_BUCKETS) {
+      const entry = mutable?.buckets.get(bucket);
+      buckets[bucket] = {
+        generation: entry?.generation ?? 0,
+        context_window: entry?.contextWindow ?? 0,
+        tool_calls: entry?.toolCalls ?? 0,
+        touched: (entry?.sessions.size ?? 0) > 0,
+      };
+    }
+    return {
+      id: session.id,
+      started_at: session.started_at,
+      input_cost: parts.input + parts.cacheRead + parts.cacheCreation,
+      output_cost: parts.output,
+      buckets,
+    };
+  });
+}
+
+type PerSessionBuckets = Map<ActivityBucket, MutableBucket>;
 
 function fastTokenEconomicsForSession(db: Database, sessionId: number): TokenEconomics | null {
   const scopeCte = `WITH RECURSIVE scoped_session(id) AS (
@@ -447,7 +546,7 @@ function blockSize(block: BlockRow): number {
   if (block.type === "tool_use") {
     return byteLength(`${block.tool_name ?? ""}\n${block.tool_input ?? ""}`);
   }
-  return byteLength(block.text ?? "");
+  return block.text_bytes;
 }
 
 function addBucket(

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -240,7 +240,6 @@ type SettingsInfo = {
 type DashboardData = {
   summary: Summary | null;
   sessions: SessionSummary[];
-  byTool: DimensionRow[];
   byModel: DimensionRow[];
   byProject: DimensionRow[];
   byDay: DimensionRow[];
@@ -261,7 +260,6 @@ type DashboardData = {
 const emptyData: DashboardData = {
   summary: null,
   sessions: [],
-  byTool: [],
   byModel: [],
   byProject: [],
   byDay: [],
@@ -277,6 +275,124 @@ const emptyData: DashboardData = {
   tokenEconomics: null,
   now: null,
   dateBounds: null,
+};
+
+type DataSlice = Exclude<keyof DashboardData, "sessions">;
+
+// Each page fetches only the slices it renders; fetching everything for every
+// page made first paint wait on the slowest analytics endpoint. Slices are
+// cached per (date filter, reload generation), so navigating back is free and
+// SSE-triggered refreshes only refetch what the active page shows.
+const SLICE_LOADERS: Record<
+  DataSlice,
+  { dateScoped: boolean; load: (dateQuery: string) => Promise<Partial<DashboardData>> }
+> = {
+  summary: {
+    dateScoped: true,
+    load: async (q) => ({
+      summary: await getJson<Summary>(withDateQuery("/api/stats/summary", q)),
+    }),
+  },
+  byModel: {
+    dateScoped: true,
+    load: async (q) => ({
+      byModel: await getJson<DimensionRow[]>(withDateQuery("/api/stats/by-dimension?dim=model", q)),
+    }),
+  },
+  byProject: {
+    dateScoped: true,
+    load: async (q) => ({
+      byProject: await getJson<DimensionRow[]>(
+        withDateQuery("/api/stats/by-dimension?dim=project", q),
+      ),
+    }),
+  },
+  byDay: {
+    dateScoped: true,
+    load: async (q) => ({
+      byDay: await getJson<DimensionRow[]>(withDateQuery("/api/stats/by-dimension?dim=day", q)),
+    }),
+  },
+  projects: {
+    dateScoped: false,
+    load: async () => ({ projects: await getJson<ProjectSummary[]>("/api/projects") }),
+  },
+  tools: {
+    dateScoped: true,
+    load: async (q) => ({
+      tools: await getJson<ToolRow[]>(withDateQuery("/api/tools/usage?limit=100", q)),
+    }),
+  },
+  mcp: {
+    dateScoped: true,
+    load: async (q) => ({
+      mcp: await getJson<McpRow[]>(withDateQuery("/api/tools/mcp-usage?limit=100", q)),
+    }),
+  },
+  files: {
+    dateScoped: true,
+    load: async (q) => ({
+      files: await getJson<FileRow[]>(withDateQuery("/api/files?group=path&limit=100", q)),
+    }),
+  },
+  recommendations: {
+    dateScoped: false,
+    load: async () => ({
+      recommendations: await getJson<Recommendation[]>("/api/recommendations?status=all"),
+    }),
+  },
+  config: {
+    dateScoped: false,
+    load: async () => ({ config: await getJson<ConfigView>("/api/config") }),
+  },
+  settings: {
+    dateScoped: false,
+    load: async () => ({ settings: await getJson<SettingsInfo>("/api/settings") }),
+  },
+  activity: {
+    dateScoped: true,
+    load: async (q) => ({
+      activity: await getJson<Activity>(withDateQuery("/api/analytics/activity", q)),
+    }),
+  },
+  modelSparklines: {
+    dateScoped: true,
+    load: async (q) => ({
+      modelSparklines: await getJson<ModelSparklines>(
+        withDateQuery("/api/analytics/model-sparklines", q),
+      ),
+    }),
+  },
+  tokenEconomics: {
+    dateScoped: true,
+    load: async (q) => ({
+      tokenEconomics: await getJson<TokenEconomics>(
+        withDateQuery("/api/analytics/token-economics", q),
+      ),
+    }),
+  },
+  now: {
+    dateScoped: false,
+    load: async () => ({ now: await getJson<NowView>("/api/analytics/now") }),
+  },
+  dateBounds: {
+    dateScoped: false,
+    load: async () => ({ dateBounds: await getJson<DateBounds>("/api/date-bounds") }),
+  },
+};
+
+// Slices the app shell itself renders (sidebar stats, sync button, pickers).
+const SHELL_SLICES: DataSlice[] = ["summary", "now", "dateBounds"];
+
+const ROUTE_SLICES: Record<string, DataSlice[]> = {
+  Sessions: [],
+  Projects: ["projects"],
+  Search: [],
+  Analytics: ["byDay", "byModel", "byProject", "activity", "modelSparklines", "tokenEconomics"],
+  Insights: ["recommendations", "settings"],
+  "Tools & MCP": ["tools", "mcp"],
+  Files: ["files"],
+  Settings: ["config", "settings"],
 };
 
 type NavItem = {
@@ -303,7 +419,7 @@ const OPENAI_ICON_PATH =
 const ANTHROPIC_ICON_PATH =
   "M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z";
 
-const SESSION_PAGE_SIZE = 100;
+const SESSION_PAGE_SIZE = 50;
 const SESSION_DETAIL_MESSAGE_LIMIT = 160;
 const SESSION_TABLE_SKELETON_KEYS = Array.from(
   { length: 10 },
@@ -337,6 +453,9 @@ function App() {
   const dateQuery = dateRangeQuery(dateRangeSelection);
   const sessionLoadKey = `${dateQuery}:${reloadKey}`;
   const refreshTimerRef = useRef<number | null>(null);
+  const loadedSlicesRef = useRef(new Map<DataSlice, string>());
+  const activeView = activeRoute(path);
+  const showsSessions = activeView === "Sessions";
   const [theme, setTheme] = useState<ThemeChoice>(() => {
     const stored = localStorage.getItem("decant-theme");
     return stored === "light" || stored === "dark" ? stored : "system";
@@ -386,73 +505,28 @@ function App() {
   }, [dateQuery]);
 
   useEffect(() => {
-    void reloadKey;
+    const sliceKey = (slice: DataSlice): string =>
+      SLICE_LOADERS[slice].dateScoped ? `${dateQuery}|${reloadKey}` : `${reloadKey}`;
+    const needed = [...new Set([...SHELL_SLICES, ...(ROUTE_SLICES[activeView] ?? [])])];
+    const missing = needed.filter(
+      (slice) => loadedSlicesRef.current.get(slice) !== sliceKey(slice),
+    );
+    if (missing.length === 0) {
+      return;
+    }
     let cancelled = false;
-    Promise.all([
-      getJson<Summary>(withDateQuery("/api/stats/summary", dateQuery)),
-      getJson<DimensionRow[]>(withDateQuery("/api/stats/by-dimension?dim=tool", dateQuery)),
-      getJson<DimensionRow[]>(withDateQuery("/api/stats/by-dimension?dim=model", dateQuery)),
-      getJson<DimensionRow[]>(withDateQuery("/api/stats/by-dimension?dim=project", dateQuery)),
-      getJson<DimensionRow[]>(withDateQuery("/api/stats/by-dimension?dim=day", dateQuery)),
-      getJson<ProjectSummary[]>("/api/projects"),
-      getJson<ToolRow[]>(withDateQuery("/api/tools/usage?limit=100", dateQuery)),
-      getJson<McpRow[]>(withDateQuery("/api/tools/mcp-usage?limit=100", dateQuery)),
-      getJson<FileRow[]>(withDateQuery("/api/files?group=path&limit=100", dateQuery)),
-      getJson<Recommendation[]>("/api/recommendations?status=all"),
-      getJson<ConfigView>("/api/config"),
-      getJson<SettingsInfo>("/api/settings"),
-      getJson<Activity>(withDateQuery("/api/analytics/activity", dateQuery)),
-      getJson<ModelSparklines>(withDateQuery("/api/analytics/model-sparklines", dateQuery)),
-      getJson<TokenEconomics>(withDateQuery("/api/analytics/token-economics", dateQuery)),
-      getJson<NowView>("/api/analytics/now"),
-      getJson<DateBounds>("/api/date-bounds"),
-    ])
-      .then(
-        ([
-          summary,
-          byTool,
-          byModel,
-          byProject,
-          byDay,
-          projects,
-          tools,
-          mcp,
-          files,
-          recommendations,
-          config,
-          settings,
-          activity,
-          modelSparklines,
-          tokenEconomics,
-          now,
-          dateBounds,
-        ]) => {
-          if (cancelled) {
-            return;
-          }
-          setData((current) => ({
-            summary,
-            sessions: current.sessions,
-            byTool,
-            byModel,
-            byProject,
-            byDay,
-            projects,
-            tools,
-            mcp,
-            files,
-            recommendations,
-            config,
-            settings,
-            activity,
-            modelSparklines,
-            tokenEconomics,
-            now,
-            dateBounds,
-          }));
-          setError(null);
-        },
-      )
+    Promise.all(missing.map((slice) => SLICE_LOADERS[slice].load(dateQuery)))
+      .then((parts) => {
+        if (cancelled) {
+          return;
+        }
+        const merged = Object.assign({}, ...parts) as Partial<DashboardData>;
+        setData((current) => ({ ...current, ...merged }));
+        for (const slice of missing) {
+          loadedSlicesRef.current.set(slice, sliceKey(slice));
+        }
+        setError(null);
+      })
       .catch((err: unknown) => {
         if (!cancelled) {
           setError(errorMessage(err));
@@ -461,9 +535,12 @@ function App() {
     return () => {
       cancelled = true;
     };
-  }, [dateQuery, reloadKey]);
+  }, [activeView, dateQuery, reloadKey]);
 
   useEffect(() => {
+    if (!showsSessions) {
+      return;
+    }
     let cancelled = false;
     const plan = planSessionLoad({
       loadedRequestKey: loadedSessionKey,
@@ -506,7 +583,14 @@ function App() {
     return () => {
       cancelled = true;
     };
-  }, [data.sessions.length, dateQuery, loadedSessionKey, sessionLimit, sessionLoadKey]);
+  }, [
+    data.sessions.length,
+    dateQuery,
+    loadedSessionKey,
+    sessionLimit,
+    sessionLoadKey,
+    showsSessions,
+  ]);
 
   useEffect(() => {
     const events = new EventSource("/api/events");
@@ -519,10 +603,10 @@ function App() {
     };
   }, [requestRefresh]);
 
-  const active = activeRoute(path);
+  const active = activeView;
   const activeKey = activeRouteKey(path);
   const metrics = data.summary;
-  const lastActivity = latestSessionDay(data.sessions);
+  const lastActivity = data.dateBounds?.max ?? latestSessionDay(data.sessions);
   const syncInProgress = data.now?.sync_in_progress === true;
   const runSync = () => {
     if (syncInProgress) {

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -606,7 +606,10 @@ function App() {
   const active = activeView;
   const activeKey = activeRouteKey(path);
   const metrics = data.summary;
-  const lastActivity = data.dateBounds?.max ?? latestSessionDay(data.sessions);
+  // Prefer the loaded (date-filtered) session list, matching the sidebar's
+  // other stats; dateBounds is archive-wide and only a fallback for routes
+  // that never load session rows, so it must never win over an in-range value.
+  const lastActivity = latestSessionDay(data.sessions) ?? formatDay(data.dateBounds?.max ?? null);
   const syncInProgress = data.now?.sync_in_progress === true;
   const runSync = () => {
     if (syncInProgress) {
@@ -3254,12 +3257,16 @@ function capitalize(value: string): string {
 
 function latestSessionDay(sessions: SessionSummary[]): string | null {
   const latest = sessions.find((session) => session.started_at != null)?.started_at;
-  if (latest == null) {
+  return latest == null ? null : formatDay(latest);
+}
+
+function formatDay(value: string | null): string | null {
+  if (value == null) {
     return null;
   }
-  const date = new Date(latest);
+  const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
-    return latest;
+    return value;
   }
   return date.toLocaleDateString(undefined, { month: "short", day: "2-digit" });
 }

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -46,6 +46,12 @@ export interface WatchStoppedEvent {
 
 export type WatchEvent = SyncEvent | SyncErrorEvent | WatchReadyEvent | WatchStoppedEvent;
 
+export type SyncRunner = (
+  config: Config,
+  status: SyncStatusStore,
+  cancel: { aborted: boolean },
+) => Promise<SyncReport>;
+
 export interface WatchOptions {
   config: Config;
   intervalMs?: number;
@@ -55,6 +61,12 @@ export interface WatchOptions {
   open?: (path: string) => Database;
   enableWatch?: boolean;
   syncOnStart?: boolean;
+  /**
+   * How to execute one sync. Defaults to the in-process runSyncOnce; servers
+   * pass a worker-backed runner so multi-second ingests cannot stall the
+   * request event loop.
+   */
+  runner?: SyncRunner;
 }
 
 export interface WatchHandle {
@@ -150,6 +162,9 @@ export function startWatch(options: WatchOptions): WatchHandle {
   const intervalMs = options.intervalMs ?? DEFAULT_SYNC_INTERVAL_MS;
   const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
   const open = options.open ?? openDb;
+  const runner: SyncRunner =
+    options.runner ??
+    (async (config, syncStatus, cancelFlag) => runSyncOnce(config, syncStatus, cancelFlag, open));
   const enableWatch = options.enableWatch !== false;
   const syncOnStart = options.syncOnStart !== false;
   const cancel = { aborted: false };
@@ -208,7 +223,7 @@ export function startWatch(options: WatchOptions): WatchHandle {
         nextReason = null;
         pendingReason = null;
         try {
-          const report = runSyncOnce(options.config, status, cancel, open);
+          const report = await runner(options.config, status, cancel);
           emit({ type: "sync", reason: current, report, status: status.snapshot() });
         } catch (error) {
           emit({

--- a/test/economics-cache.test.ts
+++ b/test/economics-cache.test.ts
@@ -1,0 +1,182 @@
+import { Database } from "bun:sqlite";
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openDb } from "../src/db.ts";
+import { EconomicsCache } from "../src/economics-cache.ts";
+import { upsertSession } from "../src/ingest.ts";
+import { handleRequest } from "../src/server.ts";
+import { parseClaudeSession } from "../src/sources/claude.ts";
+import { parseCodexSession } from "../src/sources/codex.ts";
+import { computeSessionEconomicsVectors, tokenEconomics } from "../src/token-economics.ts";
+
+const workDir = mkdtempSync(join(tmpdir(), "decant-economics-cache-test-"));
+afterAll(() => rmSync(workDir, { recursive: true, force: true }));
+
+let dbCounter = 0;
+function seededDbPath(): string {
+  dbCounter += 1;
+  const path = join(workDir, `economics-${dbCounter}.db`);
+  const db = openDb(path);
+  upsertSession(
+    db,
+    parseClaudeSession("sess-enr-claude", fixture("claude", "enriched.jsonl")),
+    "/x/claude.jsonl",
+    1,
+    2,
+    "claude",
+  );
+  db.close();
+  return path;
+}
+
+function fixture(tool: "claude" | "codex", name: string): string {
+  return readFileSync(join(import.meta.dir, "..", "fixtures", tool, name), "utf8");
+}
+
+describe("economics cache", () => {
+  test("serves tokenEconomics-identical answers from one computation", async () => {
+    const dbPath = seededDbPath();
+    const db = openDb(dbPath);
+    let computeCalls = 0;
+    const cache = new EconomicsCache({
+      dbPath,
+      db,
+      computeVectors: (path) => {
+        computeCalls += 1;
+        const worker = new Database(path, { readonly: true, strict: true });
+        try {
+          return Promise.resolve(computeSessionEconomicsVectors(worker));
+        } finally {
+          worker.close();
+        }
+      },
+    });
+
+    expect(await cache.get()).toEqual(tokenEconomics(db));
+    expect(await cache.get({ from: "2026-05-04", to: "2026-05-04" })).toEqual(
+      tokenEconomics(db, { from: "2026-05-04", to: "2026-05-04" }),
+    );
+    expect(await cache.get({ from: "2030-01-01", to: null })).toEqual(
+      tokenEconomics(db, { from: "2030-01-01" }),
+    );
+    expect(computeCalls).toBe(1);
+    cache.dispose();
+    db.close();
+  });
+
+  test("detects external writes, serves stale, then rebuilds and notifies", async () => {
+    const dbPath = seededDbPath();
+    const db = openDb(dbPath);
+    let computeCalls = 0;
+    let rebuilt = 0;
+    const cache = new EconomicsCache({
+      dbPath,
+      db,
+      onRebuilt: () => {
+        rebuilt += 1;
+      },
+      computeVectors: (path) => {
+        computeCalls += 1;
+        const worker = new Database(path, { readonly: true, strict: true });
+        try {
+          return Promise.resolve(computeSessionEconomicsVectors(worker));
+        } finally {
+          worker.close();
+        }
+      },
+    });
+
+    const first = await cache.get();
+    expect(computeCalls).toBe(1);
+    expect(rebuilt).toBe(0);
+
+    // Simulate a sync worker: another connection ingests a session.
+    const writer = openDb(dbPath);
+    upsertSession(
+      writer,
+      parseCodexSession("sess-enr-codex", fixture("codex", "enriched.jsonl"), new Map()),
+      "/x/codex.jsonl",
+      1,
+      2,
+      "codex",
+    );
+    writer.close();
+    // The main connection has to touch the database once before data_version
+    // reflects the external commit.
+    db.query("SELECT COUNT(*) FROM session").get();
+
+    const stale = await cache.get();
+    expect(stale).toEqual(first);
+    await cache.settled();
+    expect(computeCalls).toBe(2);
+    expect(rebuilt).toBe(1);
+    expect(await cache.get()).toEqual(tokenEconomics(db));
+    cache.dispose();
+    db.close();
+  });
+
+  test("invalidate() kicks a rebuild without a request", async () => {
+    const dbPath = seededDbPath();
+    const db = openDb(dbPath);
+    let computeCalls = 0;
+    const cache = new EconomicsCache({
+      dbPath,
+      db,
+      computeVectors: (path) => {
+        computeCalls += 1;
+        const worker = new Database(path, { readonly: true, strict: true });
+        try {
+          return Promise.resolve(computeSessionEconomicsVectors(worker));
+        } finally {
+          worker.close();
+        }
+      },
+    });
+    cache.invalidate();
+    await cache.settled();
+    expect(computeCalls).toBe(1);
+    expect(await cache.get()).toEqual(tokenEconomics(db));
+    expect(computeCalls).toBe(1);
+    cache.dispose();
+    db.close();
+  });
+
+  test("stats worker computes the same vectors as an in-process run", async () => {
+    const dbPath = seededDbPath();
+    const cache = new EconomicsCache({ dbPath, db: openDb(dbPath) });
+    const viaWorker = await cache.get();
+    const direct = openDb(dbPath);
+    expect(viaWorker).toEqual(tokenEconomics(direct));
+    direct.close();
+    cache.dispose();
+  });
+
+  test("token-economics route answers from the cache when provided", async () => {
+    const dbPath = seededDbPath();
+    const db = openDb(dbPath);
+    const config = { dbPath, claudeDir: join(workDir, "none"), codexDir: join(workDir, "none") };
+    const cache = new EconomicsCache({
+      dbPath,
+      db,
+      computeVectors: (path) => {
+        const worker = new Database(path, { readonly: true, strict: true });
+        try {
+          return Promise.resolve(computeSessionEconomicsVectors(worker));
+        } finally {
+          worker.close();
+        }
+      },
+    });
+    const response = await handleRequest(
+      new Request("http://127.0.0.1:3000/api/analytics/token-economics"),
+      config,
+      { db, economics: cache },
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(JSON.parse(JSON.stringify(tokenEconomics(db))));
+    cache.dispose();
+    db.close();
+  });
+});

--- a/test/economics-cache.test.ts
+++ b/test/economics-cache.test.ts
@@ -35,23 +35,33 @@ function fixture(tool: "claude" | "codex", name: string): string {
   return readFileSync(join(import.meta.dir, "..", "fixtures", tool, name), "utf8");
 }
 
+function inProcessComputeVectors(path: string) {
+  const worker = new Database(path, { readonly: true, strict: true });
+  try {
+    return computeSessionEconomicsVectors(worker);
+  } finally {
+    worker.close();
+  }
+}
+
+/** A computeVectors fake that counts calls and computes in-process (no real
+ * Worker), for tests that only care about cache orchestration. */
+function countingComputeVectors(counter: { calls: number }) {
+  return (path: string) => {
+    counter.calls += 1;
+    return Promise.resolve(inProcessComputeVectors(path));
+  };
+}
+
 describe("economics cache", () => {
   test("serves tokenEconomics-identical answers from one computation", async () => {
     const dbPath = seededDbPath();
     const db = openDb(dbPath);
-    let computeCalls = 0;
+    const counter = { calls: 0 };
     const cache = new EconomicsCache({
       dbPath,
       db,
-      computeVectors: (path) => {
-        computeCalls += 1;
-        const worker = new Database(path, { readonly: true, strict: true });
-        try {
-          return Promise.resolve(computeSessionEconomicsVectors(worker));
-        } finally {
-          worker.close();
-        }
-      },
+      computeVectors: countingComputeVectors(counter),
     });
 
     expect(await cache.get()).toEqual(tokenEconomics(db));
@@ -61,7 +71,7 @@ describe("economics cache", () => {
     expect(await cache.get({ from: "2030-01-01", to: null })).toEqual(
       tokenEconomics(db, { from: "2030-01-01" }),
     );
-    expect(computeCalls).toBe(1);
+    expect(counter.calls).toBe(1);
     cache.dispose();
     db.close();
   });
@@ -69,7 +79,7 @@ describe("economics cache", () => {
   test("detects external writes, serves stale, then rebuilds and notifies", async () => {
     const dbPath = seededDbPath();
     const db = openDb(dbPath);
-    let computeCalls = 0;
+    const counter = { calls: 0 };
     let rebuilt = 0;
     const cache = new EconomicsCache({
       dbPath,
@@ -77,19 +87,11 @@ describe("economics cache", () => {
       onRebuilt: () => {
         rebuilt += 1;
       },
-      computeVectors: (path) => {
-        computeCalls += 1;
-        const worker = new Database(path, { readonly: true, strict: true });
-        try {
-          return Promise.resolve(computeSessionEconomicsVectors(worker));
-        } finally {
-          worker.close();
-        }
-      },
+      computeVectors: countingComputeVectors(counter),
     });
 
     const first = await cache.get();
-    expect(computeCalls).toBe(1);
+    expect(counter.calls).toBe(1);
     expect(rebuilt).toBe(0);
 
     // Simulate a sync worker: another connection ingests a session.
@@ -110,7 +112,7 @@ describe("economics cache", () => {
     const stale = await cache.get();
     expect(stale).toEqual(first);
     await cache.settled();
-    expect(computeCalls).toBe(2);
+    expect(counter.calls).toBe(2);
     expect(rebuilt).toBe(1);
     expect(await cache.get()).toEqual(tokenEconomics(db));
     cache.dispose();
@@ -120,26 +122,89 @@ describe("economics cache", () => {
   test("invalidate() kicks a rebuild without a request", async () => {
     const dbPath = seededDbPath();
     const db = openDb(dbPath);
-    let computeCalls = 0;
+    const counter = { calls: 0 };
     const cache = new EconomicsCache({
       dbPath,
       db,
-      computeVectors: (path) => {
-        computeCalls += 1;
-        const worker = new Database(path, { readonly: true, strict: true });
-        try {
-          return Promise.resolve(computeSessionEconomicsVectors(worker));
-        } finally {
-          worker.close();
-        }
-      },
+      computeVectors: countingComputeVectors(counter),
     });
     cache.invalidate();
     await cache.settled();
-    expect(computeCalls).toBe(1);
+    expect(counter.calls).toBe(1);
     expect(await cache.get()).toEqual(tokenEconomics(db));
-    expect(computeCalls).toBe(1);
+    expect(counter.calls).toBe(1);
     cache.dispose();
+    db.close();
+  });
+
+  test("invalidate() during an in-flight rebuild schedules an immediate follow-up", async () => {
+    const dbPath = seededDbPath();
+    const db = openDb(dbPath);
+    const counter = { calls: 0 };
+    let rebuilt = 0;
+    // Captured before the ingest below, standing in for a worker whose read
+    // already happened by the time invalidate() fires mid-build — the case
+    // where naive coalescing would leave the cache pinned to a stale answer.
+    const preIngestVectors = inProcessComputeVectors(dbPath);
+    const gate = Promise.withResolvers<void>();
+    const cache = new EconomicsCache({
+      dbPath,
+      db,
+      onRebuilt: () => {
+        rebuilt += 1;
+      },
+      computeVectors: async (path) => {
+        counter.calls += 1;
+        if (counter.calls === 1) {
+          await gate.promise;
+          return preIngestVectors;
+        }
+        return inProcessComputeVectors(path);
+      },
+    });
+
+    cache.prewarm(); // build #1: blocked on gate, will resolve with stale data
+    upsertSession(
+      db,
+      parseCodexSession("sess-enr-codex", fixture("codex", "enriched.jsonl"), new Map()),
+      "/x/codex.jsonl",
+      1,
+      2,
+      "codex",
+    );
+    // Must NOT be silently coalesced into build #1, which already committed
+    // to answering with the pre-ingest snapshot.
+    cache.invalidate();
+    gate.resolve();
+    await cache.settled();
+
+    expect(counter.calls).toBe(2);
+    expect(rebuilt).toBe(1);
+    expect(await cache.get()).toEqual(tokenEconomics(db));
+    cache.dispose();
+    db.close();
+  });
+
+  test("dispose() aborts an in-flight rebuild instead of waiting for it", async () => {
+    const dbPath = seededDbPath();
+    const db = openDb(dbPath);
+    let sawAbort = false;
+    const cache = new EconomicsCache({
+      dbPath,
+      db,
+      computeVectors: (_path, { signal }) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener("abort", () => {
+            sawAbort = true;
+            reject(new Error("aborted"));
+          });
+        }),
+    });
+
+    cache.prewarm();
+    cache.dispose();
+    await cache.settled();
+    expect(sawAbort).toBe(true);
     db.close();
   });
 
@@ -160,14 +225,7 @@ describe("economics cache", () => {
     const cache = new EconomicsCache({
       dbPath,
       db,
-      computeVectors: (path) => {
-        const worker = new Database(path, { readonly: true, strict: true });
-        try {
-          return Promise.resolve(computeSessionEconomicsVectors(worker));
-        } finally {
-          worker.close();
-        }
-      },
+      computeVectors: countingComputeVectors({ calls: 0 }),
     });
     const response = await handleRequest(
       new Request("http://127.0.0.1:3000/api/analytics/token-economics"),

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -122,6 +122,76 @@ describe("query reads", () => {
     db.close();
   });
 
+  test("getSession assembles nested subagent trees with display titles", () => {
+    const db = freshDb();
+    db.exec(`
+      INSERT INTO session(id, tool, source_session_id, title, started_at, is_subagent,
+                          parent_session_id, spawn_tool_use_id, agent_id, agent_type,
+                          spawn_depth, estimated_cost_usd, message_count)
+      VALUES
+        (1, 'claude_code', 'root', NULL, '2026-07-01T00:00:00Z', 0, NULL, NULL, NULL, NULL, NULL, 1.0, 1),
+        (2, 'claude_code', 'kid-a', NULL, '2026-07-01T00:01:00Z', 1, 1, 'tu-a', 'agent-a', 'Explore', 1, 0.5, 1),
+        (3, 'claude_code', 'kid-b', NULL, '2026-07-01T00:02:00Z', 1, 1, 'tu-b', 'agent-b', 'Plan', 1, 0.25, 1),
+        (4, 'claude_code', 'grandkid', NULL, '2026-07-01T00:03:00Z', 1, 2, 'tu-c', 'agent-c', 'Explore', 2, 0.125, 1);
+      INSERT INTO message(id, session_id, seq, role, raw) VALUES
+        (1, 1, 0, 'user', '{}'),
+        (2, 2, 0, 'user', '{}'),
+        (3, 3, 0, 'user', '{}'),
+        (4, 4, 0, 'user', '{}');
+      INSERT INTO block(message_id, session_id, ordinal, type, text) VALUES
+        (1, 1, 0, 'text', 'Root prompt'),
+        (2, 2, 0, 'text', 'Child A prompt'),
+        (3, 3, 0, 'text', 'Child B prompt'),
+        (4, 4, 0, 'text', 'Grandchild prompt');
+    `);
+
+    const detail = getSession(db, 1);
+    expect(detail?.summary.title).toBe("Root prompt");
+    expect(detail?.summary.subagent_count).toBe(2);
+    expect(detail?.summary.subagent_estimated_cost_usd).toBeCloseTo(0.75);
+    expect(detail?.messages).toHaveLength(1);
+    expect(detail?.subagents.map((child) => child.summary.title)).toEqual([
+      "Child A prompt",
+      "Child B prompt",
+    ]);
+    expect(detail?.subagents[0]).toMatchObject({
+      spawn_tool_use_id: "tu-a",
+      agent_id: "agent-a",
+      agent_type: "Explore",
+      spawn_depth: 1,
+    });
+    expect(detail?.subagents[0]?.messages).toEqual([]);
+    expect(detail?.subagents[0]?.subagents.map((child) => child.summary.title)).toEqual([
+      "Grandchild prompt",
+    ]);
+    expect(detail?.subagents[1]?.subagents).toEqual([]);
+    db.close();
+  });
+
+  test("getSession caps subagent nesting at five levels below the root", () => {
+    const db = freshDb();
+    const rows: string[] = ["(1, 'claude_code', 'chain-0', '2026-07-01T00:00:00Z', 0, NULL)"];
+    for (let id = 2; id <= 8; id += 1) {
+      rows.push(
+        `(${id}, 'claude_code', 'chain-${id - 1}', '2026-07-01T00:0${id - 1}:00Z', 1, ${id - 1})`,
+      );
+    }
+    db.exec(`
+      INSERT INTO session(id, tool, source_session_id, started_at, is_subagent, parent_session_id)
+      VALUES ${rows.join(", ")};
+    `);
+
+    const detail = getSession(db, 1);
+    let level = 0;
+    let cursor = detail?.subagents ?? [];
+    while (cursor.length > 0) {
+      level += 1;
+      cursor = cursor[0]?.subagents ?? [];
+    }
+    expect(level).toBe(5);
+    db.close();
+  });
+
   test("search with no match returns empty", () => {
     const db = seeded();
     expect(search(db, "zzznotpresentzzz", 10)).toEqual([]);

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -7,7 +7,7 @@ import type { Config } from "../src/config.ts";
 import { openDb } from "../src/db.ts";
 import { upsertSession } from "../src/ingest.ts";
 import { regenerate } from "../src/recommendations.ts";
-import { handleRequest, publishServerEvent } from "../src/server.ts";
+import { handleRequest, publishServerEvent, serve } from "../src/server.ts";
 import { parseClaudeSession } from "../src/sources/claude.ts";
 import { parseCodexSession } from "../src/sources/codex.ts";
 
@@ -475,5 +475,52 @@ describe("server routes", () => {
       ingested_count: 0,
       last_error: null,
     });
+  });
+
+  test("stop() resolves promptly even while a request awaits an in-flight economics rebuild", async () => {
+    const config = freshConfig();
+    const gate = Promise.withResolvers<void>();
+    let sawAbort = false;
+    const server = serve({
+      config,
+      port: 0,
+      economicsComputeVectors: (_path, { signal }) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener("abort", () => {
+            sawAbort = true;
+            reject(new Error("aborted"));
+          });
+          // Never resolves on its own; only the abort (from server.stop()'s
+          // dispose) or the test's gate settles this.
+          gate.promise.then(() => reject(new Error("test cleanup")));
+        }),
+    });
+
+    // Start a real request that will hang awaiting the gated rebuild — this
+    // reproduces the exact scenario where naive ordering (disposing the
+    // economics cache only *after* awaiting Bun's native stop()) deadlocks:
+    // native stop() waits for this in-flight handler, which waits for the
+    // rebuild, which is never told to abort until stop() already returned.
+    const pendingRequest = fetch(
+      `http://127.0.0.1:${server.port}/api/analytics/token-economics`,
+    ).catch((error: unknown) => error);
+    // Let the connection actually get accepted and the handler reach its
+    // await on the rebuild; racing stop() immediately after fetch() can
+    // force-close the connection before the server ever processes it, which
+    // would make this test pass regardless of the dispose ordering.
+    await Bun.sleep(50);
+
+    const t0 = performance.now();
+    await Promise.race([
+      server.stop(true),
+      new Promise((_resolve, reject) =>
+        setTimeout(() => reject(new Error("server.stop() did not resolve within 2s")), 2000),
+      ),
+    ]);
+    expect(performance.now() - t0).toBeLessThan(2000);
+    expect(sawAbort).toBe(true);
+
+    gate.resolve();
+    await pendingRequest.catch(() => {});
   });
 });

--- a/test/token-economics.test.ts
+++ b/test/token-economics.test.ts
@@ -7,7 +7,13 @@ import { openDb } from "../src/db.ts";
 import { upsertSession } from "../src/ingest.ts";
 import { parseClaudeSession } from "../src/sources/claude.ts";
 import { parseCodexSession } from "../src/sources/codex.ts";
-import { tokenEconomics, tokenEconomicsForSession } from "../src/token-economics.ts";
+import {
+  aggregateEconomicsVectors,
+  computeSessionEconomicsVectors,
+  economicsVectorMatchesFilter,
+  tokenEconomics,
+  tokenEconomicsForSession,
+} from "../src/token-economics.ts";
 
 const workDir = mkdtempSync(join(tmpdir(), "decant-token-economics-test-"));
 afterAll(() => rmSync(workDir, { recursive: true, force: true }));
@@ -249,6 +255,54 @@ describe("token economics", () => {
     );
     expect(scoped?.buckets.some((row) => row.sessions > 1)).toBe(true);
     expect(tokenEconomicsForSession(db, 999_999)).toBeNull();
+    db.close();
+  });
+
+  test("precomputed vectors reproduce tokenEconomics for any date filter", () => {
+    const db = freshDb();
+    upsertSession(
+      db,
+      parseClaudeSession("sess-enr-claude", fixture("claude", "enriched.jsonl")),
+      "/x/claude.jsonl",
+      1,
+      2,
+      "claude",
+    );
+    upsertSession(
+      db,
+      parseCodexSession("sess-enr-codex", fixture("codex", "enriched.jsonl"), new Map()),
+      "/x/codex.jsonl",
+      1,
+      2,
+      "codex",
+    );
+    // Split the sessions across days, and leave one session dateless to pin
+    // the SQL NULL semantics: excluded whenever a bound is set.
+    db.exec(`
+      UPDATE session SET started_at = '2026-01-01T09:00:00Z' WHERE id = 1;
+      UPDATE session SET started_at = NULL WHERE id = 2;
+    `);
+
+    const vectors = computeSessionEconomicsVectors(db);
+    expect(vectors).toHaveLength(2);
+    const filters = [
+      undefined,
+      { from: "2026-01-01", to: "2026-01-01" },
+      { from: "2026-01-02", to: null },
+      { from: null, to: "2025-12-31" },
+    ] as const;
+    for (const filter of filters) {
+      const fromVectors = aggregateEconomicsVectors(
+        vectors.filter((vector) => economicsVectorMatchesFilter(vector, filter)),
+      );
+      expect(fromVectors).toEqual(tokenEconomics(db, filter));
+    }
+
+    const bounded = vectors.filter((vector) =>
+      economicsVectorMatchesFilter(vector, { from: "2026-01-01", to: null }),
+    );
+    expect(bounded.map((vector) => vector.id)).toEqual([1]);
+    expect(aggregateEconomicsVectors([])).toEqual(tokenEconomics(db, { from: "2030-01-01" }));
     db.close();
   });
 });

--- a/test/watch.test.ts
+++ b/test/watch.test.ts
@@ -118,6 +118,40 @@ describe("watch mode", () => {
     expect(events.at(-1)?.type).toBe("stopped");
   });
 
+  test("startWatch delegates syncs to an injected runner", async () => {
+    const config = freshConfig();
+    const events: WatchEvent[] = [];
+    const runnerCalls: string[] = [];
+    const handle = startWatch({
+      config,
+      enableWatch: false,
+      intervalMs: 0,
+      syncOnStart: false,
+      onEvent: (event) => events.push(event),
+      runner: (runnerConfig, status) => {
+        runnerCalls.push(runnerConfig.dbPath);
+        status.start();
+        const report = {
+          scanned: 3,
+          ingested: 2,
+          skipped: 1,
+          issues: 0,
+          failed: 0,
+          cancelled: false,
+        };
+        status.finishOk(report);
+        return Promise.resolve(report);
+      },
+    });
+
+    handle.trigger("manual");
+    const event = await onceSync(events);
+    expect(runnerCalls).toEqual([config.dbPath]);
+    expect(event.report.ingested).toBe(2);
+    expect(event.status.last_report).toContain("ingested 2");
+    await handle.stop();
+  });
+
   test("periodic sweep is enough to ingest when native watch is disabled", async () => {
     const config = freshConfig();
     seedClaude(config);


### PR DESCRIPTION
# Sub-100ms pages for `decant serve`

Profiled against a real 2.6GB archive (2.9k sessions / 347k messages / 322k blocks), every page waited on a 17-endpoint fetch gated by `/api/analytics/token-economics` (~2.7s), session detail pages with many subagents took 15–17s, and watcher ingests froze all routes for seconds. This PR takes every page to well under 100ms in steady use.

## Measured impact (real 2.6GB archive, warm)

| Surface | Before | After |
|---|---|---|
| Session detail with 97 subagents | 15.8–17.3 s | 8–19 ms |
| `/api/analytics/token-economics` | ~2,700 ms | ~1 ms |
| First paint of any page | ~3.5 s | 30–81 ms |
| Sessions list incl. subagent trees | ~600 ms | ~58 ms |
| Page revisits | full refetch | 0 fetches |
| `/api/health` during a watcher sync | 3–6 s stalls | ~1 ms |

## Root causes and fixes

1. **Title derivation scanned the whole archive per call, once per subagent (N+1).**
   Without ANALYZE stats, SQLite starts the title query from every text block in the archive; session detail repeated it per subagent. Now: pinned join order (`CROSS JOIN` + `INDEXED BY`), an early-exit correlated first-candidate pass with a conservative SQL twin of the agent-context filter (`AGENT_CONTEXT_SQL` skips a strict subset of what `isAgentContextText` skips; the JS filter stays authoritative via the exact pass-2 fallback), and one batched summary + title query for a session's whole subagent tree.

2. **Token economics re-read all 322k blocks' full text on every request.**
   The bucket math now compiles into per-session vectors — `computeSessionEconomicsVectors` + `aggregateEconomicsVectors` reproduce `tokenEconomics()` exactly (equivalence + golden tests) — computed in a worker thread (`stats-worker.ts`) at boot and after syncs, cached in `EconomicsCache`, and served from memory for any date filter. Staleness is detected via `PRAGMA data_version` (stale-while-revalidate; `archive_updated` SSE nudges clients when the model refreshes).

3. **Watcher syncs ran ingest synchronously on the serve event loop.**
   `serve()` now owns the watcher with a worker-backed runner (`startWatch` gained an injectable `runner`), republishes watcher events over SSE (`sync`, `archive_updated`, `ready`, `stopped` — previously only manual syncs published), keeps `/api/sync-status` accurate for auto-syncs, and invalidates the economics cache when ingests land. Shutdown stays prompt: a cancel poll terminates an in-flight sync worker with the same `cancelled: true` report shape as the in-process runner.

4. **The React app fetched all 17 endpoints for every page.**
   Pages now load only their slices (`SLICE_LOADERS`/`ROUTE_SLICES`), cached per (date filter, reload generation). Revisits fetch nothing; SSE refreshes refetch only the active view. Dropped the dead `byTool` fetch; sessions page loads 50 rows into the existing infinite scroll.

5. **Foundation:** `mmap_size` on the DB (2–7× on large scans; FTS search of a common term 177→24ms), `PRAGMA optimize` after ingest write bursts, and tool usage skips its session join when no date filter applies.

## Post-review fixes

A workflow-backed code review (multiple finder agents + independent verifiers) caught several real bugs before hitting a rate limit mid-verification; the confirmed ones are fixed in the second commit, each backed by an empirical repro and a permanent regression test:

- **`decant serve` hung indefinitely on Ctrl-C whenever a browser tab had the dashboard open.** Bun's native `server.stop()` never resolves while an SSE connection is open unless connections are forced closed. Separately, an in-flight economics-cache rebuild blocked shutdown for the rest of its multi-second archive scan, because the cache was only told to abort *after* awaiting native `stop()` — by which point the very thing blocking `stop()` had no way to be cancelled. Fixed by threading an `AbortSignal` into the rebuild so `dispose()` can cancel an in-flight worker immediately, and disposing the cache *before* awaiting a forced native stop. Reproduced and verified against the real 2.6GB archive: 7.4s → 129ms (rebuild in flight) and indefinite → 84ms (SSE open).
- **Every watcher event was published to SSE twice** (`sync`, `archive_updated`, `ready`, `stopped` each arrived twice per occurrence) — `server.ts`'s own publisher and the CLI's forwarded callback both called `publishServerEvent`. Fixed by making the CLI callback terminal-output-only.
- **An ingest landing mid-rebuild could leave token-economics stale indefinitely** — `invalidate()` during an in-flight rebuild silently coalesced onto it with no follow-up scheduled. Fixed with a pending-rebuild flag that triggers an immediate follow-up once the in-flight build settles.
- **The sidebar's "latest activity" stat regressed**: unformatted, archive-wide, and no longer respecting the active date filter that the adjacent session/cost stats still honor. Restored.
- **`decant serve --trusted-peer` silently dropped the flag** (only `watch` declared the option; pre-existing on `main`) and, once declared, would have permanently masked `DECANT_TRUSTED_PEERS` by always passing an explicit array. Fixed opportunistically since serve's option handling was already being touched.

## Verification

- `bun test` (244), `bunx tsc --noEmit`, `bunx biome check .` all green; goldens unchanged.
- New tests: subagent-tree characterization + depth cap, vectors/filter equivalence, economics-cache staleness/invalidation-during-rebuild/dispose-aborts-worker, cache-backed route, injectable watch runner, and a `serve()`-level integration test proving `stop()` resolves promptly while a request awaits an in-flight rebuild (fails at 2s without the fix, passes in ~80ms with it).
- Benched end-to-end on a served clone of the real archive during an active background ingest and at steady state; browser-verified all nine pages render with real data via Playwright; both shutdown-hang fixes verified with subprocess-level repros sending real `SIGINT` against the real binary.

## Known trade-offs

- First touch of a page's data after a server boot pays one-time disk I/O (e.g. Tools ~500ms once, then ~50ms). Steady-state holds the <100ms target.
- FTS search of very common terms is ~25–40ms warm but can reach ~300ms cold after large ingests.
- The dev-mode bundle is 5.4MB unminified (~300ms first browser load, then cached); compiled builds serve minified. Code-splitting ECharts is a possible follow-up.
- Manual/watcher sync pays ~3s of fixed Worker startup overhead per invocation (spinning up a fresh thread and loading `ingest.ts`'s module graph each time), independent of how much work there is to do — noticed while verifying the SSE fix, not something this PR changes. Worth a follow-up (e.g. a persistent worker) if manual sync latency matters.
