### PR TITLE
fix(tokens): correct wall-clock activity attribution

### DIFF
--- a/src/buckets.ts
+++ b/src/buckets.ts
@@ -1,6 +1,6 @@
 import type { Json } from "./model.ts";
 
-export const ACTIVITY_BUCKETS = ["planning", "communicating", "context", "code"] as const;
+export const ACTIVITY_BUCKETS = ["context", "planning", "code", "communicating"] as const;
 export type ActivityBucket = (typeof ACTIVITY_BUCKETS)[number];
 
 const SHELL_TOOLS = new Set(["bash", "exec_command", "local_shell", "shell"]);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -822,7 +822,7 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
     .command("tokens")
     .alias("economics")
     .description(
-      "break tokens, cost, agent time, and user wait into planning, communicating, context, and code",
+      "break tokens, cost, agent time, and user wait into context, planning, code, and communicating",
     )
     .action(() =>
       run(() => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -822,7 +822,7 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
     .command("tokens")
     .alias("economics")
     .description(
-      "break token, cost, and time usage into planning, communicating, context, and code",
+      "break tokens, cost, agent time, and user wait into planning, communicating, context, and code",
     )
     .action(() =>
       run(() => {
@@ -839,7 +839,10 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
                   `${formatDuration(bucket.active_ms)}`,
               )
               .join("\n")
-              .concat(row.buckets.length > 0 ? "\n" : ""),
+              .concat(row.buckets.length > 0 ? "\n" : "")
+              .concat(
+                `waiting_on_user\t-\t-\t-\t${formatDuration(row.totals.waiting_on_user_ms)}\n`,
+              ),
           );
         } finally {
           archive.db.close();

--- a/src/token-economics.ts
+++ b/src/token-economics.ts
@@ -45,9 +45,8 @@ export interface TokenEconomicsBucket {
   // "how much *time* went to orientation/planning/etc.", not just tokens.
   // User-authored response gaps are reported separately in totals.
   active_ms: number;
-  // Present only from the ordered whole-archive path, which can place each
-  // contribution before/after the first edit. Absent from the fast per-session
-  // path, which distributes by aggregate weights and has no order.
+  // Ordered block allocation places each contribution before/after the first
+  // edit for both archive-wide and per-session results.
   phases?: Record<Phase, PhaseAmounts>;
 }
 
@@ -79,14 +78,6 @@ interface SessionRow {
   total_cache_creation_tokens: number;
   total_reasoning_tokens: number;
   est_reasoning_tokens: number;
-}
-
-interface FastToolRow {
-  session_id: number;
-  tool_name: string | null;
-  input: string | null;
-  calls: number;
-  output_bytes: number | null;
 }
 
 interface BlockRow {
@@ -140,6 +131,8 @@ export interface SessionEconomicsVector {
   started_at: string | null;
   input_cost: number;
   output_cost: number;
+  // Total billed input volume, including cache reads and cache creation.
+  billed_input_tokens: number;
   waiting_on_user_ms: number;
   buckets: Record<
     ActivityBucket,
@@ -248,11 +241,53 @@ export function aggregateEconomicsVectors(
       outputCost * share(entry.genOrientation, totalGeneration) +
       inputCost * share(entry.windowOrientation, windowBasis);
   }
-  return finish(buckets, inputCost, outputCost, true, waitingOnUserMs);
+  return finish(buckets, inputCost, outputCost, waitingOnUserMs);
 }
 
 export function tokenEconomicsForSession(db: Database, sessionId: number): TokenEconomics | null {
-  return fastTokenEconomicsForSession(db, sessionId);
+  const scopeCte = `WITH RECURSIVE scoped_session(id) AS (
+    SELECT id FROM session WHERE id = ?1
+    UNION ALL
+    SELECT child.id
+    FROM session child
+    JOIN scoped_session parent ON parent.id = child.parent_session_id
+  )`;
+  const vectors = vectorsForScope(db, scopeCte, [sessionId]);
+  return vectors.length === 0 ? null : aggregateEconomicsVectors(withBilledInputWindow(vectors));
+}
+
+/** Session panels retain their billed-input Window total while using the same
+ * block-level activity weights as archive analytics. Allocate each run's input
+ * volume over the content that actually contributed to its context. */
+function withBilledInputWindow(vectors: SessionEconomicsVector[]): SessionEconomicsVector[] {
+  return vectors.map((vector) => {
+    const totalWeight = ACTIVITY_BUCKETS.reduce((sum, bucket) => {
+      const part = vector.buckets[bucket];
+      return sum + part.generation + part.context_window;
+    }, 0);
+    const buckets = {} as SessionEconomicsVector["buckets"];
+    for (const bucket of ACTIVITY_BUCKETS) {
+      const part = vector.buckets[bucket];
+      const weight = part.generation + part.context_window;
+      const allocatedInput =
+        totalWeight > 0
+          ? vector.billed_input_tokens * (weight / totalWeight)
+          : bucket === "context"
+            ? vector.billed_input_tokens
+            : 0;
+      const orientationWeight = part.generation_orientation + part.context_window_orientation;
+      const orientationShare =
+        weight > 0 ? orientationWeight / weight : bucket === "context" ? 1 : 0;
+      buckets[bucket] = {
+        ...part,
+        context_window: part.context_window + allocatedInput,
+        context_window_orientation:
+          part.context_window_orientation + allocatedInput * orientationShare,
+        touched: part.touched || allocatedInput > 0,
+      };
+    }
+    return { ...vector, buckets };
+  });
 }
 
 /** Load ordered block rows for generation and latency allocation. Tool-result
@@ -382,7 +417,7 @@ function vectorsForScope(
         generation: entry?.generation ?? 0,
         context_window: entry?.contextWindow ?? 0,
         tool_calls: entry?.toolCalls ?? 0,
-        touched: (entry?.sessions.size ?? 0) > 0,
+        touched: (entry?.sessions.size ?? 0) > 0 || (entry?.activeMs ?? 0) > 0,
         generation_orientation: entry?.genOrientation ?? 0,
         context_window_orientation: entry?.windowOrientation ?? 0,
         active_ms: entry?.activeMs ?? 0,
@@ -394,6 +429,10 @@ function vectorsForScope(
       started_at: session.started_at,
       input_cost: parts.input + parts.cacheRead + parts.cacheCreation,
       output_cost: parts.output,
+      billed_input_tokens:
+        session.total_input_tokens +
+        session.total_cache_read_tokens +
+        session.total_cache_creation_tokens,
       waiting_on_user_ms: mutable?.latency.waitingOnUserMs ?? 0,
       buckets,
     };
@@ -401,199 +440,6 @@ function vectorsForScope(
 }
 
 type PerSessionBuckets = Map<ActivityBucket, MutableBucket>;
-
-function fastTokenEconomicsForSession(db: Database, sessionId: number): TokenEconomics | null {
-  const scopeCte = `WITH RECURSIVE scoped_session(id) AS (
-    SELECT id FROM session WHERE id = ?1
-    UNION ALL
-    SELECT child.id
-    FROM session child
-    JOIN scoped_session parent ON parent.id = child.parent_session_id
-  )`;
-  const sessions = db
-    .query(
-      `${scopeCte}
-       SELECT s.id, s.model, s.total_input_tokens, s.total_output_tokens,
-              s.total_cache_read_tokens, s.total_cache_creation_tokens,
-              s.total_reasoning_tokens, s.est_reasoning_tokens
-       FROM session s
-       JOIN scoped_session fs ON fs.id = s.id`,
-    )
-    .all(sessionId) as SessionRow[];
-  if (sessions.length === 0) {
-    return null;
-  }
-
-  const buckets = emptyBuckets();
-  const latency = emptyLatency();
-  const toolRows = db
-    .query(
-      `${scopeCte}
-       SELECT t.session_id, t.tool_name, t.input, 1 AS calls,
-              COALESCE(t.output_bytes, 0) AS output_bytes
-       FROM tool_call t
-       JOIN scoped_session fs ON fs.id = t.session_id`,
-    )
-    .all(sessionId) as FastToolRow[];
-
-  let inputCost = 0;
-  let outputCost = 0;
-  let inputWindowTokens = 0;
-  let remainingOutputTokens = 0;
-  const toolCallWeights = new Map<ActivityBucket, number>();
-  for (const session of sessions) {
-    const planning = Math.min(
-      session.total_output_tokens,
-      session.total_reasoning_tokens || session.est_reasoning_tokens,
-    );
-    addBucket(buckets, "planning", planning, session.id);
-    remainingOutputTokens += Math.max(0, session.total_output_tokens - planning);
-    inputWindowTokens +=
-      session.total_input_tokens +
-      session.total_cache_read_tokens +
-      session.total_cache_creation_tokens;
-    const parts = estimateCostParts(
-      session.model,
-      {
-        input: session.total_input_tokens,
-        output: session.total_output_tokens,
-        cacheRead: session.total_cache_read_tokens,
-        cacheCreation: session.total_cache_creation_tokens,
-        reasoning: session.total_reasoning_tokens,
-      },
-      defaultPricing(),
-    );
-    inputCost += parts.input + parts.cacheRead + parts.cacheCreation;
-    outputCost += parts.output;
-  }
-
-  for (const row of toolRows) {
-    const bucket = toolBucket(row.tool_name, row.input);
-    const entry = buckets.get(bucket);
-    if (entry == null) {
-      continue;
-    }
-    entry.contextWindow += (row.output_bytes ?? 0) / CHARS_PER_TOKEN;
-    entry.toolCalls += row.calls;
-    entry.sessions.add(row.session_id);
-    toolCallWeights.set(bucket, (toolCallWeights.get(bucket) ?? 0) + row.calls);
-  }
-
-  distributeByWeights(remainingOutputTokens, toolCallWeights, buckets, sessions);
-  const windowWeights = toolCallWeights.size > 0 ? toolCallWeights : generationWeights(buckets);
-  distributeWindow(inputWindowTokens, windowWeights, buckets, sessions);
-  for (const entry of buckets.values()) {
-    entry.contextWindow += entry.generation;
-  }
-
-  // Wall-clock time per activity. The fast path omits phase output; empty
-  // boundaries classify its ordered rows as orientation only internally.
-  const latencyBlocks = blockRowsForScope(db, scopeCte, [sessionId]);
-  const noBoundaries = new Map<number, number>();
-  for (const [id, sessionBlocks] of groupBy(latencyBlocks, (block) => block.session_id)) {
-    allocateLatency(id, sessionBlocks, buckets, noBoundaries, latency);
-  }
-
-  const totalGeneration = sumBuckets(buckets, "generation");
-  const totalWindow = sumBuckets(buckets, "contextWindow");
-  for (const entry of buckets.values()) {
-    entry.cost =
-      outputCost * share(entry.generation, totalGeneration) +
-      inputCost * share(entry.contextWindow, totalWindow);
-  }
-  // No ordering on the fast path, so it emits no phase split (withPhases=false).
-  return finish(buckets, inputCost, outputCost, false, latency.waitingOnUserMs);
-}
-
-function distributeByWeights(
-  tokens: number,
-  weights: Map<ActivityBucket, number>,
-  buckets: Map<ActivityBucket, MutableBucket>,
-  sessions: SessionRow[],
-): void {
-  if (tokens <= 0) {
-    return;
-  }
-  const totalWeight = sumWeights(weights);
-  if (totalWeight <= 0) {
-    addSharedGeneration(buckets, "communicating", tokens, sessions);
-    return;
-  }
-  for (const [bucket, weight] of weights) {
-    addSharedGeneration(buckets, bucket, tokens * (weight / totalWeight), sessions);
-  }
-}
-
-function distributeWindow(
-  tokens: number,
-  weights: Map<ActivityBucket, number>,
-  buckets: Map<ActivityBucket, MutableBucket>,
-  sessions: SessionRow[],
-): void {
-  if (tokens <= 0) {
-    return;
-  }
-  const totalWeight = sumWeights(weights);
-  if (totalWeight <= 0) {
-    addSharedWindow(buckets, "context", tokens, sessions);
-    return;
-  }
-  for (const [bucket, weight] of weights) {
-    addSharedWindow(buckets, bucket, tokens * (weight / totalWeight), sessions);
-  }
-}
-
-function generationWeights(
-  buckets: Map<ActivityBucket, MutableBucket>,
-): Map<ActivityBucket, number> {
-  const weights = new Map<ActivityBucket, number>();
-  for (const [bucket, entry] of buckets) {
-    if (entry.generation > 0) {
-      weights.set(bucket, entry.generation);
-    }
-  }
-  return weights;
-}
-
-function addSharedGeneration(
-  buckets: Map<ActivityBucket, MutableBucket>,
-  bucket: ActivityBucket,
-  tokens: number,
-  sessions: SessionRow[],
-): void {
-  const entry = buckets.get(bucket);
-  if (entry == null || tokens <= 0) {
-    return;
-  }
-  entry.generation += tokens;
-  for (const session of sessions) {
-    entry.sessions.add(session.id);
-  }
-}
-
-function addSharedWindow(
-  buckets: Map<ActivityBucket, MutableBucket>,
-  bucket: ActivityBucket,
-  tokens: number,
-  sessions: SessionRow[],
-): void {
-  const entry = buckets.get(bucket);
-  if (entry == null || tokens <= 0) {
-    return;
-  }
-  entry.contextWindow += tokens;
-  for (const session of sessions) {
-    entry.sessions.add(session.id);
-  }
-}
-
-function sumWeights(weights: Map<ActivityBucket, number>): number {
-  let total = 0;
-  for (const value of weights.values()) {
-    total += value;
-  }
-  return total;
-}
 
 /** First-edit boundary per session: the message seq of the first file-editing
  * tool_use. Messages with seq < boundary are orientation; the edit's own
@@ -970,7 +816,6 @@ function finish(
   buckets: Map<ActivityBucket, MutableBucket>,
   inputCost: number,
   outputCost: number,
-  withPhases = false,
   waitingOnUserMs = 0,
 ): TokenEconomics {
   const totalCost = sumBuckets(buckets, "cost");
@@ -986,9 +831,7 @@ function finish(
       cost_share: share(entry?.cost ?? 0, totalCost),
       active_ms: Math.round(entry?.activeMs ?? 0),
     };
-    if (withPhases) {
-      row.phases = phasesFor(entry);
-    }
+    row.phases = phasesFor(entry);
     return row;
   });
   const activeMs = rows.reduce((sum, row) => sum + row.active_ms, 0);
@@ -1003,12 +846,10 @@ function finish(
     waiting_on_user_ms: waitingMs,
     attributed_ms: activeMs + waitingMs,
   };
-  if (withPhases) {
-    totals.phases = {
-      orientation: sumPhase(rows, "orientation"),
-      implementation: sumPhase(rows, "implementation"),
-    };
-  }
+  totals.phases = {
+    orientation: sumPhase(rows, "orientation"),
+    implementation: sumPhase(rows, "implementation"),
+  };
   return { buckets: rows, totals };
 }
 

--- a/src/token-economics.ts
+++ b/src/token-economics.ts
@@ -12,9 +12,9 @@ import { type DateFilter, sessionDatePredicate, whereClause } from "./date-filte
 const CHARS_PER_TOKEN = 4;
 const encoder = new TextEncoder();
 
-// A gap longer than this between two messages is the agent waiting on the human,
-// not working; cap it so idle time never inflates the activity latency. Mirrors
-// the ACTIVE_GAP_CAP_SECONDS used for session active_seconds in enrich.ts.
+// Cap every inter-message gap so long model, tool, or human pauses do not
+// dominate the timing breakdown. Mirrors the ACTIVE_GAP_CAP_SECONDS used for
+// session active_seconds in enrich.ts.
 const ACTIVE_GAP_CAP_MS = 300_000;
 
 /** A run splits into two phases at the first file edit: "orientation" (reading
@@ -43,6 +43,7 @@ export interface TokenEconomicsBucket {
   // sum of capped gaps between consecutive messages, charged to the activity
   // mix of the message that closed each gap (see allocateLatency). Answers
   // "how much *time* went to orientation/planning/etc.", not just tokens.
+  // User-authored response gaps are reported separately in totals.
   active_ms: number;
   // Present only from the ordered whole-archive path, which can place each
   // contribution before/after the first edit. Absent from the fast per-session
@@ -58,7 +59,12 @@ export interface TokenEconomics {
     estimated_cost_usd: number;
     input_cost_usd: number;
     output_cost_usd: number;
+    // Time attributed to the four agent activity buckets.
     active_ms: number;
+    // Capped gaps closed by user-authored text, kept separate from agent time.
+    waiting_on_user_ms: number;
+    // All timing captured from block-bearing messages: agent time plus waiting.
+    attributed_ms: number;
     phases?: Record<Phase, PhaseAmounts>;
   };
 }
@@ -123,6 +129,10 @@ interface MutableBucket {
   activeMsOrientation: number;
 }
 
+interface MutableLatency {
+  waitingOnUserMs: number;
+}
+
 type QueryParam = string | number;
 
 export interface SessionEconomicsVector {
@@ -130,6 +140,7 @@ export interface SessionEconomicsVector {
   started_at: string | null;
   input_cost: number;
   output_cost: number;
+  waiting_on_user_ms: number;
   buckets: Record<
     ActivityBucket,
     {
@@ -195,9 +206,11 @@ export function aggregateEconomicsVectors(
   const buckets = emptyBuckets();
   let inputCost = 0;
   let outputCost = 0;
+  let waitingOnUserMs = 0;
   for (const vector of vectors) {
     inputCost += vector.input_cost;
     outputCost += vector.output_cost;
+    waitingOnUserMs += vector.waiting_on_user_ms;
     for (const bucket of ACTIVITY_BUCKETS) {
       const entry = buckets.get(bucket);
       const part = vector.buckets[bucket];
@@ -235,11 +248,36 @@ export function aggregateEconomicsVectors(
       outputCost * share(entry.genOrientation, totalGeneration) +
       inputCost * share(entry.windowOrientation, windowBasis);
   }
-  return finish(buckets, inputCost, outputCost, true);
+  return finish(buckets, inputCost, outputCost, true, waitingOnUserMs);
 }
 
 export function tokenEconomicsForSession(db: Database, sessionId: number): TokenEconomics | null {
   return fastTokenEconomicsForSession(db, sessionId);
+}
+
+/** Load ordered block rows for generation and latency allocation. Tool-result
+ * blocks do not duplicate their calling tool metadata, so resolve it through
+ * the ingest-time tool_call linkage. */
+function blockRowsForScope(db: Database, scopeCte: string, params: QueryParam[]): BlockRow[] {
+  return db
+    .query(
+      `${scopeCte}
+       SELECT b.session_id, b.message_id, m.seq AS seq, m.role, m.output_tokens, b.type,
+              COALESCE(b.tool_name, tc.tool_name) AS tool_name,
+              m.timestamp AS timestamp,
+              CASE WHEN b.type IN ('tool_use', 'tool_result', 'web_search')
+                   THEN COALESCE(b.tool_input, tc.input) END AS tool_input,
+              CASE WHEN b.type = 'tool_result'
+                   THEN COALESCE(length(CAST(b.tool_result AS BLOB)), 0)
+                   ELSE COALESCE(length(CAST(b.text AS BLOB)), 0)
+              END AS text_bytes
+       FROM block b
+       JOIN message m ON m.id = b.message_id
+       JOIN scoped_session fs ON fs.id = b.session_id
+       LEFT JOIN tool_call tc ON tc.result_block_id = b.id
+       ORDER BY b.session_id, m.seq, b.ordinal`,
+    )
+    .all(...params) as BlockRow[];
 }
 
 function vectorsForScope(
@@ -261,36 +299,30 @@ function vectorsForScope(
     return [];
   }
 
-  const vectorBySession = new Map<number, { session: SessionRow; buckets: PerSessionBuckets }>();
+  const vectorBySession = new Map<
+    number,
+    { session: SessionRow; buckets: PerSessionBuckets; latency: MutableLatency }
+  >();
   for (const session of sessions) {
-    vectorBySession.set(session.id, { session, buckets: emptyBuckets() });
+    vectorBySession.set(session.id, {
+      session,
+      buckets: emptyBuckets(),
+      latency: emptyLatency(),
+    });
   }
 
   // Ship byte lengths, not text: bucket math only needs sizes, plus the tool
   // input for the block types whose bucket depends on the command being run.
   // Ordering (session, seq, ordinal) lets us place each block before/after the
   // session's first file edit.
-  const blocks = db
-    .query(
-      `${scopeCte}
-       SELECT b.session_id, b.message_id, m.seq AS seq, m.role, m.output_tokens, b.type,
-              b.tool_name, m.timestamp AS timestamp,
-              CASE WHEN b.type IN ('tool_use', 'tool_result', 'web_search')
-                   THEN b.tool_input END AS tool_input,
-              COALESCE(length(CAST(b.text AS BLOB)), 0) AS text_bytes
-       FROM block b
-       JOIN message m ON m.id = b.message_id
-       JOIN scoped_session fs ON fs.id = b.session_id
-       ORDER BY b.session_id, m.seq, b.ordinal`,
-    )
-    .all(...params) as BlockRow[];
+  const blocks = blockRowsForScope(db, scopeCte, params);
   const boundaries = firstEditSeqBySession(blocks);
   const blocksBySession = groupBy(blocks, (block) => block.session_id);
   for (const [sessionId, sessionBlocks] of blocksBySession) {
     const vector = vectorBySession.get(sessionId);
     if (vector != null) {
       allocateGeneration([vector.session], sessionBlocks, vector.buckets, boundaries);
-      allocateLatency(sessionId, sessionBlocks, vector.buckets, boundaries);
+      allocateLatency(sessionId, sessionBlocks, vector.buckets, boundaries, vector.latency);
     }
   }
   for (const vector of vectorBySession.values()) {
@@ -362,6 +394,7 @@ function vectorsForScope(
       started_at: session.started_at,
       input_cost: parts.input + parts.cacheRead + parts.cacheCreation,
       output_cost: parts.output,
+      waiting_on_user_ms: mutable?.latency.waitingOnUserMs ?? 0,
       buckets,
     };
   });
@@ -392,6 +425,7 @@ function fastTokenEconomicsForSession(db: Database, sessionId: number): TokenEco
   }
 
   const buckets = emptyBuckets();
+  const latency = emptyLatency();
   const toolRows = db
     .query(
       `${scopeCte}
@@ -452,26 +486,12 @@ function fastTokenEconomicsForSession(db: Database, sessionId: number): TokenEco
     entry.contextWindow += entry.generation;
   }
 
-  // Wall-clock time per activity. The fast path has no first-edit ordering, so
-  // it emits no phase split (empty boundaries -> everything implementation),
-  // but a single session's ordered blocks are cheap to scan for gap timing.
-  const latencyBlocks = db
-    .query(
-      `${scopeCte}
-       SELECT b.session_id, b.message_id, m.seq AS seq, m.role, m.output_tokens, b.type,
-              b.tool_name, m.timestamp AS timestamp,
-              CASE WHEN b.type IN ('tool_use', 'tool_result', 'web_search')
-                   THEN b.tool_input END AS tool_input,
-              COALESCE(length(CAST(b.text AS BLOB)), 0) AS text_bytes
-       FROM block b
-       JOIN message m ON m.id = b.message_id
-       JOIN scoped_session fs ON fs.id = b.session_id
-       ORDER BY b.session_id, m.seq, b.ordinal`,
-    )
-    .all(sessionId) as BlockRow[];
+  // Wall-clock time per activity. The fast path omits phase output; empty
+  // boundaries classify its ordered rows as orientation only internally.
+  const latencyBlocks = blockRowsForScope(db, scopeCte, [sessionId]);
   const noBoundaries = new Map<number, number>();
   for (const [id, sessionBlocks] of groupBy(latencyBlocks, (block) => block.session_id)) {
-    allocateLatency(id, sessionBlocks, buckets, noBoundaries);
+    allocateLatency(id, sessionBlocks, buckets, noBoundaries, latency);
   }
 
   const totalGeneration = sumBuckets(buckets, "generation");
@@ -482,7 +502,7 @@ function fastTokenEconomicsForSession(db: Database, sessionId: number): TokenEco
       inputCost * share(entry.contextWindow, totalWindow);
   }
   // No ordering on the fast path, so it emits no phase split (withPhases=false).
-  return finish(buckets, inputCost, outputCost);
+  return finish(buckets, inputCost, outputCost, false, latency.waitingOnUserMs);
 }
 
 function distributeByWeights(
@@ -668,16 +688,17 @@ function allocateGeneration(
 }
 
 /** Charge wall-clock time to activity buckets. The gap between a message and
- * the one before it is the time that produced the later message -- the model
- * generating (its thinking/text/tool_use blocks) or a tool executing (the
- * tool_result block in the following user message). Each gap is capped like
- * session active_seconds, then split across the closing message's blocks by the
- * same byte-weight generation uses, so a bucket's time and its tokens line up. */
+ * the one before it is the time that produced the later message: the model
+ * generating, a tool executing, or the human writing the next prompt. Each gap
+ * is capped like session active_seconds, then split across the closing
+ * message's blocks by the same byte weight generation uses. Blockless messages
+ * are absent here, so attributed time only approximates active_seconds. */
 function allocateLatency(
   sessionId: number,
   blocks: BlockRow[],
   buckets: Map<ActivityBucket, MutableBucket>,
   boundaries: Map<number, number>,
+  latency: MutableLatency,
 ): void {
   let previous: number | null = null;
   for (const message of orderedMessages(blocks)) {
@@ -687,7 +708,13 @@ function allocateLatency(
     }
     if (previous != null) {
       const gap = Math.min(Math.max(0, at - previous), ACTIVE_GAP_CAP_MS);
-      distributeLatency(gap, message.blocks, buckets, phaseOf(boundaries, sessionId, message.seq));
+      distributeLatency(
+        gap,
+        message.blocks,
+        buckets,
+        phaseOf(boundaries, sessionId, message.seq),
+        latency,
+      );
     }
     previous = at;
   }
@@ -721,6 +748,7 @@ function distributeLatency(
   blocks: BlockRow[],
   buckets: Map<ActivityBucket, MutableBucket>,
   phase: Phase,
+  latency: MutableLatency,
 ): void {
   if (ms <= 0 || blocks.length === 0) {
     return;
@@ -728,10 +756,15 @@ function distributeLatency(
   const weighted = blocks.map((block) => ({ block, weight: Math.max(1, blockSize(block)) }));
   const totalWeight = weighted.reduce((sum, item) => sum + item.weight, 0);
   for (const item of weighted) {
+    const shareMs = ms * (item.weight / totalWeight);
+    if (item.block.role === "user" && item.block.type === "text") {
+      latency.waitingOnUserMs += shareMs;
+      continue;
+    }
     addLatency(
       buckets,
       blockBucket(item.block.type, item.block.tool_name, item.block.tool_input),
-      ms * (item.weight / totalWeight),
+      shareMs,
       phase,
     );
   }
@@ -904,6 +937,10 @@ function emptyBuckets(): Map<ActivityBucket, MutableBucket> {
   );
 }
 
+function emptyLatency(): MutableLatency {
+  return { waitingOnUserMs: 0 };
+}
+
 function phasesFor(entry: MutableBucket | undefined): Record<Phase, PhaseAmounts> {
   const gen = entry?.generation ?? 0;
   const win = entry?.contextWindow ?? 0;
@@ -934,6 +971,7 @@ function finish(
   inputCost: number,
   outputCost: number,
   withPhases = false,
+  waitingOnUserMs = 0,
 ): TokenEconomics {
   const totalCost = sumBuckets(buckets, "cost");
   const rows: TokenEconomicsBucket[] = ACTIVITY_BUCKETS.map((bucket) => {
@@ -953,13 +991,17 @@ function finish(
     }
     return row;
   });
+  const activeMs = rows.reduce((sum, row) => sum + row.active_ms, 0);
+  const waitingMs = Math.round(waitingOnUserMs);
   const totals: TokenEconomics["totals"] = {
     generation_tokens: rows.reduce((sum, row) => sum + row.generation_tokens, 0),
     context_window_tokens: rows.reduce((sum, row) => sum + row.context_window_tokens, 0),
     estimated_cost_usd: totalCost,
     input_cost_usd: inputCost,
     output_cost_usd: outputCost,
-    active_ms: rows.reduce((sum, row) => sum + row.active_ms, 0),
+    active_ms: activeMs,
+    waiting_on_user_ms: waitingMs,
+    attributed_ms: activeMs + waitingMs,
   };
   if (withPhases) {
     totals.phases = {

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -137,6 +137,8 @@ type TokenEconomics = {
     input_cost_usd: number;
     output_cost_usd: number;
     active_ms: number;
+    waiting_on_user_ms: number;
+    attributed_ms: number;
   };
 };
 
@@ -1960,7 +1962,7 @@ function ActivityPanel({ activity }: { activity: Activity | null }) {
 
 function TokenEconomicsPanel({
   compact: isCompact = false,
-  description = "Estimated tokens and cost by planning, communicating, context, and code",
+  description = "Estimated tokens, cost, and agent time by activity; capped user response time is shown separately.",
   economics,
   title = "Activity breakdown",
 }: {
@@ -1992,7 +1994,11 @@ function TokenEconomicsPanel({
             </span>
             <span>
               <strong>{duration(economics.totals.active_ms)}</strong>
-              time
+              agent time
+            </span>
+            <span>
+              <strong>{duration(economics.totals.waiting_on_user_ms)}</strong>
+              waiting
             </span>
           </div>
         ) : null}
@@ -4092,7 +4098,7 @@ function SessionDetailView({ id }: { id: number }) {
       {economics != null ? (
         <TokenEconomicsPanel
           compact
-          description="Estimated activity inside this session, including nested subagents."
+          description="Estimated agent activity inside this session, including nested subagents; capped user response time is shown separately."
           economics={economics}
           title="Activity breakdown"
         />

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -1964,16 +1964,19 @@ function TokenEconomicsPanel({
   compact: isCompact = false,
   description = "Estimated tokens, cost, and agent time by activity; capped user response time is shown separately.",
   economics,
+  subagentRuns = 0,
   title = "Activity breakdown",
 }: {
   compact?: boolean;
   description?: string;
   economics: TokenEconomics | null;
+  subagentRuns?: number;
   title?: string;
 }) {
   const buckets = economics?.buckets ?? [];
   const totalCost = economics?.totals.estimated_cost_usd ?? 0;
   const totalActiveMs = economics?.totals.active_ms ?? 0;
+  const showAgentRuns = !isCompact;
   return (
     <section className={`panel token-economics-panel${isCompact ? " is-compact" : ""}`}>
       <div className="panel-heading">
@@ -1999,6 +2002,12 @@ function TokenEconomicsPanel({
               <strong>{duration(economics.totals.waiting_on_user_ms)}</strong>
               waiting
             </span>
+            {isCompact && subagentRuns > 0 ? (
+              <span>
+                <strong>1 root + {formatInt(subagentRuns)}</strong>
+                {subagentRuns === 1 ? "subagent" : "subagents"}
+              </span>
+            ) : null}
           </div>
         ) : null}
       </div>
@@ -2021,7 +2030,7 @@ function TokenEconomicsPanel({
               <col className="col-activity-number" />
               <col className="col-activity-number" />
               <col className="col-activity-number" />
-              <col className="col-activity-number" />
+              {showAgentRuns ? <col className="col-activity-number" /> : null}
             </colgroup>
             <thead>
               <tr className="activity-table-head">
@@ -2040,11 +2049,13 @@ function TokenEconomicsPanel({
                 <th className="numeric activity-number" scope="col">
                   Window
                 </th>
-                <th className="numeric activity-number" scope="col">
-                  <span title="Root sessions and nested subagent runs contributing to this activity">
-                    Agent runs
-                  </span>
-                </th>
+                {showAgentRuns ? (
+                  <th className="numeric activity-number" scope="col">
+                    <span title="Root sessions and nested subagent runs contributing to this activity">
+                      Agent runs
+                    </span>
+                  </th>
+                ) : null}
               </tr>
             </thead>
             <tbody>
@@ -2101,9 +2112,11 @@ function TokenEconomicsPanel({
                         <td className="numeric muted activity-number">
                           {compact(bucket.context_window_tokens)}
                         </td>
-                        <td className="numeric muted activity-number">
-                          {formatInt(bucket.sessions)}
-                        </td>
+                        {showAgentRuns ? (
+                          <td className="numeric muted activity-number">
+                            {formatInt(bucket.sessions)}
+                          </td>
+                        ) : null}
                       </tr>
                     )}
                   </Tooltip>
@@ -4069,6 +4082,7 @@ function SessionDetailView({ id }: { id: number }) {
   const toc = threadToc(messages);
   const stats = threadStats(detail.summary, messages, toc);
   const subagentsByToolUse = subagentMap(detail.subagents);
+  const subagentRuns = countSubagentRuns(detail.subagents);
 
   return (
     <div className="session-detail">
@@ -4115,6 +4129,7 @@ function SessionDetailView({ id }: { id: number }) {
           compact
           description="Estimated agent activity inside this session, including nested subagents; capped user response time is shown separately."
           economics={economics}
+          subagentRuns={subagentRuns}
           title="Activity breakdown"
         />
       ) : null}
@@ -4523,6 +4538,13 @@ function subagentMap(subagents: SubagentDetailData[]): Map<string, SubagentDetai
     }
   }
   return map;
+}
+
+function countSubagentRuns(subagents: SubagentDetailData[]): number {
+  return subagents.reduce(
+    (total, subagent) => total + 1 + countSubagentRuns(subagent.subagents),
+    0,
+  );
 }
 
 function renderableMessages(

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -117,7 +117,7 @@ type NowView = {
   sync_in_progress: boolean;
 };
 
-type ActivityBucket = "planning" | "communicating" | "context" | "code";
+type ActivityBucket = "context" | "planning" | "code" | "communicating";
 
 type TokenEconomics = {
   buckets: {

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -1971,9 +1971,7 @@ function TokenEconomicsPanel({
   economics: TokenEconomics | null;
   title?: string;
 }) {
-  const buckets = (economics?.buckets ?? [])
-    .slice()
-    .sort((left, right) => right.estimated_cost_usd - left.estimated_cost_usd);
+  const buckets = economics?.buckets ?? [];
   const totalCost = economics?.totals.estimated_cost_usd ?? 0;
   const totalActiveMs = economics?.totals.active_ms ?? 0;
   return (
@@ -2019,6 +2017,7 @@ function TokenEconomicsPanel({
               <col className="col-activity" />
               <col className="col-share" />
               <col className="col-activity-number" />
+              <col className="col-share" />
               <col className="col-activity-number" />
               <col className="col-activity-number" />
               <col className="col-activity-number" />
@@ -2031,6 +2030,7 @@ function TokenEconomicsPanel({
                 <th className="numeric activity-number" scope="col">
                   Cost
                 </th>
+                <th scope="col">Time spent</th>
                 <th className="numeric activity-number" scope="col">
                   Time
                 </th>
@@ -2081,8 +2081,19 @@ function TokenEconomicsPanel({
                         <td className="numeric activity-number">
                           {money(bucket.estimated_cost_usd)}
                         </td>
+                        <td className="activity-share">
+                          <span className="activity-share-inner">
+                            <span className="activity-bar">
+                              <span
+                                className={`tone-${tone}`}
+                                style={{ width: `${timeShare * 100}%` }}
+                              />
+                            </span>
+                            <small>{Math.round(timeShare * 100)}%</small>
+                          </span>
+                        </td>
                         <td className="numeric muted activity-number">
-                          {duration(bucket.active_ms)} · {Math.round(timeShare * 100)}%
+                          {duration(bucket.active_ms)}
                         </td>
                         <td className="numeric muted activity-number">
                           {compact(bucket.generation_tokens)}
@@ -4273,7 +4284,7 @@ function SessionDetailSkeleton() {
         </div>
         <div className="activity-table-wrap">
           <div className="skeleton-table">
-            {["context", "planning", "communicating", "code"].map((key) => (
+            {["context", "planning", "code", "communicating"].map((key) => (
               <span className="skeleton-line" key={key} />
             ))}
           </div>

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -1975,6 +1975,7 @@ function TokenEconomicsPanel({
     .slice()
     .sort((left, right) => right.estimated_cost_usd - left.estimated_cost_usd);
   const totalCost = economics?.totals.estimated_cost_usd ?? 0;
+  const totalActiveMs = economics?.totals.active_ms ?? 0;
   return (
     <section className={`panel token-economics-panel${isCompact ? " is-compact" : ""}`}>
       <div className="panel-heading">
@@ -2040,7 +2041,9 @@ function TokenEconomicsPanel({
                   Window
                 </th>
                 <th className="numeric activity-number" scope="col">
-                  Sessions
+                  <span title="Root sessions and nested subagent runs contributing to this activity">
+                    Agent runs
+                  </span>
                 </th>
               </tr>
             </thead>
@@ -2048,6 +2051,7 @@ function TokenEconomicsPanel({
               {buckets.map((bucket) => {
                 const tone = activityTone(bucket.bucket);
                 const share = Math.max(0, Math.min(1, bucket.cost_share));
+                const timeShare = totalActiveMs > 0 ? bucket.active_ms / totalActiveMs : 0;
                 return (
                   <Tooltip content={activityDescription(bucket.bucket)} key={bucket.bucket}>
                     {(tooltipProps) => (
@@ -2078,7 +2082,7 @@ function TokenEconomicsPanel({
                           {money(bucket.estimated_cost_usd)}
                         </td>
                         <td className="numeric muted activity-number">
-                          {duration(bucket.active_ms)}
+                          {duration(bucket.active_ms)} · {Math.round(timeShare * 100)}%
                         </td>
                         <td className="numeric muted activity-number">
                           {compact(bucket.generation_tokens)}

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1454,7 +1454,7 @@ mark {
 }
 
 .token-economics-panel.is-compact .activity-table {
-  min-width: max(100%, 1040px);
+  min-width: max(100%, 960px);
   font-size: 12px;
 }
 
@@ -1468,6 +1468,18 @@ mark {
 
 .activity-table .col-activity-number {
   width: 9%;
+}
+
+.token-economics-panel.is-compact .activity-table .col-activity {
+  width: 18%;
+}
+
+.token-economics-panel.is-compact .activity-table .col-share {
+  width: 22%;
+}
+
+.token-economics-panel.is-compact .activity-table .col-activity-number {
+  width: 9.5%;
 }
 
 .activity-table th,

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1448,26 +1448,26 @@ mark {
 }
 
 .activity-table {
-  min-width: 760px;
+  min-width: 1040px;
   table-layout: fixed;
   font-size: 13px;
 }
 
 .token-economics-panel.is-compact .activity-table {
-  min-width: 100%;
+  min-width: max(100%, 1040px);
   font-size: 12px;
 }
 
 .activity-table .col-activity {
-  width: 20%;
+  width: 17%;
 }
 
 .activity-table .col-share {
-  width: 30%;
+  width: 19%;
 }
 
 .activity-table .col-activity-number {
-  width: 12.5%;
+  width: 9%;
 }
 
 .activity-table th,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -104,8 +104,15 @@ describe("runCli", () => {
       buckets: expect.arrayContaining([
         expect.objectContaining({ bucket: "context", active_ms: expect.any(Number) }),
       ]),
-      totals: expect.objectContaining({ active_ms: expect.any(Number) }),
+      totals: expect.objectContaining({
+        active_ms: expect.any(Number),
+        waiting_on_user_ms: expect.any(Number),
+        attributed_ms: expect.any(Number),
+      }),
     });
+    const humanTokens = await runCli(["--db", dbPath, "--no-sync", "tokens"]);
+    expect(humanTokens).toMatchObject({ code: 0, stderr: "" });
+    expect(humanTokens.stdout).toContain("waiting_on_user\t-\t-\t-");
 
     const search = await runCli([...base, "search", "auth", "--limit", "5"]);
     expect(search.code).toBe(0);

--- a/test/token-economics.test.ts
+++ b/test/token-economics.test.ts
@@ -129,8 +129,9 @@ describe("token economics", () => {
     );
 
     const economics = tokenEconomics(db);
-    // Total attributed time equals the session's active_seconds (both are the
-    // sum of the same capped inter-message gaps), within rounding.
+    // This synthetic fixture has one blockless system message. The four agent
+    // buckets plus explicit user wait approximately reconcile to the broader
+    // active_seconds chain, within rounding.
     const activeSeconds = (
       db.query("SELECT active_seconds FROM session WHERE id = ?1").get(sessionId) as {
         active_seconds: number;
@@ -138,7 +139,11 @@ describe("token economics", () => {
     ).active_seconds;
     expect(activeSeconds).toBeGreaterThan(0);
     expect(economics.totals.active_ms).toBeGreaterThan(0);
-    expect(economics.totals.active_ms).toBeCloseTo(activeSeconds * 1000, -2);
+    expect(economics.totals.waiting_on_user_ms).toBe(330_000);
+    expect(economics.totals.attributed_ms).toBeCloseTo(activeSeconds * 1000, -2);
+    // The fixture spends 30s generating mutating tool calls and 30s executing
+    // an Edit result; both portions belong to code.
+    expect(economics.buckets.find((row) => row.bucket === "code")?.active_ms).toBe(60_000);
 
     // Buckets' time sums to the total, and each bucket's phase split sums back
     // to the bucket (rounding can drift the two rounded halves by <=1ms).
@@ -165,29 +170,38 @@ describe("token economics", () => {
     // and its total matches the aggregate for the same session.
     const scoped = tokenEconomicsForSession(db, sessionId);
     expect(scoped?.totals.active_ms).toBe(economics.totals.active_ms);
+    expect(scoped?.totals.waiting_on_user_ms).toBe(economics.totals.waiting_on_user_ms);
+    expect(scoped?.totals.attributed_ms).toBe(economics.totals.attributed_ms);
+    expect(scoped?.buckets.find((row) => row.bucket === "code")?.active_ms).toBe(60_000);
     expect(scoped?.buckets.every((row) => row.phases === undefined)).toBe(true);
     db.close();
   });
 
-  test("caps idle gaps so waiting on the human never inflates activity time", () => {
+  test("caps waiting on the user and keeps it out of agent activity", () => {
     const db = freshDb();
-    // Two assistant turns an hour apart: the raw gap is 3600s but a single
-    // capped gap can contribute at most 300s of attributed time.
+    // A blockless system message splits the raw 3600s gap for active_seconds,
+    // while block-based attribution sees one gap capped at 300s.
     const content = [
       JSON.stringify({
-        type: "user",
-        timestamp: "2026-05-06T09:00:00.000Z",
-        message: { role: "user", content: [{ type: "text", text: "start" }] },
-      }),
-      JSON.stringify({
         type: "assistant",
-        timestamp: "2026-05-06T10:00:00.000Z",
+        timestamp: "2026-05-06T09:00:00.000Z",
         message: {
           role: "assistant",
           model: "claude-opus-4-7",
           usage: { input_tokens: 10, output_tokens: 5 },
-          content: [{ type: "text", text: "done thinking after a long human pause" }],
+          content: [{ type: "text", text: "Ready for your response." }],
         },
+      }),
+      JSON.stringify({
+        type: "system",
+        timestamp: "2026-05-06T09:04:10.000Z",
+        subtype: "compact_boundary",
+        content: "Conversation compacted",
+      }),
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-05-06T10:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "Continue." }] },
       }),
     ].join("\n");
     upsertSession(
@@ -200,7 +214,65 @@ describe("token economics", () => {
     );
 
     const economics = tokenEconomics(db);
-    expect(economics.totals.active_ms).toBe(300_000);
+    expect(economics.totals.active_ms).toBe(0);
+    expect(economics.totals.waiting_on_user_ms).toBe(300_000);
+    expect(economics.totals.attributed_ms).toBe(300_000);
+    const activeSeconds = (
+      db.query("SELECT active_seconds FROM session").get() as { active_seconds: number }
+    ).active_seconds;
+    expect(economics.totals.attributed_ms).toBeLessThan(activeSeconds * 1000);
+    db.close();
+  });
+
+  test("weights mixed tool results and user text by their actual bytes", () => {
+    const db = freshDb();
+    const content = [
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-05-06T09:00:00.000Z",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-7",
+          usage: { input_tokens: 10, output_tokens: 5 },
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_edit",
+              name: "Edit",
+              input: { file_path: "/x/a.ts", old_string: "a", new_string: "b" },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-05-06T09:00:10.000Z",
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_edit", content: "123456789" },
+            { type: "text", text: "x" },
+          ],
+        },
+      }),
+    ].join("\n");
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("sess-mixed-result", `${content}\n`),
+      "/x/mixed-result.jsonl",
+      1,
+      2,
+      "mixed-result",
+    );
+
+    const economics = tokenEconomics(db);
+    expect(economics.buckets.find((row) => row.bucket === "code")?.active_ms).toBe(9_000);
+    expect(economics.totals.waiting_on_user_ms).toBe(1_000);
+    expect(economics.totals.attributed_ms).toBe(10_000);
+
+    const scoped = tokenEconomicsForSession(db, sessionId);
+    expect(scoped?.buckets.find((row) => row.bucket === "code")?.active_ms).toBe(9_000);
+    expect(scoped?.totals.waiting_on_user_ms).toBe(1_000);
     db.close();
   });
 
@@ -227,6 +299,8 @@ describe("token economics", () => {
       tool_calls: 1,
       sessions: 1,
     });
+    expect(aggregate.buckets.find((row) => row.bucket === "code")?.active_ms).toBe(3_000);
+    expect(aggregate.buckets.find((row) => row.bucket === "context")?.active_ms).toBe(2_000);
 
     const scoped = tokenEconomicsForSession(db, sessionId);
     expect(scoped?.buckets.find((row) => row.bucket === "code")).toMatchObject({
@@ -237,6 +311,8 @@ describe("token economics", () => {
       tool_calls: 1,
       sessions: 1,
     });
+    expect(scoped?.buckets.find((row) => row.bucket === "code")?.active_ms).toBe(3_000);
+    expect(scoped?.buckets.find((row) => row.bucket === "context")?.active_ms).toBe(2_000);
     db.close();
   });
 
@@ -323,12 +399,16 @@ describe("token economics", () => {
     const aggregateCode = tokenEconomics(db).buckets.find((row) => row.bucket === "code");
     expect(aggregateCode).toMatchObject({ tool_calls: 1, sessions: 1 });
     expect(aggregateCode?.generation_tokens).toBeGreaterThan(0);
+    // One second generated the call and one second executed it. The latter is
+    // resolved through tool_call.result_block_id rather than defaulting to context.
+    expect(aggregateCode?.active_ms).toBe(2_000);
 
-    const scopedCode = tokenEconomicsForSession(db, sessionId)?.buckets.find(
-      (row) => row.bucket === "code",
-    );
+    const scopedEconomics = tokenEconomicsForSession(db, sessionId);
+    const scopedCode = scopedEconomics?.buckets.find((row) => row.bucket === "code");
     expect(scopedCode).toMatchObject({ tool_calls: 1, sessions: 1 });
     expect(scopedCode?.generation_tokens).toBeGreaterThan(0);
+    expect(scopedCode?.active_ms).toBe(2_000);
+
     db.close();
   });
 

--- a/test/token-economics.test.ts
+++ b/test/token-economics.test.ts
@@ -110,10 +110,27 @@ describe("token economics", () => {
     const context = economics.buckets.find((row) => row.bucket === "context");
     expect(context?.phases?.orientation.context_window_tokens).toBeGreaterThan(0);
 
-    // The fast per-session path cannot order turns, so it omits the phase split.
+    // The per-session path uses the same ordered allocator while retaining its
+    // billed-input Window total.
     const scoped = tokenEconomicsForSession(db, sessionId);
-    expect(scoped?.buckets.every((row) => row.phases === undefined)).toBe(true);
-    expect(scoped?.totals.phases).toBeUndefined();
+    expect(scoped?.totals.generation_tokens).toBe(economics.totals.generation_tokens);
+    const billedInput = (
+      db
+        .query(
+          `SELECT total_input_tokens + total_cache_read_tokens + total_cache_creation_tokens AS tokens
+           FROM session WHERE id = ?1`,
+        )
+        .get(sessionId) as { tokens: number }
+    ).tokens;
+    expect(
+      Math.abs(
+        (scoped?.totals.context_window_tokens ?? 0) -
+          economics.totals.context_window_tokens -
+          billedInput,
+      ),
+    ).toBeLessThanOrEqual(2);
+    expect(scoped?.totals.estimated_cost_usd).toBe(economics.totals.estimated_cost_usd);
+    expect(scoped?.buckets.every((row) => row.phases !== undefined)).toBe(true);
     db.close();
   });
 
@@ -165,15 +182,18 @@ describe("token economics", () => {
     expect(
       economics.buckets.find((row) => row.bucket === "code")?.phases?.orientation.active_ms,
     ).toBe(0);
-
-    // The fast per-session path has no phase ordering but still reports time,
-    // and its total matches the aggregate for the same session.
+    // The scoped result uses the same block-level allocation for generated
+    // messages and time, while allocating the full billed input window.
     const scoped = tokenEconomicsForSession(db, sessionId);
     expect(scoped?.totals.active_ms).toBe(economics.totals.active_ms);
     expect(scoped?.totals.waiting_on_user_ms).toBe(economics.totals.waiting_on_user_ms);
     expect(scoped?.totals.attributed_ms).toBe(economics.totals.attributed_ms);
     expect(scoped?.buckets.find((row) => row.bucket === "code")?.active_ms).toBe(60_000);
-    expect(scoped?.buckets.every((row) => row.phases === undefined)).toBe(true);
+    const communicating = scoped?.buckets.find((row) => row.bucket === "communicating");
+    expect(communicating?.active_ms).toBeGreaterThan(0);
+    expect(communicating?.generation_tokens).toBeGreaterThan(0);
+    expect(communicating?.estimated_cost_usd).toBeGreaterThan(0);
+    expect(communicating?.sessions).toBe(1);
     db.close();
   });
 
@@ -221,6 +241,48 @@ describe("token economics", () => {
       db.query("SELECT active_seconds FROM session").get() as { active_seconds: number }
     ).active_seconds;
     expect(economics.totals.attributed_ms).toBeLessThan(activeSeconds * 1000);
+    db.close();
+  });
+
+  test("counts an agent run when it contributes only wall-clock activity", () => {
+    const db = freshDb();
+    const content = [
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-05-06T09:00:00.000Z",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-7",
+          usage: { input_tokens: 0, output_tokens: 0 },
+          content: [{ type: "text", text: "Starting." }],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-05-06T09:00:10.000Z",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-7",
+          usage: { input_tokens: 0, output_tokens: 0 },
+          content: [{ type: "text", text: "Done." }],
+        },
+      }),
+    ].join("\n");
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("sess-time-only", `${content}\n`),
+      "/x/time-only.jsonl",
+      1,
+      2,
+      "time-only",
+    );
+
+    const economics = tokenEconomicsForSession(db, sessionId);
+    expect(economics?.buckets.find((row) => row.bucket === "communicating")).toMatchObject({
+      active_ms: 10_000,
+      generation_tokens: 0,
+      sessions: 1,
+    });
     db.close();
   });
 

--- a/test/token-economics.test.ts
+++ b/test/token-economics.test.ts
@@ -50,10 +50,10 @@ describe("token economics", () => {
 
     const economics = tokenEconomics(db);
     expect(economics.buckets.map((row) => row.bucket)).toEqual([
-      "planning",
-      "communicating",
       "context",
+      "planning",
       "code",
+      "communicating",
     ]);
     expect(economics.totals.generation_tokens).toBeGreaterThan(0);
     expect(economics.totals.context_window_tokens).toBeGreaterThan(


### PR DESCRIPTION
## Summary

- resolve tool-result latency through the existing `tool_call.result_block_id` linkage so edit, build, and test execution time reaches the correct activity bucket
- separate capped user response gaps from agent communication time as `waiting_on_user_ms`
- use ordered block-level allocation for session panels so assistant prose receives generated tokens and cost even when the run also uses tools
- preserve the session panel's billed-input Window total while distributing it with the corrected activity weights
- keep activity rows in the canonical Context, Planning, Code, Communicating order across API, CLI, and UI output
- split time into a Time spent share bar and a separate Time value, mirroring Cost share and Cost
- retain Agent runs as an archive-wide contributor metric, remove the redundant per-session column, and summarize root/subagent runs once in the session header when nested agents exist
- centralize the ordered block query and clarify that blockless messages can make attribution differ from `active_seconds`

## Root cause

Parsed `tool_result` blocks intentionally do not duplicate the calling tool name or input. The latency allocator classified those blocks directly, so every tool execution fell through to `context`, including mutating edits and build/test commands. User-authored prompt gaps also closed on text blocks and were silently included in `communicating`.

The session-specific economics shortcut also distributed all non-reasoning output by tool-call counts. Once a session used a tool, assistant prose could show communication time but receive no generated tokens, cost, or contributing-run count.

## Impact

The activity breakdown now reports agent communication independently from time waiting on the user, linked tool executions use the same context/code classifier as their calls, and session-level messages receive their share of tokens and cost. The table order is stable rather than cost-ranked, and cost and time now use parallel share/value columns. Session tables stay focused on activity metrics; nested-agent participation appears only when it adds information. Existing archives require no migration or rebuild.

## Review follow-up

The pre-publish merge-gate review found two additional edges:

- mixed user messages containing both text and tool results need tool-result byte weights from `b.tool_result`, not the null `b.text` field
- directly swapping the session allocator changed the meaning of Window from billed input volume to content footprint, so session vectors now retain billed input and distribute it with the corrected block weights

Both paths have focused regressions, including read-only tool execution and time-only Agent runs.

## Validation

- `just check`
  - 252 tests passed
  - `bunx tsc --noEmit`
  - `bunx biome check .`
  - native distribution staging smoke
- browser smoke against a temporary archive copy
  - ordinary session: seven activity columns with no redundant Agent runs value
  - nested-agent session: `1 root + 1 subagent` in the panel header with the same seven activity columns
  - canonical activity order and paired cost/time share bars preserved
