### PR TITLE
feat(tokens): recognize shell-based edits at the phase boundary

### DIFF
--- a/src/buckets.ts
+++ b/src/buckets.ts
@@ -64,11 +64,38 @@ export function toolBucket(
   return "context";
 }
 
-/** True for tools that mutate a file on disk (the phase boundary marker):
- * the first such tool_use flips a session from orientation to implementation.
- * Excludes shell writes -- only explicit edit/patch/write tools count. */
-export function isCodeEditTool(toolName: string | null | undefined): boolean {
-  return CODE_TOOLS.has(localToolName(toolName ?? "").toLowerCase());
+// High-precision markers that a shell command mutates a source file. Kept
+// deliberately narrow: a false positive moves the phase boundary earlier and
+// mislabels orientation as implementation, which is worse than missing one. So
+// no bare `>` redirect (too often /dev/null, /tmp, logs) -- only unambiguous
+// in-place edits, patch application, and explicit file writes.
+const SHELL_EDIT_PATTERNS: RegExp[] = [
+  /\bgit\s+apply\b(?![^\n]*--(?:check|stat|summary|numstat))/, // apply a patch for real
+  /\bsed\b[^\n|]*\s-i\b/, // in-place edit
+  /\bpatch\b[^\n|]*-p\d/, // patch -p1 < ...
+  /\bwriteFileSync\b|\bfs\.write\b|\.writeFile\b/, // node fs writes (node -e ...)
+  /\bopen\([^)]*['"][wa]\+?['"]/, // python open(..., "w"/"a")
+  /\bapplypatch\b/,
+];
+
+/** True for tools that mutate a file on disk (the phase boundary marker): the
+ * first such tool_use flips a session from orientation to implementation. Covers
+ * the structured edit tools (edit/write/patch) AND shell commands that clearly
+ * write a file (git apply, sed -i, fs.writeFileSync, ...), since agents sometimes
+ * implement through the shell rather than the edit tool. */
+export function isCodeEditTool(
+  toolName: string | null | undefined,
+  input?: string | Json,
+): boolean {
+  const normalized = localToolName(toolName ?? "").toLowerCase();
+  if (CODE_TOOLS.has(normalized)) {
+    return true;
+  }
+  if (SHELL_TOOLS.has(normalized)) {
+    const command = commandFromInput(input);
+    return command != null && SHELL_EDIT_PATTERNS.some((re) => re.test(command));
+  }
+  return false;
 }
 
 export function blockBucket(

--- a/src/token-economics.ts
+++ b/src/token-economics.ts
@@ -534,7 +534,7 @@ function sumWeights(weights: Map<ActivityBucket, number>): number {
 function firstEditSeqBySession(blocks: BlockRow[]): Map<number, number> {
   const boundary = new Map<number, number>();
   for (const block of blocks) {
-    if (block.type !== "tool_use" || !isCodeEditTool(block.tool_name)) {
+    if (block.type !== "tool_use" || !isCodeEditTool(block.tool_name, block.tool_input)) {
       continue;
     }
     const current = boundary.get(block.session_id);

--- a/test/buckets.test.ts
+++ b/test/buckets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bashBucket, blockBucket, toolBucket } from "../src/buckets.ts";
+import { bashBucket, blockBucket, isCodeEditTool, toolBucket } from "../src/buckets.ts";
 
 describe("activity bucket classifier", () => {
   test("classifies fixed tool families", () => {
@@ -39,5 +39,41 @@ describe("activity bucket classifier", () => {
     expect(blockBucket("text")).toBe("communicating");
     expect(blockBucket("tool_use", "Write")).toBe("code");
     expect(blockBucket("tool_result", "Read")).toBe("context");
+  });
+
+  test("isCodeEditTool: structured edit tools", () => {
+    for (const t of ["Edit", "Write", "MultiEdit", "NotebookEdit", "apply_patch"]) {
+      expect(isCodeEditTool(t)).toBe(true);
+    }
+    expect(isCodeEditTool("Read")).toBe(false);
+    expect(isCodeEditTool("Bash")).toBe(false); // no command -> not an edit
+  });
+
+  test("isCodeEditTool: shell commands that mutate a file count as edits", () => {
+    const edits = [
+      "git apply /tmp/pr.diff",
+      "sed -i 's/a/b/' src/x.ts",
+      "patch -p1 < /tmp/x.patch",
+      'node -e \'require("fs").writeFileSync("a.ts", body)\'',
+      "python3 -c \"open('a.py','w').write(x)\"",
+    ];
+    for (const cmd of edits) {
+      expect(isCodeEditTool("Bash", { command: cmd })).toBe(true);
+      expect(isCodeEditTool("shell", JSON.stringify({ command: cmd }))).toBe(true);
+    }
+  });
+
+  test("isCodeEditTool: read-only / benign shell is NOT an edit", () => {
+    const benign = [
+      "git apply --check /tmp/pr.diff",
+      "grep -rn foo src",
+      "cat package.json",
+      "echo hi > /dev/null",
+      "yarn build > /tmp/build.log",
+      "git diff --stat",
+    ];
+    for (const cmd of benign) {
+      expect(isCodeEditTool("Bash", { command: cmd })).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## What

The orientation → implementation phase boundary (from #31) fires on the first **structured** edit tool (Edit/Write/MultiEdit/apply_patch). Agents sometimes implement **through the shell** — `git apply`, `sed -i`, `node -e '…writeFileSync…'` — and those runs never tripped the boundary, so they read as **100% orientation** even though they wrote the change.

`isCodeEditTool(toolName, input)` now also inspects shell commands and treats a narrow set of unambiguous file-mutating commands as edits.

## Heuristic (deliberately conservative)

A false positive moves the boundary *earlier* and mislabels orientation as implementation — worse than missing one — so the set is high-precision: `git apply` (excl. --check/--stat/--summary), `sed -i`, `patch -pN`, `writeFileSync`/`fs.write*`, python `open(…, "w"/"a")`, `applypatch`. **No bare `>`/`>>` redirect** (too often /dev/null, /tmp, logs).

## Tests

Structured tools, the shell-edit set, and benign/read-only shell (`git apply --check`, `grep`, `echo > /dev/null`, `yarn build > /tmp/build.log`, `git diff --stat`). `bun test` (248), `tsc --noEmit`, `biome check .` green.

## Impact

Small on the current dataset — corrects the phase split for runs that implemented via shell rather than the edit tools. Draft for heuristic review before it lands in canonical accounting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)