### PR TITLE
feat: dosu.dev UX refresh — Analytics home, grouped sidebar, Warp handoff

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -178,7 +178,12 @@ function launchWarp(
 
 function warpConfigYaml(cmd: string, env: Record<string, string | undefined> | undefined): string {
   // Same working-dir chain as launchAgent; Warp requires an absolute cwd.
-  const cwd = env?.DECANT_SKILLS_DIR ?? process.env.DECANT_SKILLS_DIR ?? homelikeDir();
+  const cwd =
+    env?.DECANT_SKILLS_DIR ??
+    process.env.DECANT_SKILLS_DIR ??
+    env?.HOME ??
+    process.env.HOME ??
+    process.cwd();
   // JSON.stringify produces valid YAML double-quoted scalars, so the shell
   // command's quoting survives YAML parsing untouched.
   return `---

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentKey, IdeKey, TerminalKey, UserSettings } from "./settings.ts";
@@ -103,6 +103,8 @@ function launchIn(
       return openArgs("kitty", [shell(env), "-lc", cmd], run);
     case "wezterm":
       return openArgs("WezTerm", ["start", "--", shell(env), "-lc", cmd], run);
+    case "warp":
+      return launchWarp(cmd, run, env);
     default:
       return run("osascript", ["-e", terminalAppScript(cmd)]);
   }
@@ -147,6 +149,48 @@ function itermScript(cmd: string): string {
   set w to (create window with default profile)
   tell current session of w to write text ${applescriptString(cmd)}
 end tell`;
+}
+
+// Warp has no AppleScript/exec API; the only scriptable entry point that runs
+// a command is a Launch Configuration opened by file stem, and the file must
+// live inside launch_configurations (absolute paths elsewhere do not resolve).
+function launchWarp(
+  cmd: string,
+  run: (bin: string, args: string[]) => LaunchResult,
+  env: Record<string, string | undefined> | undefined,
+): LaunchResult {
+  const home = env?.HOME ?? process.env.HOME;
+  if (home == null || home === "") {
+    return {
+      ok: false,
+      error: "Could not find a home directory for Warp launch configurations.",
+    };
+  }
+  const dir = join(home, ".warp", "launch_configurations");
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "decant-handoff.yaml"), warpConfigYaml(cmd, env));
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+  return run("open", ["warp://launch/decant-handoff"]);
+}
+
+function warpConfigYaml(cmd: string, env: Record<string, string | undefined> | undefined): string {
+  // Same working-dir chain as launchAgent; Warp requires an absolute cwd.
+  const cwd = env?.DECANT_SKILLS_DIR ?? process.env.DECANT_SKILLS_DIR ?? homelikeDir();
+  // JSON.stringify produces valid YAML double-quoted scalars, so the shell
+  // command's quoting survives YAML parsing untouched.
+  return `---
+name: decant-handoff
+windows:
+  - tabs:
+      - title: decant
+        layout:
+          cwd: ${JSON.stringify(cwd)}
+          commands:
+            - exec: ${JSON.stringify(cmd)}
+`;
 }
 
 function shell(env: Record<string, string | undefined> | undefined): string {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,7 +3,14 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
 export type AgentKey = "claude" | "codex";
-export type TerminalKey = "terminal" | "iterm" | "ghostty" | "wezterm" | "kitty" | "alacritty";
+export type TerminalKey =
+  | "terminal"
+  | "iterm"
+  | "warp"
+  | "ghostty"
+  | "wezterm"
+  | "kitty"
+  | "alacritty";
 export type IdeKey = "vscode" | "cursor" | "zed" | "sublime" | "intellij";
 
 export interface UserSettings {
@@ -22,6 +29,7 @@ const validAgents = new Set<AgentKey>(["claude", "codex"]);
 const validTerminals = new Set<TerminalKey>([
   "terminal",
   "iterm",
+  "warp",
   "ghostty",
   "wezterm",
   "kitty",
@@ -37,6 +45,7 @@ export const agentOptions: [AgentKey, string][] = [
 export const terminalOptions: [TerminalKey, string][] = [
   ["terminal", "Terminal"],
   ["iterm", "iTerm"],
+  ["warp", "Warp"],
   ["ghostty", "Ghostty"],
   ["wezterm", "WezTerm"],
   ["kitty", "kitty"],
@@ -117,6 +126,8 @@ function detectTerminal(env: Record<string, string | undefined>): TerminalKey {
   switch (env.TERM_PROGRAM) {
     case "iTerm.app":
       return "iterm";
+    case "WarpTerminal":
+      return "warp";
     case "ghostty":
       return "ghostty";
     case "WezTerm":

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -51,7 +51,7 @@ import {
 import { createPortal } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { planSessionLoad, shouldShowSessionSkeleton } from "./loading-state.ts";
-import { activeRoute, activeRouteKey, navItems, pathOnly, titleFor } from "./routes.ts";
+import { activeRoute, activeRouteKey, navSections, pathOnly, titleFor } from "./routes.ts";
 import "./styles.css";
 
 type Summary = {
@@ -631,19 +631,26 @@ function App() {
           </button>
         </div>
         <nav aria-label="Primary">
-          {navItems.map((item) => (
-            <a
-              aria-current={activeKey === item.key ? "page" : undefined}
-              href={item.href}
-              key={item.href}
-              onClick={(event) => {
-                setMenuOpen(false);
-                navigate(event, item.href, setPath);
-              }}
-            >
-              <Icon name={item.icon} />
-              <span>{item.label}</span>
-            </a>
+          {navSections.map((section) => (
+            <div className="nav-section" key={section.label ?? "overview"}>
+              {section.label != null ? (
+                <div className="nav-section-label">{section.label}</div>
+              ) : null}
+              {section.items.map((item) => (
+                <a
+                  aria-current={activeKey === item.key ? "page" : undefined}
+                  href={item.href}
+                  key={item.href}
+                  onClick={(event) => {
+                    setMenuOpen(false);
+                    navigate(event, item.href, setPath);
+                  }}
+                >
+                  <Icon name={item.icon} />
+                  <span>{item.label}</span>
+                </a>
+              ))}
+            </div>
           ))}
         </nav>
         <div className="sidebar-footer">

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -51,6 +51,7 @@ import {
 import { createPortal } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { planSessionLoad, shouldShowSessionSkeleton } from "./loading-state.ts";
+import { activeRoute, activeRouteKey, navItems, pathOnly, titleFor } from "./routes.ts";
 import "./styles.css";
 
 type Summary = {
@@ -394,23 +395,6 @@ const ROUTE_SLICES: Record<string, DataSlice[]> = {
   Files: ["files"],
   Settings: ["config", "settings"],
 };
-
-type NavItem = {
-  key: string;
-  href: string;
-  label: string;
-  icon: IconName;
-};
-
-const navItems: NavItem[] = [
-  { key: "sessions", href: "/sessions", label: "Sessions", icon: "sessions" },
-  { key: "projects", href: "/projects", label: "Projects", icon: "folder" },
-  { key: "search", href: "/search", label: "Search", icon: "search" },
-  { key: "analytics", href: "/analytics", label: "Analytics", icon: "chart" },
-  { key: "insights", href: "/insights", label: "Insights", icon: "lightbulb" },
-  { key: "tools", href: "/tools", label: "Tools & MCP", icon: "tools" },
-  { key: "files", href: "/files", label: "Files", icon: "file" },
-];
 
 const CLAUDE_ICON_PATH =
   "m4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z";
@@ -4693,33 +4677,6 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function activeRoute(path: string): string {
-  const pathname = pathOnly(path);
-  if (pathname === "/" || pathname === "/sessions" || pathname.startsWith("/sessions/")) {
-    return "Sessions";
-  }
-  if (pathname === "/settings") {
-    return "Settings";
-  }
-  const match = navItems.find((item) => item.href === pathname);
-  return match?.label ?? "Sessions";
-}
-
-function activeRouteKey(path: string): string {
-  const pathname = pathOnly(path);
-  if (pathname === "/" || pathname === "/sessions" || pathname.startsWith("/sessions/")) {
-    return "sessions";
-  }
-  if (pathname === "/settings") {
-    return "settings";
-  }
-  return navItems.find((item) => item.href === pathname)?.key ?? "sessions";
-}
-
-function titleFor(active: string): string {
-  return active === "Sessions" ? "Session Archive" : active;
-}
-
 function shortDate(value: string): string {
   const time = Date.parse(value);
   if (!Number.isFinite(time)) {
@@ -4787,10 +4744,6 @@ function basename(path: string | null | undefined): string {
 
 function locationPath(): string {
   return `${window.location.pathname}${window.location.search}`;
-}
-
-function pathOnly(path: string): string {
-  return path.split("?", 1)[0] ?? "/";
 }
 
 function navigate(

--- a/src/ui/routes.ts
+++ b/src/ui/routes.ts
@@ -1,0 +1,67 @@
+export type NavIcon = "chart" | "sessions" | "folder" | "search" | "lightbulb" | "tools" | "file";
+
+export type NavItem = { key: string; href: string; label: string; icon: NavIcon };
+export type NavSection = { label: string | null; items: NavItem[] };
+
+// Analytics leads (overview-first); core archive next; analysis surfaces last.
+// Search and Settings are topbar utilities, not primary navigation.
+export const navSections: NavSection[] = [
+  {
+    label: null,
+    items: [{ key: "analytics", href: "/analytics", label: "Analytics", icon: "chart" }],
+  },
+  {
+    label: "Archive",
+    items: [
+      { key: "sessions", href: "/sessions", label: "Sessions", icon: "sessions" },
+      { key: "projects", href: "/projects", label: "Projects", icon: "folder" },
+    ],
+  },
+  {
+    label: "Intelligence",
+    items: [
+      { key: "insights", href: "/insights", label: "Insights", icon: "lightbulb" },
+      { key: "tools", href: "/tools", label: "Tools & MCP", icon: "tools" },
+      { key: "files", href: "/files", label: "Files", icon: "file" },
+    ],
+  },
+];
+
+export const navItems: NavItem[] = navSections.flatMap((section) => section.items);
+
+export function pathOnly(path: string): string {
+  return path.split("?", 1)[0] ?? "/";
+}
+
+export function activeRoute(path: string): string {
+  const pathname = pathOnly(path);
+  if (pathname === "/sessions" || pathname.startsWith("/sessions/")) {
+    return "Sessions";
+  }
+  if (pathname === "/search") {
+    return "Search";
+  }
+  if (pathname === "/settings") {
+    return "Settings";
+  }
+  const match = navItems.find((item) => item.href === pathname);
+  return match?.label ?? "Analytics";
+}
+
+export function activeRouteKey(path: string): string {
+  const pathname = pathOnly(path);
+  if (pathname === "/sessions" || pathname.startsWith("/sessions/")) {
+    return "sessions";
+  }
+  if (pathname === "/search") {
+    return "search";
+  }
+  if (pathname === "/settings") {
+    return "settings";
+  }
+  return navItems.find((item) => item.href === pathname)?.key ?? "analytics";
+}
+
+export function titleFor(active: string): string {
+  return active;
+}

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1,25 +1,30 @@
 :root {
   color-scheme: dark;
-  --canvas: #0b0e14;
-  --surface: #11151f;
-  --elevated: #161c28;
-  --overlay: #1b2230;
-  --line: #232b3b;
-  --line-strong: #303a4e;
-  --fg: #e7eaf0;
-  --muted: #9aa6b8;
-  --faint: #6b7689;
-  --accent: #8b5cf6;
-  --accent-hover: #a78bfa;
-  --on-accent: #f5f3ff;
-  --claude: #d97757;
-  --claude-strong: #c6613f;
-  --success: #34d399;
-  --warning: #fbbf24;
+  --canvas: #0e0d0e;
+  --surface: #161516;
+  --elevated: #1d1c1d;
+  --overlay: #242224;
+  --line: #2a282a;
+  --line-strong: #3a3739;
+  --fg: #f8f8f2;
+  --muted: #a8a29c;
+  --faint: #736f6b;
+  --accent: #d0e421;
+  --accent-hover: #dded55;
+  --on-accent: #1d1c1d;
+  --gold: #c9a771;
+  --gold-soft: #ecd5b0;
+  --claude: #ffb86c;
+  --claude-strong: #e8935a;
+  --success: #43b74f;
+  --warning: #ffb86c;
   --danger: #f87171;
-  --info: #60a5fa;
+  --info: #1086f4;
+  --magenta: #e159fc;
+  --lavender: #b184ff;
   --radius-lg: 10px;
   --radius-xl: 14px;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
@@ -27,43 +32,51 @@
 @media (prefers-color-scheme: light) {
   :root:not([data-theme]) {
     color-scheme: light;
-    --canvas: #f6f7f9;
+    --canvas: #f8f8f2;
     --surface: #ffffff;
-    --elevated: #f3f5f8;
+    --elevated: #f1f0ea;
     --overlay: #ffffff;
-    --line: #e4e8ef;
-    --line-strong: #d2d8e2;
-    --fg: #131722;
-    --muted: #5a6473;
-    --faint: #97a1b0;
-    --accent: #7c3aed;
-    --accent-hover: #6d28d9;
-    --on-accent: #ffffff;
-    --success: #059669;
+    --line: #e5e2da;
+    --line-strong: #d0ccc2;
+    --fg: #1d1c1d;
+    --muted: #5f5b56;
+    --faint: #97928b;
+    --accent: #1d1c1d;
+    --accent-hover: #3a3739;
+    --on-accent: #f8f8f2;
+    --gold: #a8834e;
+    --gold-soft: #c9a771;
+    --success: #2e8f3a;
     --warning: #b45309;
     --danger: #dc2626;
-    --info: #2563eb;
+    --info: #0b6ecf;
+    --magenta: #c026d3;
+    --lavender: #7c5cff;
   }
 }
 
 [data-theme="light"] {
   color-scheme: light;
-  --canvas: #f6f7f9;
+  --canvas: #f8f8f2;
   --surface: #ffffff;
-  --elevated: #f3f5f8;
+  --elevated: #f1f0ea;
   --overlay: #ffffff;
-  --line: #e4e8ef;
-  --line-strong: #d2d8e2;
-  --fg: #131722;
-  --muted: #5a6473;
-  --faint: #97a1b0;
-  --accent: #7c3aed;
-  --accent-hover: #6d28d9;
-  --on-accent: #ffffff;
-  --success: #059669;
+  --line: #e5e2da;
+  --line-strong: #d0ccc2;
+  --fg: #1d1c1d;
+  --muted: #5f5b56;
+  --faint: #97928b;
+  --accent: #1d1c1d;
+  --accent-hover: #3a3739;
+  --on-accent: #f8f8f2;
+  --gold: #a8834e;
+  --gold-soft: #c9a771;
+  --success: #2e8f3a;
   --warning: #b45309;
   --danger: #dc2626;
-  --info: #2563eb;
+  --info: #0b6ecf;
+  --magenta: #c026d3;
+  --lavender: #7c5cff;
 }
 
 [data-theme="dark"] {
@@ -326,7 +339,7 @@ nav a[aria-current="page"] {
   border: 1px solid var(--line);
   border-radius: 4px;
   color: var(--faint);
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 10px;
   padding: 1px 6px;
 }
@@ -1029,7 +1042,7 @@ td a:hover {
 }
 
 .mono {
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
 }
 
@@ -1144,7 +1157,7 @@ select {
 }
 
 .badge.is-mono {
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
 }
 
 .badge svg {
@@ -2117,7 +2130,7 @@ mark {
   max-width: 18rem;
   overflow: hidden;
   color: var(--muted);
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2420,7 +2433,7 @@ mark {
 
 .tool-call > div span {
   overflow: hidden;
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -2505,7 +2518,7 @@ mark {
   border: 1px solid var(--line);
   border-radius: 5px;
   color: var(--faint);
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   padding: 2px 6px;
 }
@@ -2602,7 +2615,7 @@ pre {
   max-width: 100%;
   margin: 8px 0 0;
   color: var(--muted);
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1.5;
   white-space: pre-wrap;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -195,6 +195,7 @@ nav a {
   display: flex;
   align-items: center;
   gap: 12px;
+  border-left: 2px solid transparent;
   border-radius: 8px;
   color: var(--muted);
   font-size: 14px;
@@ -216,8 +217,9 @@ nav a:hover {
 }
 
 nav a[aria-current="page"] {
-  background: color-mix(in oklab, var(--accent) 12%, transparent);
-  color: var(--accent);
+  border-left: 2px solid var(--gold);
+  background: color-mix(in oklab, var(--accent) 8%, transparent);
+  color: var(--fg);
 }
 
 .nav-section {
@@ -270,7 +272,7 @@ nav a[aria-current="page"] {
   width: 6px;
   height: 6px;
   border-radius: 999px;
-  background: var(--success);
+  background: var(--accent);
   animation: pulse 1.6s ease-in-out infinite;
 }
 
@@ -304,6 +306,22 @@ nav a[aria-current="page"] {
   background: color-mix(in oklab, var(--canvas) 84%, transparent);
   padding: 0 24px;
   backdrop-filter: blur(14px);
+}
+
+.topbar::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 -1px;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--gold) 0%, transparent) 0%,
+    color-mix(in oklab, var(--gold) 55%, transparent) 25%,
+    color-mix(in oklab, var(--gold-soft) 55%, transparent) 50%,
+    color-mix(in oklab, var(--gold) 55%, transparent) 75%,
+    color-mix(in oklab, var(--gold) 0%, transparent) 100%
+  );
+  pointer-events: none;
 }
 
 .topbar h1 {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -207,6 +207,24 @@ nav a[aria-current="page"] {
   color: var(--accent);
 }
 
+.nav-section {
+  display: flex;
+  flex-direction: column;
+}
+
+.nav-section + .nav-section {
+  margin-top: 14px;
+}
+
+.nav-section-label {
+  padding: 0 20px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+
 .sidebar-footer {
   display: grid;
   gap: 6px;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -46,6 +46,8 @@
     --on-accent: #f8f8f2;
     --gold: #a8834e;
     --gold-soft: #c9a771;
+    --claude: #b4571e;
+    --claude-strong: #9c4a17;
     --success: #2e8f3a;
     --warning: #b45309;
     --danger: #dc2626;
@@ -71,6 +73,8 @@
   --on-accent: #f8f8f2;
   --gold: #a8834e;
   --gold-soft: #c9a771;
+  --claude: #b4571e;
+  --claude-strong: #9c4a17;
   --success: #2e8f3a;
   --warning: #b45309;
   --danger: #dc2626;

--- a/test/launcher.test.ts
+++ b/test/launcher.test.ts
@@ -50,30 +50,34 @@ describe("launcher", () => {
   test("launchAgent writes a Warp launch configuration and opens it by name", () => {
     const home = mkdtempSync(join(tmpdir(), "decant-warp-"));
     const calls: { bin: string; args: string[] }[] = [];
-    const result = launchAgent(
-      "claude",
-      "review the flaky test",
-      null,
-      { agent: "claude", terminal: "warp", ide: "vscode" },
-      {
-        platform: "darwin",
-        env: { HOME: home, DECANT_SKILLS_DIR: home, SHELL: "/bin/zsh" },
-        run: (bin, args) => {
-          calls.push({ bin, args });
-          return { ok: true };
+    try {
+      const result = launchAgent(
+        "claude",
+        "review the flaky test",
+        null,
+        { agent: "claude", terminal: "warp", ide: "vscode" },
+        {
+          platform: "darwin",
+          env: { HOME: home, DECANT_SKILLS_DIR: home, SHELL: "/bin/zsh" },
+          run: (bin, args) => {
+            calls.push({ bin, args });
+            return { ok: true };
+          },
+          tempName: () => "decant-prompt-warp-test.txt",
         },
-        tempName: () => "decant-prompt-warp-test.txt",
-      },
-    );
-    expect(result.ok).toBe(true);
-    expect(calls).toEqual([{ bin: "open", args: ["warp://launch/decant-handoff"] }]);
-    const config = readFileSync(
-      join(home, ".warp", "launch_configurations", "decant-handoff.yaml"),
-      "utf8",
-    );
-    expect(config).toContain("name: decant-handoff");
-    expect(config).toContain("decant-prompt-warp-test.txt");
-    expect(config).toContain(JSON.stringify(home)); // cwd as quoted YAML scalar
+      );
+      expect(result.ok).toBe(true);
+      expect(calls).toEqual([{ bin: "open", args: ["warp://launch/decant-handoff"] }]);
+      const config = readFileSync(
+        join(home, ".warp", "launch_configurations", "decant-handoff.yaml"),
+        "utf8",
+      );
+      expect(config).toContain("name: decant-handoff");
+      expect(config).toContain("decant-prompt-warp-test.txt");
+      expect(config).toContain(JSON.stringify(home)); // cwd as quoted YAML scalar
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   test("openIde validates platform and directory before running open", () => {

--- a/test/launcher.test.ts
+++ b/test/launcher.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { canLaunch, command, launchAgent, openIde } from "../src/launcher.ts";
@@ -45,6 +45,35 @@ describe("launcher", () => {
     expect(calls[0]?.bin).toBe("open");
     expect(calls[0]?.args).toContain("Ghostty");
     expect(calls[0]?.args.join(" ")).toContain("claude");
+  });
+
+  test("launchAgent writes a Warp launch configuration and opens it by name", () => {
+    const home = mkdtempSync(join(tmpdir(), "decant-warp-"));
+    const calls: { bin: string; args: string[] }[] = [];
+    const result = launchAgent(
+      "claude",
+      "review the flaky test",
+      null,
+      { agent: "claude", terminal: "warp", ide: "vscode" },
+      {
+        platform: "darwin",
+        env: { HOME: home, DECANT_SKILLS_DIR: home, SHELL: "/bin/zsh" },
+        run: (bin, args) => {
+          calls.push({ bin, args });
+          return { ok: true };
+        },
+        tempName: () => "decant-prompt-warp-test.txt",
+      },
+    );
+    expect(result.ok).toBe(true);
+    expect(calls).toEqual([{ bin: "open", args: ["warp://launch/decant-handoff"] }]);
+    const config = readFileSync(
+      join(home, ".warp", "launch_configurations", "decant-handoff.yaml"),
+      "utf8",
+    );
+    expect(config).toContain("name: decant-handoff");
+    expect(config).toContain("decant-prompt-warp-test.txt");
+    expect(config).toContain(JSON.stringify(home)); // cwd as quoted YAML scalar
   });
 
   test("openIde validates platform and directory before running open", () => {

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -2,7 +2,13 @@ import { afterAll, describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { detectedSettings, getSettings, saveSettings, settingsPath } from "../src/settings.ts";
+import {
+  detectedSettings,
+  getSettings,
+  saveSettings,
+  settingsPath,
+  terminalOptions,
+} from "../src/settings.ts";
 
 const workDir = mkdtempSync(join(tmpdir(), "decant-settings-test-"));
 afterAll(() => rmSync(workDir, { recursive: true, force: true }));
@@ -40,5 +46,29 @@ describe("settings", () => {
     const merged = saveSettings({ agent: "nope", terminal: "wezterm" }, { env });
     expect(merged).toMatchObject({ agent: "codex", terminal: "wezterm", ide: "zed" });
     expect(getSettings({ env }).terminal).toBe("wezterm");
+  });
+
+  test("detects Warp from TERM_PROGRAM and accepts it as a saved value", () => {
+    const detected = detectedSettings({
+      env: { TERM_PROGRAM: "WarpTerminal" },
+      appExists: () => false,
+    });
+    expect(detected.terminal).toBe("warp");
+    expect(terminalOptions.map(([key]) => key)).toContain("warp");
+  });
+
+  test("saveSettings round-trips Warp terminal through getSettings", () => {
+    const env = { DECANT_CONFIG_DIR: join(workDir, "warp") };
+    const saved = saveSettings(
+      {
+        agent: "claude",
+        terminal: "warp",
+        ide: "vscode",
+      },
+      { env, appExists: () => false },
+    );
+    expect(saved.terminal).toBe("warp");
+    const loaded = getSettings({ env });
+    expect(loaded.terminal).toBe("warp");
   });
 });

--- a/test/ui-routes.test.ts
+++ b/test/ui-routes.test.ts
@@ -22,6 +22,7 @@ describe("ui routes", () => {
   });
 
   test("search and settings stay routable without sidebar slots", () => {
+    expect(navItems.map((item) => item.key)).not.toContain("search");
     expect(activeRoute("/search")).toBe("Search");
     expect(activeRoute("/settings")).toBe("Settings");
   });

--- a/test/ui-routes.test.ts
+++ b/test/ui-routes.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { activeRoute, activeRouteKey, navItems, titleFor } from "../src/ui/routes.ts";
+
+describe("ui routes", () => {
+  test("root path lands on Analytics", () => {
+    expect(activeRoute("/")).toBe("Analytics");
+    expect(activeRouteKey("/")).toBe("analytics");
+  });
+
+  test("analytics is the first nav item", () => {
+    expect(navItems[0]?.key).toBe("analytics");
+  });
+
+  test("unknown paths fall back to Analytics", () => {
+    expect(activeRoute("/definitely-not-a-page")).toBe("Analytics");
+    expect(activeRouteKey("/definitely-not-a-page")).toBe("analytics");
+  });
+
+  test("session detail routes stay in Sessions", () => {
+    expect(activeRoute("/sessions/42")).toBe("Sessions");
+    expect(activeRouteKey("/sessions/42?from=list")).toBe("sessions");
+  });
+
+  test("search and settings stay routable without sidebar slots", () => {
+    expect(activeRoute("/search")).toBe("Search");
+    expect(activeRoute("/settings")).toBe("Settings");
+  });
+
+  test("topbar title matches the nav label exactly", () => {
+    expect(titleFor("Sessions")).toBe("Sessions");
+  });
+});


### PR DESCRIPTION
## Summary

Implements the UX/UI refresh plan (2026-07-10): decant's local web UI adopts the dosu.dev design language, Analytics becomes the landing page and first nav item, the sidebar is regrouped per researched IA patterns, and agent handoff now supports Warp — previously unselectable and undetectable, so handoffs on a Warp machine silently opened Terminal.app.

## Changes

- **Warp terminal support** (`src/settings.ts`, `src/launcher.ts`): `warp` joins the TerminalKey union, options list, and detection (`TERM_PROGRAM=WarpTerminal`). Launching writes `~/.warp/launch_configurations/decant-handoff.yaml` (stable name, overwritten per launch) and opens `warp://launch/decant-handoff` — Warp has no AppleScript command support, so the launch-config deep link is the only scriptable entry point that runs a command (verified on-machine; configs outside that directory do not resolve).
- **Analytics as home** (`src/ui/routes.ts` new, `src/ui/main.tsx`): nav/route logic extracted into a pure, tested module (following the `loading-state.ts` precedent); `/` and unknown paths land on Analytics; Search leaves the primary nav (the topbar affordance stays and `/search` remains routable).
- **Grouped sidebar** (`src/ui/main.tsx`, `src/ui/styles.css`): Analytics up top, then **Archive** (Sessions, Projects) and **Intelligence** (Insights, Tools & MCP, Files); nav labels now match page headers ("Session Archive" title mismatch is gone).
- **dosu.dev design tokens** (`src/ui/styles.css`): warm charcoal canvas + `#f8f8f2` ink; lime `#d0e421` action accent in dark / charcoal primary in light (mirroring dosu.dev's own light-app answer); gold hairline pair `#c9a771`/`#ecd5b0`; dosu accent family for data; new `--font-mono` (JetBrains Mono-first stack, no bundled fonts — local-first invariant intact) replacing 7 hardcoded mono stacks.
- **Texture** (`src/ui/styles.css`): gold gradient hairline under the topbar, gold active-nav indicator (layout-shift-free via transparent border on inactive items), lime live-dot.
- **Final-review fix** (`c50aee9`): light-theme `--claude`/`--claude-strong` darkened to `#b4571e`/`#9c4a17` for WCAG ≥4.5:1 on white (the plan's light block omitted them, inheriting near-illegible peach), plus a regression test pinning Search out of the nav.

## Verification

- `bun test` 253/253 across 31 files (+9 tests vs base), `bunx tsc --noEmit` clean, `bunx biome check .` clean.
- Each task went through an independent implementer → reviewer loop; a final whole-branch review returned "mergeable with fixes," and the one Important finding (light-theme Claude contrast) landed as `c50aee9`.
- Playwright smoke against a **fixtures-only** archive: `/` renders Analytics with populated stats/charts; sidebar groups and labels correct with no Search item; both themes readable; Settings lists Warp and **auto-detects it** under `TERM_PROGRAM=WarpTerminal`.
- Live launch smoke on a real Mac: `POST /api/launch/agent` with terminal=warp → `ok:true`, launch-config YAML written with quoted cwd + prompt-file exec, Warp window opened running the agent. Regression with terminal=terminal → Terminal.app opens via the untouched osascript path. (iTerm isn't installed on this machine; its path is covered by existing unit tests.)
- Before/after screenshots in both themes were captured against synthetic fixture data only (no real transcripts).

## Follow-ups (from the final review, deliberately out of scope here)

- Wire a real `/` keyboard shortcut for search or drop the topbar kbd hint — pre-existing gap; the hint has no handler on main either.
- Dark-mode `--claude` equals `--warning` (`#ffb86c`) — plan-chosen mapping; differentiate later if Claude badges vs warning chips read ambiguous on Insights.
- Light-mode `td a:hover` resolves to the resting color (accent = fg in light) — add an underline or hover to `--accent-hover`.
- `--magenta`/`--lavender` are defined but unconsumed — future chart palette.
- `launchWarp`'s write-failure Result path lacks a dedicated test.
- Light-mode live-dot is charcoal (it tracks `--accent` per the plan); revisit if the "live" semantic feels lost.

Branch is `teedole/`-prefixed per request (plan draft said `feat/dosu-ux-refresh`).

---
https://claude.ai/code/session_01H2b4AssmBDVz3CgiwLecXy
