### PR TITLE
feat(tokens): split economics into orientation/implementation phases

### DIFF
--- a/src/buckets.ts
+++ b/src/buckets.ts
@@ -64,6 +64,13 @@ export function toolBucket(
   return "context";
 }
 
+/** True for tools that mutate a file on disk (the phase boundary marker):
+ * the first such tool_use flips a session from orientation to implementation.
+ * Excludes shell writes -- only explicit edit/patch/write tools count. */
+export function isCodeEditTool(toolName: string | null | undefined): boolean {
+  return CODE_TOOLS.has(localToolName(toolName ?? "").toLowerCase());
+}
+
 export function blockBucket(
   blockType: string | null,
   toolName?: string | null,

--- a/src/token-economics.ts
+++ b/src/token-economics.ts
@@ -1,10 +1,28 @@
 import type { Database } from "bun:sqlite";
-import { ACTIVITY_BUCKETS, type ActivityBucket, blockBucket, toolBucket } from "./buckets.ts";
+import {
+  ACTIVITY_BUCKETS,
+  type ActivityBucket,
+  blockBucket,
+  isCodeEditTool,
+  toolBucket,
+} from "./buckets.ts";
 import { defaultPricing, estimateCostParts } from "./cost.ts";
 import { type DateFilter, sessionDatePredicate, whereClause } from "./date-filter.ts";
 
 const CHARS_PER_TOKEN = 4;
 const encoder = new TextEncoder();
+
+/** A run splits into two phases at the first file edit: "orientation" (reading
+ * and planning HOW to change the code) and "implementation" (writing it). The
+ * phase breakdown is orthogonal to the activity buckets -- every bucket carries
+ * how much of it happened before vs after the first edit. */
+export type Phase = "orientation" | "implementation";
+
+export interface PhaseAmounts {
+  generation_tokens: number;
+  context_window_tokens: number;
+  estimated_cost_usd: number;
+}
 
 export interface TokenEconomicsBucket {
   bucket: ActivityBucket;
@@ -14,6 +32,10 @@ export interface TokenEconomicsBucket {
   tool_calls: number;
   sessions: number;
   cost_share: number;
+  // Present only from the ordered whole-archive path (`tokens`), which can place
+  // each contribution before/after the first edit. Absent from the fast
+  // per-session path, which distributes by aggregate weights and has no order.
+  phases?: Record<Phase, PhaseAmounts>;
 }
 
 export interface TokenEconomics {
@@ -24,6 +46,7 @@ export interface TokenEconomics {
     estimated_cost_usd: number;
     input_cost_usd: number;
     output_cost_usd: number;
+    phases?: Record<Phase, PhaseAmounts>;
   };
 }
 
@@ -49,6 +72,7 @@ interface FastToolRow {
 interface BlockRow {
   session_id: number;
   message_id: number;
+  seq: number;
   role: string | null;
   output_tokens: number | null;
   type: string | null;
@@ -63,6 +87,7 @@ interface ResultRow {
   input: string | null;
   tool_result: string | null;
   output_bytes: number | null;
+  call_seq: number | null;
 }
 
 interface MutableBucket {
@@ -71,6 +96,12 @@ interface MutableBucket {
   cost: number;
   toolCalls: number;
   sessions: Set<number>;
+  // Orientation-phase portions (pre-first-edit). Implementation = total - these.
+  // genOrientation feeds windowOrientation the same way generation feeds
+  // contextWindow, so the phase cost split mirrors the whole-bucket formula.
+  genOrientation: number;
+  windowOrientation: number;
+  costOrientation: number;
 }
 
 type QueryParam = string | number;
@@ -109,13 +140,13 @@ function tokenEconomicsForScope(
   const buckets = emptyBuckets();
 
   if (sessionIds.length === 0) {
-    return finish(buckets, 0, 0);
+    return finish(buckets, 0, 0, true);
   }
 
   const blocks = db
     .query(
       `${scopeCte}
-       SELECT b.session_id, m.id AS message_id, m.role, m.output_tokens, b.type,
+       SELECT b.session_id, m.id AS message_id, m.seq AS seq, m.role, m.output_tokens, b.type,
               b.text, b.tool_name, b.tool_input
        FROM block b
        JOIN message m ON m.id = b.message_id
@@ -123,15 +154,19 @@ function tokenEconomicsForScope(
        ORDER BY b.session_id, m.seq, b.ordinal`,
     )
     .all(...params) as BlockRow[];
-  allocateGeneration(sessions, blocks, buckets);
+  const boundaries = firstEditSeqBySession(blocks);
+  allocateGeneration(sessions, blocks, buckets, boundaries);
 
   const results = db
     .query(
       `${scopeCte}
-       SELECT t.session_id, t.tool_name, t.input, rb.tool_result, t.output_bytes
+       SELECT t.session_id, t.tool_name, t.input, rb.tool_result, t.output_bytes,
+              cm.seq AS call_seq
        FROM tool_call t
        JOIN scoped_session fs ON fs.id = t.session_id
-       LEFT JOIN block rb ON rb.id = t.result_block_id`,
+       LEFT JOIN block rb ON rb.id = t.result_block_id
+       LEFT JOIN block cb ON cb.id = t.call_block_id
+       LEFT JOIN message cm ON cm.id = cb.message_id`,
     )
     .all(...params) as ResultRow[];
   for (const row of results) {
@@ -141,9 +176,16 @@ function tokenEconomicsForScope(
     if (entry == null) {
       continue;
     }
-    entry.contextWindow += size / CHARS_PER_TOKEN;
+    const tokens = size / CHARS_PER_TOKEN;
+    entry.contextWindow += tokens;
     entry.toolCalls += 1;
     entry.sessions.add(row.session_id);
+    // A tool result belongs to orientation if its call happened before the
+    // session's first edit. Unplaceable calls (no call block) default to
+    // implementation so orientation is never overstated.
+    if (phaseOf(boundaries, row.session_id, row.call_seq) === "orientation") {
+      entry.windowOrientation += tokens;
+    }
   }
 
   let inputCost = 0;
@@ -167,15 +209,22 @@ function tokenEconomicsForScope(
   const totalGeneration = sumBuckets(buckets, "generation");
   const totalWindow = sumBuckets(buckets, "contextWindow");
   for (const entry of buckets.values()) {
+    // Generation is part of the window; mirror it into the orientation portion
+    // so the phase cost split uses the same window basis as the whole bucket.
     entry.contextWindow += entry.generation;
+    entry.windowOrientation += entry.genOrientation;
   }
   const totalWindowWithGeneration = sumBuckets(buckets, "contextWindow");
+  const windowBasis = totalWindowWithGeneration || totalWindow;
   for (const entry of buckets.values()) {
     entry.cost =
       outputCost * share(entry.generation, totalGeneration) +
-      inputCost * share(entry.contextWindow, totalWindowWithGeneration || totalWindow);
+      inputCost * share(entry.contextWindow, windowBasis);
+    entry.costOrientation =
+      outputCost * share(entry.genOrientation, totalGeneration) +
+      inputCost * share(entry.windowOrientation, windowBasis);
   }
-  return finish(buckets, inputCost, outputCost);
+  return finish(buckets, inputCost, outputCost, true);
 }
 
 function fastTokenEconomicsForSession(db: Database, sessionId: number): TokenEconomics | null {
@@ -361,10 +410,41 @@ function sumWeights(weights: Map<ActivityBucket, number>): number {
   return total;
 }
 
+/** First-edit boundary per session: the message seq of the first file-editing
+ * tool_use. Messages with seq < boundary are orientation; the edit's own
+ * message and everything after are implementation. Sessions that never edit
+ * have no boundary (Infinity) -> the whole run is orientation. */
+function firstEditSeqBySession(blocks: BlockRow[]): Map<number, number> {
+  const boundary = new Map<number, number>();
+  for (const block of blocks) {
+    if (block.type !== "tool_use" || !isCodeEditTool(block.tool_name)) {
+      continue;
+    }
+    const current = boundary.get(block.session_id);
+    if (current == null || block.seq < current) {
+      boundary.set(block.session_id, block.seq);
+    }
+  }
+  return boundary;
+}
+
+function phaseOf(
+  boundaries: Map<number, number>,
+  sessionId: number,
+  seq: number | null | undefined,
+): Phase {
+  if (seq == null) {
+    return "implementation";
+  }
+  const boundary = boundaries.get(sessionId) ?? Number.POSITIVE_INFINITY;
+  return seq < boundary ? "orientation" : "implementation";
+}
+
 function allocateGeneration(
   sessions: SessionRow[],
   blocks: BlockRow[],
   buckets: Map<ActivityBucket, MutableBucket>,
+  boundaries: Map<number, number>,
 ): void {
   const blocksBySession = groupBy(blocks, (block) => block.session_id);
   for (const session of sessions) {
@@ -378,7 +458,9 @@ function allocateGeneration(
     }
     if (messageOutput.size > 0) {
       for (const [messageId, outputTokens] of messageOutput) {
-        allocateOutput(session.id, outputTokens, messageBlocks.get(messageId) ?? [], buckets);
+        const rows = messageBlocks.get(messageId) ?? [];
+        const phase = phaseOf(boundaries, session.id, rows[0]?.seq);
+        allocateOutput(session.id, outputTokens, rows, buckets, phase);
       }
       continue;
     }
@@ -386,15 +468,36 @@ function allocateGeneration(
       session.total_output_tokens,
       session.total_reasoning_tokens || session.est_reasoning_tokens,
     );
-    addBucket(buckets, "planning", planning, session.id);
     const assistantBlocks = sessionBlocks.filter(
       (block) => block.role === "assistant" && block.type !== "thinking",
+    );
+    // No per-message usage: split the aggregate planning lump between phases by
+    // the size-weight of assistant blocks on each side of the boundary.
+    const orientationWeight = assistantBlocks
+      .filter((block) => phaseOf(boundaries, session.id, block.seq) === "orientation")
+      .reduce((sum, block) => sum + Math.max(1, blockSize(block)), 0);
+    const totalWeight =
+      assistantBlocks.reduce((sum, block) => sum + Math.max(1, blockSize(block)), 0) || 1;
+    addBucket(
+      buckets,
+      "planning",
+      planning * (orientationWeight / totalWeight),
+      session.id,
+      "orientation",
+    );
+    addBucket(
+      buckets,
+      "planning",
+      planning * (1 - orientationWeight / totalWeight),
+      session.id,
+      "implementation",
     );
     distribute(
       session.id,
       Math.max(0, session.total_output_tokens - planning),
       assistantBlocks,
       buckets,
+      boundaries,
     );
   }
 }
@@ -404,26 +507,55 @@ function allocateOutput(
   outputTokens: number,
   blocks: BlockRow[],
   buckets: Map<ActivityBucket, MutableBucket>,
+  phase: Phase,
 ): void {
   const hasThinking = blocks.some((block) => block.type === "thinking");
   const visible = blocks
     .filter((block) => block.type !== "thinking")
     .reduce((sum, block) => sum + blockSize(block), 0);
   const planning = hasThinking ? Math.max(0, outputTokens - visible / CHARS_PER_TOKEN) : 0;
-  addBucket(buckets, "planning", planning, sessionId);
-  distribute(
+  addBucket(buckets, "planning", planning, sessionId, phase);
+  distributeVisible(
     sessionId,
     Math.max(0, outputTokens - planning),
     blocks.filter((block) => block.type !== "thinking"),
     buckets,
+    phase,
   );
 }
 
+/** Distribute across blocks that all share one phase (used per-message). */
+function distributeVisible(
+  sessionId: number,
+  tokens: number,
+  blocks: BlockRow[],
+  buckets: Map<ActivityBucket, MutableBucket>,
+  phase: Phase,
+): void {
+  if (tokens <= 0 || blocks.length === 0) {
+    return;
+  }
+  const weighted = blocks.map((block) => ({ block, weight: Math.max(1, blockSize(block)) }));
+  const totalWeight = weighted.reduce((sum, item) => sum + item.weight, 0);
+  for (const item of weighted) {
+    addBucket(
+      buckets,
+      blockBucket(item.block.type, item.block.tool_name, item.block.tool_input),
+      tokens * (item.weight / totalWeight),
+      sessionId,
+      phase,
+    );
+  }
+}
+
+/** Distribute across blocks that may straddle the boundary (fallback branch);
+ * each block's phase is decided by its own seq. */
 function distribute(
   sessionId: number,
   tokens: number,
   blocks: BlockRow[],
   buckets: Map<ActivityBucket, MutableBucket>,
+  boundaries: Map<number, number>,
 ): void {
   if (tokens <= 0 || blocks.length === 0) {
     return;
@@ -439,6 +571,7 @@ function distribute(
       blockBucket(item.block.type, item.block.tool_name, item.block.tool_input),
       tokens * (item.weight / totalWeight),
       sessionId,
+      phaseOf(boundaries, sessionId, item.block.seq),
     );
   }
 }
@@ -455,12 +588,16 @@ function addBucket(
   bucket: ActivityBucket,
   tokens: number,
   sessionId: number,
+  phase?: Phase,
 ): void {
   const entry = buckets.get(bucket);
   if (entry == null || tokens <= 0) {
     return;
   }
   entry.generation += tokens;
+  if (phase === "orientation") {
+    entry.genOrientation += tokens;
+  }
   entry.sessions.add(sessionId);
 }
 
@@ -468,20 +605,51 @@ function emptyBuckets(): Map<ActivityBucket, MutableBucket> {
   return new Map(
     ACTIVITY_BUCKETS.map((bucket) => [
       bucket,
-      { generation: 0, contextWindow: 0, cost: 0, toolCalls: 0, sessions: new Set<number>() },
+      {
+        generation: 0,
+        contextWindow: 0,
+        cost: 0,
+        toolCalls: 0,
+        sessions: new Set<number>(),
+        genOrientation: 0,
+        windowOrientation: 0,
+        costOrientation: 0,
+      },
     ]),
   );
+}
+
+function phasesFor(entry: MutableBucket | undefined): Record<Phase, PhaseAmounts> {
+  const gen = entry?.generation ?? 0;
+  const win = entry?.contextWindow ?? 0;
+  const cost = entry?.cost ?? 0;
+  const genO = entry?.genOrientation ?? 0;
+  const winO = entry?.windowOrientation ?? 0;
+  const costO = entry?.costOrientation ?? 0;
+  return {
+    orientation: {
+      generation_tokens: Math.round(genO),
+      context_window_tokens: Math.round(winO),
+      estimated_cost_usd: costO,
+    },
+    implementation: {
+      generation_tokens: Math.round(gen - genO),
+      context_window_tokens: Math.round(win - winO),
+      estimated_cost_usd: cost - costO,
+    },
+  };
 }
 
 function finish(
   buckets: Map<ActivityBucket, MutableBucket>,
   inputCost: number,
   outputCost: number,
+  withPhases = false,
 ): TokenEconomics {
   const totalCost = sumBuckets(buckets, "cost");
-  const rows = ACTIVITY_BUCKETS.map((bucket) => {
+  const rows: TokenEconomicsBucket[] = ACTIVITY_BUCKETS.map((bucket) => {
     const entry = buckets.get(bucket);
-    return {
+    const row: TokenEconomicsBucket = {
       bucket,
       generation_tokens: Math.round(entry?.generation ?? 0),
       context_window_tokens: Math.round(entry?.contextWindow ?? 0),
@@ -490,17 +658,43 @@ function finish(
       sessions: entry?.sessions.size ?? 0,
       cost_share: share(entry?.cost ?? 0, totalCost),
     };
+    if (withPhases) {
+      row.phases = phasesFor(entry);
+    }
+    return row;
   });
-  return {
-    buckets: rows,
-    totals: {
-      generation_tokens: rows.reduce((sum, row) => sum + row.generation_tokens, 0),
-      context_window_tokens: rows.reduce((sum, row) => sum + row.context_window_tokens, 0),
-      estimated_cost_usd: totalCost,
-      input_cost_usd: inputCost,
-      output_cost_usd: outputCost,
-    },
+  const totals: TokenEconomics["totals"] = {
+    generation_tokens: rows.reduce((sum, row) => sum + row.generation_tokens, 0),
+    context_window_tokens: rows.reduce((sum, row) => sum + row.context_window_tokens, 0),
+    estimated_cost_usd: totalCost,
+    input_cost_usd: inputCost,
+    output_cost_usd: outputCost,
   };
+  if (withPhases) {
+    totals.phases = {
+      orientation: sumPhase(rows, "orientation"),
+      implementation: sumPhase(rows, "implementation"),
+    };
+  }
+  return { buckets: rows, totals };
+}
+
+function sumPhase(rows: TokenEconomicsBucket[], phase: Phase): PhaseAmounts {
+  const acc: PhaseAmounts = {
+    generation_tokens: 0,
+    context_window_tokens: 0,
+    estimated_cost_usd: 0,
+  };
+  for (const row of rows) {
+    const p = row.phases?.[phase];
+    if (p == null) {
+      continue;
+    }
+    acc.generation_tokens += p.generation_tokens;
+    acc.context_window_tokens += p.context_window_tokens;
+    acc.estimated_cost_usd += p.estimated_cost_usd;
+  }
+  return acc;
 }
 
 function sumBuckets(

--- a/test/token-economics.test.ts
+++ b/test/token-economics.test.ts
@@ -65,6 +65,52 @@ describe("token economics", () => {
     db.close();
   });
 
+  test("splits each bucket into orientation/implementation phases that sum to the whole", () => {
+    const db = freshDb();
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("sess-enr-claude", fixture("claude", "enriched.jsonl")),
+      "/x/claude.jsonl",
+      1,
+      2,
+      "claude",
+    );
+
+    const economics = tokenEconomics(db);
+    // Every bucket carries a phase split whose parts sum back to the bucket total.
+    for (const row of economics.buckets) {
+      expect(row.phases).toBeDefined();
+      const { orientation, implementation } = row.phases as NonNullable<typeof row.phases>;
+      expect(orientation.generation_tokens + implementation.generation_tokens).toBe(
+        row.generation_tokens,
+      );
+      expect(orientation.context_window_tokens + implementation.context_window_tokens).toBe(
+        row.context_window_tokens,
+      );
+      expect(orientation.estimated_cost_usd + implementation.estimated_cost_usd).toBeCloseTo(
+        row.estimated_cost_usd,
+        12,
+      );
+      expect(orientation.estimated_cost_usd).toBeGreaterThanOrEqual(0);
+      expect(implementation.estimated_cost_usd).toBeGreaterThanOrEqual(0);
+    }
+    // Totals phase split sums to the run total.
+    const phases = economics.totals.phases as NonNullable<typeof economics.totals.phases>;
+    expect(phases).toBeDefined();
+    expect(
+      phases.orientation.estimated_cost_usd + phases.implementation.estimated_cost_usd,
+    ).toBeCloseTo(economics.totals.estimated_cost_usd, 12);
+    // The fixture reads before it edits, so some context is gathered in orientation.
+    const context = economics.buckets.find((row) => row.bucket === "context");
+    expect(context?.phases?.orientation.context_window_tokens).toBeGreaterThan(0);
+
+    // The fast per-session path cannot order turns, so it omits the phase split.
+    const scoped = tokenEconomicsForSession(db, sessionId);
+    expect(scoped?.buckets.every((row) => row.phases === undefined)).toBe(true);
+    expect(scoped?.totals.phases).toBeUndefined();
+    db.close();
+  });
+
   test("classifies Codex patch edits as code and read-only shell as context", () => {
     const db = freshDb();
     const sessionId = upsertSession(


### PR DESCRIPTION
## What

Adds an **orientation vs. implementation** phase split to token economics, orthogonal to the existing activity buckets (planning / communicating / context / code). Every bucket — and the totals — now report how much happened *before* vs *after* the session's first file edit, as `phases: { orientation, implementation }`.

- "orientation" = reading the codebase and planning *how* to change it (pre-first-edit)
- "implementation" = actually writing the change (first-edit onward)

## Why

To measure how much of a run is spent *understanding the codebase* — the surface a knowledge base can offload — vs. actually implementing. In our PR-replay study this is ~half of all spend, but it was previously buried across the planning and context buckets.

## How

- `isCodeEditTool()` (buckets.ts) marks the phase boundary: the first `edit`/`write`/`multiedit`/`notebookedit`/`apply_patch` tool_use. Shell writes do **not** count.
- The ordered whole-archive path (`tokens`) tags every generation, context-window, and cost contribution by phase. Parts sum **exactly** back to each bucket total (generation, window, and cost).
- The fast per-session path has no turn ordering and so **omits** `phases` (field is optional).
- Focused test asserts the phase invariant (orientation + implementation == bucket total) and the fast-path omission.

## Validation

- `bun test` (233 pass), `tsc --noEmit`, `biome check .` all green.
- Applied against a 120-run PR-replay archive: total cost unchanged to the cent (purely additive), 0 boundary-detection misses on codex, edit-free research runs correctly resolve to 100% orientation.

Draft: opening for review of the approach before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)