### PR TITLE
feat(tokens): attribute wall-clock time to activity buckets and phases

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -821,7 +821,9 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
   program
     .command("tokens")
     .alias("economics")
-    .description("break token and cost usage into planning, communicating, context, and code")
+    .description(
+      "break token, cost, and time usage into planning, communicating, context, and code",
+    )
     .action(() =>
       run(() => {
         const archive = readArchive();
@@ -833,7 +835,8 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
                 (bucket) =>
                   `${bucket.bucket}\t${formatNumber(bucket.generation_tokens)}\t` +
                   `${formatNumber(bucket.context_window_tokens)}\t` +
-                  `${bucket.estimated_cost_usd.toFixed(4)}`,
+                  `${bucket.estimated_cost_usd.toFixed(4)}\t` +
+                  `${formatDuration(bucket.active_ms)}`,
               )
               .join("\n")
               .concat(row.buckets.length > 0 ? "\n" : ""),
@@ -1059,6 +1062,19 @@ function trustedPeers(values: string[] | undefined): string[] {
 
 function formatNumber(value: number): string {
   return String(Math.round(value));
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ${totalSeconds % 60}s`;
+  }
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
 }
 
 function parseOperation(value: string): Operation | null {

--- a/src/token-economics.ts
+++ b/src/token-economics.ts
@@ -12,6 +12,11 @@ import { type DateFilter, sessionDatePredicate, whereClause } from "./date-filte
 const CHARS_PER_TOKEN = 4;
 const encoder = new TextEncoder();
 
+// A gap longer than this between two messages is the agent waiting on the human,
+// not working; cap it so idle time never inflates the activity latency. Mirrors
+// the ACTIVE_GAP_CAP_SECONDS used for session active_seconds in enrich.ts.
+const ACTIVE_GAP_CAP_MS = 300_000;
+
 /** A run splits into two phases at the first file edit: "orientation" (reading
  * and planning HOW to change the code) and "implementation" (writing it). The
  * phase breakdown is orthogonal to the activity buckets -- every bucket carries
@@ -22,6 +27,8 @@ export interface PhaseAmounts {
   generation_tokens: number;
   context_window_tokens: number;
   estimated_cost_usd: number;
+  // Wall-clock time attributed to this phase, from capped inter-message gaps.
+  active_ms: number;
 }
 
 export interface TokenEconomicsBucket {
@@ -32,6 +39,11 @@ export interface TokenEconomicsBucket {
   tool_calls: number;
   sessions: number;
   cost_share: number;
+  // Wall-clock time spent on this activity, in milliseconds. Measured as the
+  // sum of capped gaps between consecutive messages, charged to the activity
+  // mix of the message that closed each gap (see allocateLatency). Answers
+  // "how much *time* went to orientation/planning/etc.", not just tokens.
+  active_ms: number;
   // Present only from the ordered whole-archive path, which can place each
   // contribution before/after the first edit. Absent from the fast per-session
   // path, which distributes by aggregate weights and has no order.
@@ -46,6 +58,7 @@ export interface TokenEconomics {
     estimated_cost_usd: number;
     input_cost_usd: number;
     output_cost_usd: number;
+    active_ms: number;
     phases?: Record<Phase, PhaseAmounts>;
   };
 }
@@ -80,6 +93,7 @@ interface BlockRow {
   tool_name: string | null;
   tool_input: string | null;
   text_bytes: number;
+  timestamp: string | null;
 }
 
 interface ResultRow {
@@ -103,6 +117,10 @@ interface MutableBucket {
   genOrientation: number;
   windowOrientation: number;
   costOrientation: number;
+  // Wall-clock ms attributed to this bucket, and the orientation-phase portion
+  // (pre-first-edit). Implementation = activeMs - activeMsOrientation.
+  activeMs: number;
+  activeMsOrientation: number;
 }
 
 type QueryParam = string | number;
@@ -124,6 +142,9 @@ export interface SessionEconomicsVector {
       // matching how context_window excludes folded-in generation.
       generation_orientation: number;
       context_window_orientation: number;
+      // Wall-clock ms on this activity, and its orientation-phase portion.
+      active_ms: number;
+      active_ms_orientation: number;
     }
   >;
 }
@@ -187,6 +208,8 @@ export function aggregateEconomicsVectors(
       entry.contextWindow += part.context_window;
       entry.genOrientation += part.generation_orientation;
       entry.windowOrientation += part.context_window_orientation;
+      entry.activeMs += part.active_ms;
+      entry.activeMsOrientation += part.active_ms_orientation;
       entry.toolCalls += part.tool_calls;
       if (part.touched) {
         entry.sessions.add(vector.id);
@@ -251,7 +274,7 @@ function vectorsForScope(
     .query(
       `${scopeCte}
        SELECT b.session_id, b.message_id, m.seq AS seq, m.role, m.output_tokens, b.type,
-              b.tool_name,
+              b.tool_name, m.timestamp AS timestamp,
               CASE WHEN b.type IN ('tool_use', 'tool_result', 'web_search')
                    THEN b.tool_input END AS tool_input,
               COALESCE(length(CAST(b.text AS BLOB)), 0) AS text_bytes
@@ -267,6 +290,7 @@ function vectorsForScope(
     const vector = vectorBySession.get(sessionId);
     if (vector != null) {
       allocateGeneration([vector.session], sessionBlocks, vector.buckets, boundaries);
+      allocateLatency(sessionId, sessionBlocks, vector.buckets, boundaries);
     }
   }
   for (const vector of vectorBySession.values()) {
@@ -329,6 +353,8 @@ function vectorsForScope(
         touched: (entry?.sessions.size ?? 0) > 0,
         generation_orientation: entry?.genOrientation ?? 0,
         context_window_orientation: entry?.windowOrientation ?? 0,
+        active_ms: entry?.activeMs ?? 0,
+        active_ms_orientation: entry?.activeMsOrientation ?? 0,
       };
     }
     return {
@@ -424,6 +450,28 @@ function fastTokenEconomicsForSession(db: Database, sessionId: number): TokenEco
   distributeWindow(inputWindowTokens, windowWeights, buckets, sessions);
   for (const entry of buckets.values()) {
     entry.contextWindow += entry.generation;
+  }
+
+  // Wall-clock time per activity. The fast path has no first-edit ordering, so
+  // it emits no phase split (empty boundaries -> everything implementation),
+  // but a single session's ordered blocks are cheap to scan for gap timing.
+  const latencyBlocks = db
+    .query(
+      `${scopeCte}
+       SELECT b.session_id, b.message_id, m.seq AS seq, m.role, m.output_tokens, b.type,
+              b.tool_name, m.timestamp AS timestamp,
+              CASE WHEN b.type IN ('tool_use', 'tool_result', 'web_search')
+                   THEN b.tool_input END AS tool_input,
+              COALESCE(length(CAST(b.text AS BLOB)), 0) AS text_bytes
+       FROM block b
+       JOIN message m ON m.id = b.message_id
+       JOIN scoped_session fs ON fs.id = b.session_id
+       ORDER BY b.session_id, m.seq, b.ordinal`,
+    )
+    .all(sessionId) as BlockRow[];
+  const noBoundaries = new Map<number, number>();
+  for (const [id, sessionBlocks] of groupBy(latencyBlocks, (block) => block.session_id)) {
+    allocateLatency(id, sessionBlocks, buckets, noBoundaries);
   }
 
   const totalGeneration = sumBuckets(buckets, "generation");
@@ -619,6 +667,124 @@ function allocateGeneration(
   }
 }
 
+/** Charge wall-clock time to activity buckets. The gap between a message and
+ * the one before it is the time that produced the later message -- the model
+ * generating (its thinking/text/tool_use blocks) or a tool executing (the
+ * tool_result block in the following user message). Each gap is capped like
+ * session active_seconds, then split across the closing message's blocks by the
+ * same byte-weight generation uses, so a bucket's time and its tokens line up. */
+function allocateLatency(
+  sessionId: number,
+  blocks: BlockRow[],
+  buckets: Map<ActivityBucket, MutableBucket>,
+  boundaries: Map<number, number>,
+): void {
+  let previous: number | null = null;
+  for (const message of orderedMessages(blocks)) {
+    const at = epochMillis(message.timestamp);
+    if (at == null) {
+      continue;
+    }
+    if (previous != null) {
+      const gap = Math.min(Math.max(0, at - previous), ACTIVE_GAP_CAP_MS);
+      distributeLatency(gap, message.blocks, buckets, phaseOf(boundaries, sessionId, message.seq));
+    }
+    previous = at;
+  }
+}
+
+interface OrderedMessage {
+  seq: number;
+  timestamp: string | null;
+  blocks: BlockRow[];
+}
+
+/** Regroup seq-ordered blocks back into their messages, preserving order. */
+function orderedMessages(blocks: BlockRow[]): OrderedMessage[] {
+  const byId = new Map<number, OrderedMessage>();
+  const order: number[] = [];
+  for (const block of blocks) {
+    let message = byId.get(block.message_id);
+    if (message == null) {
+      message = { seq: block.seq, timestamp: block.timestamp, blocks: [] };
+      byId.set(block.message_id, message);
+      order.push(block.message_id);
+    }
+    message.blocks.push(block);
+  }
+  return order.map((id) => byId.get(id) as OrderedMessage);
+}
+
+/** Split one message's gap across its blocks by byte-weight into their buckets. */
+function distributeLatency(
+  ms: number,
+  blocks: BlockRow[],
+  buckets: Map<ActivityBucket, MutableBucket>,
+  phase: Phase,
+): void {
+  if (ms <= 0 || blocks.length === 0) {
+    return;
+  }
+  const weighted = blocks.map((block) => ({ block, weight: Math.max(1, blockSize(block)) }));
+  const totalWeight = weighted.reduce((sum, item) => sum + item.weight, 0);
+  for (const item of weighted) {
+    addLatency(
+      buckets,
+      blockBucket(item.block.type, item.block.tool_name, item.block.tool_input),
+      ms * (item.weight / totalWeight),
+      phase,
+    );
+  }
+}
+
+function addLatency(
+  buckets: Map<ActivityBucket, MutableBucket>,
+  bucket: ActivityBucket,
+  ms: number,
+  phase: Phase,
+): void {
+  const entry = buckets.get(bucket);
+  if (entry == null || ms <= 0) {
+    return;
+  }
+  entry.activeMs += ms;
+  if (phase === "orientation") {
+    entry.activeMsOrientation += ms;
+  }
+}
+
+/** Parse an ISO-8601 `...Z` timestamp to epoch milliseconds, keeping any
+ * fractional-second precision. Returns null for anything not UTC-suffixed,
+ * matching the conservative parsing enrich.ts uses for active_seconds. */
+function epochMillis(timestamp: string | null): number | null {
+  if (timestamp == null || !timestamp.endsWith("Z")) {
+    return null;
+  }
+  const withoutZone = timestamp.slice(0, -1);
+  const [date, time] = withoutZone.split("T");
+  if (date == null || time == null) {
+    return null;
+  }
+  const [year, month, day] = date.split("-").map((part) => Number.parseInt(part, 10));
+  const [clock, fraction] = time.split(".");
+  const [hour, minute, second] = (clock ?? "").split(":").map((part) => Number.parseInt(part, 10));
+  if (
+    [year, month, day, hour, minute, second].some((part) => part == null || !Number.isFinite(part))
+  ) {
+    return null;
+  }
+  const millis = fraction == null ? 0 : Math.round(Number.parseFloat(`0.${fraction}`) * 1000);
+  return Date.UTC(
+    year as number,
+    (month as number) - 1,
+    day as number,
+    hour as number,
+    minute as number,
+    second as number,
+    millis,
+  );
+}
+
 function allocateOutput(
   sessionId: number,
   outputTokens: number,
@@ -731,6 +897,8 @@ function emptyBuckets(): Map<ActivityBucket, MutableBucket> {
         genOrientation: 0,
         windowOrientation: 0,
         costOrientation: 0,
+        activeMs: 0,
+        activeMsOrientation: 0,
       },
     ]),
   );
@@ -743,16 +911,20 @@ function phasesFor(entry: MutableBucket | undefined): Record<Phase, PhaseAmounts
   const genO = entry?.genOrientation ?? 0;
   const winO = entry?.windowOrientation ?? 0;
   const costO = entry?.costOrientation ?? 0;
+  const active = entry?.activeMs ?? 0;
+  const activeO = entry?.activeMsOrientation ?? 0;
   return {
     orientation: {
       generation_tokens: Math.round(genO),
       context_window_tokens: Math.round(winO),
       estimated_cost_usd: costO,
+      active_ms: Math.round(activeO),
     },
     implementation: {
       generation_tokens: Math.round(gen - genO),
       context_window_tokens: Math.round(win - winO),
       estimated_cost_usd: cost - costO,
+      active_ms: Math.round(active - activeO),
     },
   };
 }
@@ -774,6 +946,7 @@ function finish(
       tool_calls: entry?.toolCalls ?? 0,
       sessions: entry?.sessions.size ?? 0,
       cost_share: share(entry?.cost ?? 0, totalCost),
+      active_ms: Math.round(entry?.activeMs ?? 0),
     };
     if (withPhases) {
       row.phases = phasesFor(entry);
@@ -786,6 +959,7 @@ function finish(
     estimated_cost_usd: totalCost,
     input_cost_usd: inputCost,
     output_cost_usd: outputCost,
+    active_ms: rows.reduce((sum, row) => sum + row.active_ms, 0),
   };
   if (withPhases) {
     totals.phases = {
@@ -801,6 +975,7 @@ function sumPhase(rows: TokenEconomicsBucket[], phase: Phase): PhaseAmounts {
     generation_tokens: 0,
     context_window_tokens: 0,
     estimated_cost_usd: 0,
+    active_ms: 0,
   };
   for (const row of rows) {
     const p = row.phases?.[phase];
@@ -810,6 +985,7 @@ function sumPhase(rows: TokenEconomicsBucket[], phase: Phase): PhaseAmounts {
     acc.generation_tokens += p.generation_tokens;
     acc.context_window_tokens += p.context_window_tokens;
     acc.estimated_cost_usd += p.estimated_cost_usd;
+    acc.active_ms += p.active_ms;
   }
   return acc;
 }

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -128,6 +128,7 @@ type TokenEconomics = {
     tool_calls: number;
     sessions: number;
     cost_share: number;
+    active_ms: number;
   }[];
   totals: {
     generation_tokens: number;
@@ -135,6 +136,7 @@ type TokenEconomics = {
     estimated_cost_usd: number;
     input_cost_usd: number;
     output_cost_usd: number;
+    active_ms: number;
   };
 };
 
@@ -1988,6 +1990,10 @@ function TokenEconomicsPanel({
               <strong>{compact(economics.totals.context_window_tokens)}</strong>
               window
             </span>
+            <span>
+              <strong>{duration(economics.totals.active_ms)}</strong>
+              time
+            </span>
           </div>
         ) : null}
       </div>
@@ -2009,6 +2015,7 @@ function TokenEconomicsPanel({
               <col className="col-activity-number" />
               <col className="col-activity-number" />
               <col className="col-activity-number" />
+              <col className="col-activity-number" />
             </colgroup>
             <thead>
               <tr className="activity-table-head">
@@ -2016,6 +2023,9 @@ function TokenEconomicsPanel({
                 <th scope="col">Cost share</th>
                 <th className="numeric activity-number" scope="col">
                   Cost
+                </th>
+                <th className="numeric activity-number" scope="col">
+                  Time
                 </th>
                 <th className="numeric activity-number" scope="col">
                   Generated
@@ -2060,6 +2070,9 @@ function TokenEconomicsPanel({
                         </td>
                         <td className="numeric activity-number">
                           {money(bucket.estimated_cost_usd)}
+                        </td>
+                        <td className="numeric muted activity-number">
+                          {duration(bucket.active_ms)}
                         </td>
                         <td className="numeric muted activity-number">
                           {compact(bucket.generation_tokens)}
@@ -3223,6 +3236,19 @@ function compact(value: number): string {
 
 function money(value: number): string {
   return `$${value.toFixed(2)}`;
+}
+
+function duration(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ${totalSeconds % 60}s`;
+  }
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
 }
 
 function relativeTime(value: string | null | undefined): string {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -101,7 +101,10 @@ describe("runCli", () => {
     const tokens = await runCli([...base, "tokens"]);
     expect(tokens.code).toBe(0);
     expect(JSON.parse(tokens.stdout)).toMatchObject({
-      buckets: expect.arrayContaining([expect.objectContaining({ bucket: "context" })]),
+      buckets: expect.arrayContaining([
+        expect.objectContaining({ bucket: "context", active_ms: expect.any(Number) }),
+      ]),
+      totals: expect.objectContaining({ active_ms: expect.any(Number) }),
     });
 
     const search = await runCli([...base, "search", "auth", "--limit", "5"]);

--- a/test/token-economics.test.ts
+++ b/test/token-economics.test.ts
@@ -117,6 +117,93 @@ describe("token economics", () => {
     db.close();
   });
 
+  test("attributes wall-clock time to activity buckets and phases", () => {
+    const db = freshDb();
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("sess-enr-claude", fixture("claude", "enriched.jsonl")),
+      "/x/claude.jsonl",
+      1,
+      2,
+      "claude",
+    );
+
+    const economics = tokenEconomics(db);
+    // Total attributed time equals the session's active_seconds (both are the
+    // sum of the same capped inter-message gaps), within rounding.
+    const activeSeconds = (
+      db.query("SELECT active_seconds FROM session WHERE id = ?1").get(sessionId) as {
+        active_seconds: number;
+      }
+    ).active_seconds;
+    expect(activeSeconds).toBeGreaterThan(0);
+    expect(economics.totals.active_ms).toBeGreaterThan(0);
+    expect(economics.totals.active_ms).toBeCloseTo(activeSeconds * 1000, -2);
+
+    // Buckets' time sums to the total, and each bucket's phase split sums back
+    // to the bucket (rounding can drift the two rounded halves by <=1ms).
+    const bucketSum = economics.buckets.reduce((sum, row) => sum + row.active_ms, 0);
+    expect(bucketSum).toBe(economics.totals.active_ms);
+    for (const row of economics.buckets) {
+      const { orientation, implementation } = row.phases as NonNullable<typeof row.phases>;
+      expect(orientation.active_ms).toBeGreaterThanOrEqual(0);
+      expect(implementation.active_ms).toBeGreaterThanOrEqual(0);
+      expect(
+        Math.abs(orientation.active_ms + implementation.active_ms - row.active_ms),
+      ).toBeLessThanOrEqual(1);
+    }
+    const phases = economics.totals.phases as NonNullable<typeof economics.totals.phases>;
+    expect(phases.orientation.active_ms + phases.implementation.active_ms).toBe(
+      economics.totals.active_ms,
+    );
+    // The fixture edits only after orienting, so edit time lands in implementation.
+    expect(
+      economics.buckets.find((row) => row.bucket === "code")?.phases?.orientation.active_ms,
+    ).toBe(0);
+
+    // The fast per-session path has no phase ordering but still reports time,
+    // and its total matches the aggregate for the same session.
+    const scoped = tokenEconomicsForSession(db, sessionId);
+    expect(scoped?.totals.active_ms).toBe(economics.totals.active_ms);
+    expect(scoped?.buckets.every((row) => row.phases === undefined)).toBe(true);
+    db.close();
+  });
+
+  test("caps idle gaps so waiting on the human never inflates activity time", () => {
+    const db = freshDb();
+    // Two assistant turns an hour apart: the raw gap is 3600s but a single
+    // capped gap can contribute at most 300s of attributed time.
+    const content = [
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-05-06T09:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "start" }] },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-05-06T10:00:00.000Z",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-7",
+          usage: { input_tokens: 10, output_tokens: 5 },
+          content: [{ type: "text", text: "done thinking after a long human pause" }],
+        },
+      }),
+    ].join("\n");
+    upsertSession(
+      db,
+      parseClaudeSession("sess-idle", `${content}\n`),
+      "/x/idle.jsonl",
+      1,
+      2,
+      "idle",
+    );
+
+    const economics = tokenEconomics(db);
+    expect(economics.totals.active_ms).toBe(300_000);
+    db.close();
+  });
+
   test("classifies Codex patch edits as code and read-only shell as context", () => {
     const db = freshDb();
     const sessionId = upsertSession(


### PR DESCRIPTION
## What

Token economics could tell you **where the money and tokens went** — across `planning` / `communicating` / `context` / `code`, and across the `orientation` / `implementation` phases — but not **where the _time_ went**. This adds a wall-clock `active_ms` measure alongside the existing token and cost figures on every bucket, phase, and total.

Now you can answer "how much time did the agent spend orienting vs implementing?" and "how much of that was planning vs running tools?", not just the token/cost equivalents.

## How

Time is the sum of capped gaps between consecutive messages — the same idle cap (300s) already used for session `active_seconds` in `enrich.ts`, so idle time waiting on a human never inflates the numbers. Each gap is charged to the activity mix of the message that *closed* it, split by the same byte-weight generation already uses:

- The gap ending at a **tool_result** message is the tool's execution time → `context` / `code`.
- The gap ending at an **assistant** message is model generation time → `planning` (thinking) / `communicating` (text) / etc.

The orientation vs implementation split reuses the existing first-edit boundary, so a run's time breaks down the same way its cost does. On the aggregate path the total `active_ms` matches the session's `active_seconds` (both sum the same capped gaps).

Both the ordered whole-archive path and the fast per-session path populate it. As with the token phase split, the fast per-session path reports bucket totals but no phase breakdown (it has no first-edit ordering).

## Surfaces

- **CLI** `decant tokens` / `economics`: new human-readable duration column (`12h 29m`).
- **API**: `active_ms` on buckets/phases/totals for `/api/analytics/token-economics` and `/api/sessions/:id/token-economics`.
- **Web UI**: a new **Time** column in the activity breakdown panel plus a total-time summary chip.

## Tests

- New cases in `test/token-economics.test.ts`: time attributed to buckets & phases (parts sum back to totals, aggregate total ≈ `active_seconds`), the idle-gap cap, and the fast-path total matching the aggregate.
- `test/cli.test.ts` asserts `active_ms` is present in the `tokens` JSON.
- Full gate green: `bun test` (250 pass), `bunx tsc --noEmit`, `bunx biome check .`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)