### PR TITLE
docs: trim derivable content from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,25 +18,9 @@ The pre-cutover tree is preserved in the signed `pre-typescript` tag.
 
 ## Layout
 
-| Path | Responsibility |
-|---|---|
-| `src/cli.ts` | Commander CLI entrypoint and all stdout/stderr/exit-code policy. |
-| `src/db.ts`, `src/schema.sql` | SQLite opener and frozen v9 baseline schema. |
-| `src/sources/` | Per-tool parsers: `claude.ts`, `codex.ts`. |
-| `src/ingest.ts` | Idempotent sync from source logs into the archive. |
-| `src/query.ts`, `src/stats.ts`, `src/export.ts` | Read/query/render surfaces. |
-| `src/distill.ts`, `src/recommendations.ts` | Deterministic artifact and recommendation generation. |
-| `src/watch.ts`, `src/server.ts` | Watch loop, local JSON routes, SSE, and UI serving. |
-| `src/economics-cache.ts`, `src/stats-worker.ts` | Precomputed token-economics vectors served from memory; heavy scans run in a worker thread off the request loop. |
-| `src/ui/` | React UI bundled by Bun HTML imports. |
-| `src/settings.ts`, `src/launcher.ts` | Local settings and native launcher helpers. |
-| `fixtures/` | Tiny synthetic Claude/Codex session files. |
-| `test/golden/` | Static golden snapshots frozen from the pre-TypeScript implementation. |
-| `npm/` | Publishable npm launcher package plus platform binary package manifests. |
-| `scripts/` | Distribution build/staging helpers. |
-| `docs/api/routes.md` | Local `decant serve` route reference. |
-| `docs/distribution.md` | npm, Docker, and source distribution notes. |
-| `docs/superpowers/` | Historical specs and implementation plans. |
+Start from `src/cli.ts`; parsers live in `src/sources/` (the extension
+point). Docs: `docs/api/routes.md` (serve routes) and `docs/distribution.md`
+(npm/Docker/source).
 
 ## Setup
 
@@ -48,37 +32,14 @@ The pre-cutover tree is preserved in the signed `pre-typescript` tag.
 
 Run from the repo root.
 
-```sh
-# One-command local UI + startup sync
-bun run dev
+- `bun run dev` — one-command local UI + startup sync.
+- `just check` — the full local quality gate (see Definition of done).
+- `bun run src/cli.ts --help` — the `decant` CLI: `sync`, `ls`, `search`,
+  `stats`, `files`, `distill`, `recommendations`, `watch`, `serve`; add
+  `--db` to target an alternate archive. `just` lists wrapper recipes for
+  the common ones.
 
-# Quality gates
-bun test
-bunx tsc --noEmit
-bunx biome check .
-just check
-
-# CLI
-bun run src/cli.ts sync
-bun run src/cli.ts ls
-bun run src/cli.ts search "auth bug"
-bun run src/cli.ts stats --by model
-bun run src/cli.ts files --group ext
-bun run src/cli.ts distill script
-bun run src/cli.ts recommendations ls
-bun run src/cli.ts --db /tmp/decant.db ls
-
-# Long-running local modes
-bun run src/cli.ts watch
-bun run src/cli.ts serve
-
-# Distribution
-bun run scripts/build-binaries.ts --target native
-bun run scripts/build-npm.ts --target native --no-build
-docker build --platform linux/amd64 -t decant:local .
-```
-
-Config:
+## Config
 
 - Archive DB: `~/.decant/decant.db`, override with `DECANT_DB` or `--db`.
 - Source dirs: `DECANT_CLAUDE_DIR`, `DECANT_CODEX_DIR`, or command flags.
@@ -93,6 +54,9 @@ A change is ready when:
 - `bun test` passes.
 - `bunx tsc --noEmit` passes.
 - `bunx biome check .` passes.
+- `just check` wraps all three plus the distribution staging smoke; CI
+  additionally builds the binary matrix, npm staging, and Docker images on
+  every push, not only for distribution changes.
 - New behavior has focused tests. Do not weaken or delete tests to make them pass.
 - Distribution changes also get a native binary smoke test and, when Docker is
   touched, a local `docker build`/`docker run --help` smoke if Docker is available.


### PR DESCRIPTION
## What

Trims `AGENTS.md` (and via symlink `CLAUDE.md`) to the guidance a session can't derive from the repo itself: +14/−50 lines, 6,337 → 4,989 chars (~340 est. tokens off every agent session's always-loaded context).

- **Layout table removed** — the 17 path/responsibility rows are reconstructable from `ls`/file headers, and the load-bearing facts (schema v9, print-free cores, parser extension point) are restated in Project invariants. A short pointer paragraph keeps the entry point and tracked docs.
- **Commands fence replaced with a compact canonical list** — the 26-line example block duplicated `package.json` scripts, the `justfile`, and `--help` output. A 3-bullet list still names every CLI subcommand, so the README/CONTRIBUTING "canonical command reference" pointers stay true.
- **`docs/superpowers/` pointer dropped** — that directory is local-only (`.git/info/exclude`), so the committed file was pointing clones at a path that doesn't exist for them.
- **New Definition-of-done bullet** — documents that `just check` wraps the three gates plus the dist staging smoke, and that CI builds the binary matrix, npm staging, and Docker images on every push, not only for distribution changes.

## Review notes

A max-effort adversarial review ran on the draft trim; 4 findings confirmed, 1 refuted. Resolutions:

1. **README.md:155 / CONTRIBUTING.md defer to AGENTS.md for the full command list** — fixed by restoring the compact Commands section (every subcommand named).
2. **`feat/cursor-source` edits the removed regions** — see heads-up below; not resolvable from this branch.
3. **`just check` / CI coverage was lost** — fixed by the new Definition-of-done bullet.
4. **Dogfooding tension**: decant's own recommendation engine (`src/recommendations.ts`) advises adding a code map to AGENTS.md, which this PR removes. Left as a deliberate tradeoff for review — restoring a compact map is a ~5-line follow-up if we'd rather practice what we ship.

## Heads-up: conflicts with `feat/cursor-source`

That branch amends the deleted Layout rows and Commands fence. When rebasing it onto this: the `cursor.ts` parser and Cursor-fixtures rows are subsumed by the Layout prose ("parsers live in `src/sources/`"); keep the branch's `DECANT_CURSOR_DIR`/`DECANT_CURSOR_CHATS_DIR` additions to the Config bullet (that hunk merges clean); drop or re-home its Commands-fence comment onto the new bullet list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
