### PR TITLE
feat: persist session economics at ingest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,10 +76,10 @@ A change is ready when:
 4. **Costs are computed at ingest** with `cost::estimateCost` and stored on the
    session row. Editing pricing does not rewrite historical rows; rebuild the
    archive to recompute.
-5. **The schema baseline is v9.** Pre-v8 archives are intentionally rebuild-only:
+5. **The schema baseline is v10.** Pre-v8 archives are intentionally rebuild-only:
    delete the archive and re-ingest from the source directories. Do not add
    broad forward migrations unless that product decision changes; the narrow
-   v8-to-v9 migration preserves existing TypeScript-cutover archives.
+   v8-to-v10 migrations preserve existing TypeScript-cutover archives.
 6. **Parsers are the extension point.** A new source tool means
    `src/sources/<tool>.ts`, synthetic fixtures, parser tests, ingest/query tests,
    and golden updates.

--- a/README.md
+++ b/README.md
@@ -101,9 +101,10 @@ Claude `stream-json` logs; pass `--path` more than once to ingest multiple paths
 `decant serve` binds `127.0.0.1:3000` by default. Override with
 `--host`/`--port`.
 
-Archives older than schema v8 are rebuild-only. v8 archives migrate to v9 on
-open; older archives should be deleted and rebuilt with `decant sync`. Source
-logs remain the source of truth.
+Archives older than schema v8 are rebuild-only. v8 and v9 archives migrate to
+v10 on open; the next `decant sync` backfills persisted economics vectors for
+unchanged sessions. Older archives should be deleted and rebuilt with
+`decant sync`. Source logs remain the source of truth.
 
 ## How It Works
 
@@ -112,7 +113,7 @@ logs remain the source of truth.
         |
         v
  Bun + TypeScript decant process
- parse -> enrich -> ingest -> SQLite WAL + FTS5
+ parse -> enrich -> ingest + economics vectors -> SQLite WAL + FTS5
         |
         +--> CLI reads / JSON
         +--> local React UI + JSON routes + SSE

--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -46,6 +46,10 @@ contract. By default, the server listens on `http://127.0.0.1:3000`.
 - `POST /api/launch/agent`
 - `POST /api/launch/ide`
 
+Session and archive token-economics routes aggregate versioned per-session
+vectors persisted during ingest. The first sync after a schema upgrade
+backfills vectors for unchanged sessions.
+
 ## Events
 
 - `GET /api/events` returns an SSE stream.

--- a/src/db.ts
+++ b/src/db.ts
@@ -5,7 +5,7 @@ import schemaSql from "./schema.sql" with { type: "text" };
 /// effective DDL with migrations 1..LATEST_SCHEMA_VERSION already applied
 /// and is now the frozen baseline, so a fresh archive is created in one step
 /// and stamped with the full migration history.
-export const LATEST_SCHEMA_VERSION = 9;
+export const LATEST_SCHEMA_VERSION = 10;
 
 /**
  * Open (or create) a decant archive and guarantee it is at
@@ -90,6 +90,19 @@ function migrate(db: Database, current: number): void {
       `);
       db.query(
         "INSERT INTO schema_migrations (version, applied_at) VALUES (9, datetime('now'))",
+      ).run();
+    }
+    if (current < 10) {
+      db.exec(`
+        CREATE TABLE session_economics (
+          session_id INTEGER PRIMARY KEY REFERENCES session(id) ON DELETE CASCADE,
+          format_version INTEGER NOT NULL,
+          vector_json TEXT NOT NULL,
+          computed_at TEXT NOT NULL
+        );
+      `);
+      db.query(
+        "INSERT INTO schema_migrations (version, applied_at) VALUES (10, datetime('now'))",
       ).run();
     }
     db.exec("COMMIT;");

--- a/src/economics-cache.ts
+++ b/src/economics-cache.ts
@@ -10,13 +10,13 @@ import {
 /**
  * Serves /api/analytics/token-economics from precomputed per-session vectors.
  *
- * Recomputing token economics from the archive walks every block row, which
- * takes seconds on multi-GB archives — far beyond any per-request budget. The
- * cache computes per-session vectors once, off the request thread, and then
- * answers any date filter by summing vectors in memory. `PRAGMA data_version`
- * cheaply detects archive writes from other connections (sync workers, CLI
- * runs); a stale cache serves the previous model while a rebuild runs in the
- * background, and onRebuilt lets the server nudge clients to refetch.
+ * Ingest persists versioned per-session vectors, so warming this cache reads
+ * compact derived rows instead of walking every transcript block. The cache
+ * then answers any date filter by summing vectors in memory.
+ * `PRAGMA data_version` cheaply detects archive writes from other connections
+ * (sync workers, CLI runs); a stale cache serves the previous model while a
+ * refresh runs in the background, and onRebuilt lets the server nudge clients
+ * to refetch.
  */
 export interface ComputeVectorsOptions {
   signal: AbortSignal;

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -12,6 +12,10 @@ import { compareCodePoints } from "./order.ts";
 import { regenerate as regenerateRecommendations } from "./recommendations.ts";
 import { parseClaudeSession } from "./sources/claude.ts";
 import { parseCodexSession } from "./sources/codex.ts";
+import {
+  materializeMissingSessionEconomics,
+  materializeSessionEconomics,
+} from "./token-economics.ts";
 import { classifyTool, preview } from "./tools.ts";
 import { resolveWorktreeRoots } from "./worktree.ts";
 
@@ -143,9 +147,12 @@ export function sync(
   }
 
   resolveSubagentParents(db);
+  const materializedEconomics = materializeMissingSessionEconomics(db);
   if (report.ingested > 0) {
     resolveWorktreeRoots(db);
     regenerateRecommendations(db);
+  }
+  if (report.ingested > 0 || materializedEconomics > 0) {
     // Refresh planner statistics after write bursts; without ANALYZE data the
     // query planner picks pathological join orders on multi-GB archives.
     db.exec("PRAGMA optimize;");
@@ -657,6 +664,8 @@ function writeSession(
       ref.timestamp,
     );
   }
+
+  materializeSessionEconomics(db, sessionId);
 
   return sessionId;
 }

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1,6 +1,6 @@
--- decant:schema_version=9
--- Effective decant schema (migrations 1..8 applied), frozen at the
--- pre-typescript cutover. Do not edit without updating schema tests.
+-- decant:schema_version=10
+-- Effective decant schema (migrations 1..10 applied), frozen as the current
+-- baseline. Do not edit without updating schema tests.
 CREATE TABLE schema_migrations(
             version INTEGER PRIMARY KEY,
             applied_at TEXT NOT NULL
@@ -152,6 +152,12 @@ CREATE TABLE model_pricing (
   cache_write_per_mtok REAL,
   source TEXT,
   updated_at TEXT
+);
+CREATE TABLE session_economics (
+  session_id INTEGER PRIMARY KEY REFERENCES session(id) ON DELETE CASCADE,
+  format_version INTEGER NOT NULL,
+  vector_json TEXT NOT NULL,
+  computed_at TEXT NOT NULL
 );
 CREATE TABLE recommendation (
   key            TEXT PRIMARY KEY,

--- a/src/token-economics.ts
+++ b/src/token-economics.ts
@@ -11,6 +11,10 @@ import { type DateFilter, sessionDatePredicate, whereClause } from "./date-filte
 
 const CHARS_PER_TOKEN = 4;
 const encoder = new TextEncoder();
+// Bump when vector semantics change so the next sync rebuilds derived rows.
+// Version 2 includes the corrected wall-clock attribution and billed-input
+// fields introduced by the v10 implementation's rebase onto main.
+export const SESSION_ECONOMICS_FORMAT_VERSION = 2;
 
 // Cap every inter-message gap so long model, tool, or human pauses do not
 // dominate the timing breakdown. Mirrors the ACTIVE_GAP_CAP_SECONDS used for
@@ -156,7 +160,7 @@ export interface SessionEconomicsVector {
 export function tokenEconomics(db: Database, filter?: DateFilter | null): TokenEconomics {
   const date = sessionDatePredicate("s", filter);
   return aggregateEconomicsVectors(
-    vectorsForScope(
+    vectorsForScopeWithCache(
       db,
       `WITH scoped_session AS (
          SELECT s.id FROM session s ${whereClause(date)}
@@ -173,7 +177,7 @@ export function tokenEconomics(db: Database, filter?: DateFilter | null): TokenE
  * from memory via aggregateEconomicsVectors().
  */
 export function computeSessionEconomicsVectors(db: Database): SessionEconomicsVector[] {
-  return vectorsForScope(db, "WITH scoped_session AS (SELECT id FROM session)", []);
+  return vectorsForScopeWithCache(db, "WITH scoped_session AS (SELECT id FROM session)", []);
 }
 
 /** Mirrors sessionDatePredicate: string-compare on the YYYY-MM-DD prefix. */
@@ -252,8 +256,13 @@ export function tokenEconomicsForSession(db: Database, sessionId: number): Token
     FROM session child
     JOIN scoped_session parent ON parent.id = child.parent_session_id
   )`;
-  const vectors = vectorsForScope(db, scopeCte, [sessionId]);
-  return vectors.length === 0 ? null : aggregateEconomicsVectors(withBilledInputWindow(vectors));
+  const expected = scopeCount(db, scopeCte, [sessionId]);
+  if (expected === 0) {
+    return null;
+  }
+  const cached = cachedVectorsForScope(db, scopeCte, [sessionId]);
+  const vectors = cached.length === expected ? cached : vectorsForScope(db, scopeCte, [sessionId]);
+  return aggregateEconomicsVectors(withBilledInputWindow(vectors));
 }
 
 /** Session panels retain their billed-input Window total while using the same
@@ -293,6 +302,158 @@ function withBilledInputWindow(vectors: SessionEconomicsVector[]): SessionEconom
 /** Load ordered block rows for generation and latency allocation. Tool-result
  * blocks do not duplicate their calling tool metadata, so resolve it through
  * the ingest-time tool_call linkage. */
+/** Persist the complete per-session vector while its normalized rows are hot
+ * in the ingest transaction. Descendant rollups stay dynamic: parent reads
+ * aggregate the independently cached vectors for the current subtree. */
+export function materializeSessionEconomics(db: Database, sessionId: number): boolean {
+  const vectors = vectorsForScope(
+    db,
+    "WITH scoped_session AS (SELECT id FROM session WHERE id = ?1)",
+    [sessionId],
+  );
+  const vector = vectors[0];
+  if (vector == null) {
+    return false;
+  }
+  storeEconomicsVector(db, vector);
+  return true;
+}
+
+/** One-time upgrade/backfill path. Normal ingest writes vectors immediately;
+ * sync also calls this so unchanged pre-v10 sessions become cached after upgrading. */
+export function materializeMissingSessionEconomics(db: Database): number {
+  const vectors = vectorsForScope(
+    db,
+    `WITH scoped_session AS (
+       SELECT s.id
+       FROM session s
+       LEFT JOIN session_economics e ON e.session_id = s.id
+       WHERE e.session_id IS NULL
+          OR e.format_version != ?1
+          OR NOT json_valid(e.vector_json)
+          OR COALESCE(json_type(e.vector_json, '$.id'), '') != 'integer'
+          OR COALESCE(json_type(e.vector_json, '$.billed_input_tokens'), '') NOT IN ('integer', 'real')
+          OR COALESCE(json_type(e.vector_json, '$.waiting_on_user_ms'), '') NOT IN ('integer', 'real')
+          OR COALESCE(json_type(e.vector_json, '$.buckets'), '') != 'object'
+     )`,
+    [SESSION_ECONOMICS_FORMAT_VERSION],
+  );
+  if (vectors.length === 0) {
+    return 0;
+  }
+  const persist = db.transaction((items: SessionEconomicsVector[]) => {
+    for (const vector of items) {
+      storeEconomicsVector(db, vector);
+    }
+  });
+  persist(vectors);
+  return vectors.length;
+}
+
+function vectorsForScopeWithCache(
+  db: Database,
+  scopeCte: string,
+  params: QueryParam[],
+): SessionEconomicsVector[] {
+  const expected = scopeCount(db, scopeCte, params);
+  if (expected === 0) {
+    return [];
+  }
+  const cached = cachedVectorsForScope(db, scopeCte, params);
+  return cached.length === expected ? cached : vectorsForScope(db, scopeCte, params);
+}
+
+function scopeCount(db: Database, scopeCte: string, params: QueryParam[]): number {
+  return (
+    db.query(`${scopeCte} SELECT COUNT(*) AS count FROM scoped_session`).get(...params) as {
+      count: number;
+    }
+  ).count;
+}
+
+function cachedVectorsForScope(
+  db: Database,
+  scopeCte: string,
+  params: QueryParam[],
+): SessionEconomicsVector[] {
+  const versionParam = `?${params.length + 1}`;
+  const rows = db
+    .query(
+      `${scopeCte}
+       SELECT e.session_id, e.vector_json, s.started_at
+       FROM scoped_session fs
+       JOIN session s ON s.id = fs.id
+       JOIN session_economics e ON e.session_id = fs.id
+       WHERE e.format_version = ${versionParam}
+       ORDER BY e.session_id`,
+    )
+    .all(...params, SESSION_ECONOMICS_FORMAT_VERSION) as {
+    session_id: number;
+    vector_json: string;
+    started_at: string | null;
+  }[];
+  const vectors: SessionEconomicsVector[] = [];
+  for (const row of rows) {
+    const vector = parseEconomicsVector(row.vector_json);
+    if (vector != null && vector.id === row.session_id) {
+      vector.started_at = row.started_at;
+      vectors.push(vector);
+    }
+  }
+  return vectors;
+}
+
+function parseEconomicsVector(raw: string): SessionEconomicsVector | null {
+  try {
+    const vector = JSON.parse(raw) as SessionEconomicsVector;
+    if (
+      typeof vector.id !== "number" ||
+      typeof vector.input_cost !== "number" ||
+      typeof vector.output_cost !== "number" ||
+      typeof vector.billed_input_tokens !== "number" ||
+      typeof vector.waiting_on_user_ms !== "number" ||
+      vector.buckets == null ||
+      typeof vector.buckets !== "object"
+    ) {
+      return null;
+    }
+    for (const bucket of ACTIVITY_BUCKETS) {
+      const part = vector.buckets[bucket];
+      if (
+        part == null ||
+        typeof part.generation !== "number" ||
+        typeof part.context_window !== "number" ||
+        typeof part.tool_calls !== "number" ||
+        typeof part.touched !== "boolean" ||
+        typeof part.generation_orientation !== "number" ||
+        typeof part.context_window_orientation !== "number" ||
+        typeof part.active_ms !== "number" ||
+        typeof part.active_ms_orientation !== "number"
+      ) {
+        return null;
+      }
+    }
+    return vector;
+  } catch {
+    return null;
+  }
+}
+
+function storeEconomicsVector(db: Database, vector: SessionEconomicsVector): void {
+  db.query(
+    `INSERT INTO session_economics(session_id, format_version, vector_json, computed_at)
+     VALUES (?1, ?2, ?3, datetime('now'))
+     ON CONFLICT(session_id) DO UPDATE SET
+       format_version = excluded.format_version,
+       vector_json = excluded.vector_json,
+       computed_at = excluded.computed_at`,
+  ).run(vector.id, SESSION_ECONOMICS_FORMAT_VERSION, JSON.stringify(vector));
+}
+
+/** Load ordered block rows for generation and latency allocation. Tool-result
+ * blocks do not duplicate their calling tool metadata, so resolve it through
+ * the ingest-time tool_call linkage. The scope-first join is intentional: it
+ * prevents SQLite from scanning the whole block table for a single session. */
 function blockRowsForScope(db: Database, scopeCte: string, params: QueryParam[]): BlockRow[] {
   return db
     .query(
@@ -306,10 +467,11 @@ function blockRowsForScope(db: Database, scopeCte: string, params: QueryParam[])
                    THEN COALESCE(length(CAST(b.tool_result AS BLOB)), 0)
                    ELSE COALESCE(length(CAST(b.text AS BLOB)), 0)
               END AS text_bytes
-       FROM block b
+       FROM scoped_session fs
+       CROSS JOIN block b INDEXED BY idx_block_session
        JOIN message m ON m.id = b.message_id
-       JOIN scoped_session fs ON fs.id = b.session_id
        LEFT JOIN tool_call tc ON tc.result_block_id = b.id
+       WHERE b.session_id = fs.id
        ORDER BY b.session_id, m.seq, b.ordinal`,
     )
     .all(...params) as BlockRow[];
@@ -372,11 +534,12 @@ function vectorsForScope(
        SELECT t.session_id, t.tool_name, t.input,
               COALESCE(t.output_bytes, length(CAST(rb.tool_result AS BLOB)), 0) AS bytes,
               cm.seq AS call_seq
-       FROM tool_call t
-       JOIN scoped_session fs ON fs.id = t.session_id
+       FROM scoped_session fs
+       CROSS JOIN tool_call t INDEXED BY idx_toolcall_session
        LEFT JOIN block rb ON rb.id = t.result_block_id
        LEFT JOIN block cb ON cb.id = t.call_block_id
-       LEFT JOIN message cm ON cm.id = cb.message_id`,
+       LEFT JOIN message cm ON cm.id = cb.message_id
+       WHERE t.session_id = fs.id`,
     )
     .all(...params) as ResultRow[];
   for (const row of results) {

--- a/src/token-economics.ts
+++ b/src/token-economics.ts
@@ -12,8 +12,8 @@ import { type DateFilter, sessionDatePredicate, whereClause } from "./date-filte
 const CHARS_PER_TOKEN = 4;
 const encoder = new TextEncoder();
 // Bump when vector semantics change so the next sync rebuilds derived rows.
-// Version 2 includes the corrected wall-clock attribution and billed-input
-// fields introduced by the v10 implementation's rebase onto main.
+// Version 2 includes corrected wall-clock attribution plus the billed-input
+// and waiting-on-user fields required by the current activity model.
 export const SESSION_ECONOMICS_FORMAT_VERSION = 2;
 
 // Cap every inter-message gap so long model, tool, or human pauses do not
@@ -170,14 +170,11 @@ export function tokenEconomics(db: Database, filter?: DateFilter | null): TokenE
   );
 }
 
-/**
- * Per-session activity vectors for the whole archive. Sums of these vectors
- * reproduce tokenEconomics() exactly for any date scope, so a caller can
- * compute them once (off the request path) and answer arbitrary date filters
- * from memory via aggregateEconomicsVectors().
- */
+/** Load persisted per-session activity vectors for the in-memory server cache.
+ * This intentionally never falls back to transcript scans: startup sync
+ * backfills missing rows and then invalidates the cache. */
 export function computeSessionEconomicsVectors(db: Database): SessionEconomicsVector[] {
-  return vectorsForScopeWithCache(db, "WITH scoped_session AS (SELECT id FROM session)", []);
+  return cachedVectorsForScope(db, "WITH scoped_session AS (SELECT id FROM session)", []);
 }
 
 /** Mirrors sessionDatePredicate: string-compare on the YYYY-MM-DD prefix. */
@@ -299,9 +296,6 @@ function withBilledInputWindow(vectors: SessionEconomicsVector[]): SessionEconom
   });
 }
 
-/** Load ordered block rows for generation and latency allocation. Tool-result
- * blocks do not duplicate their calling tool metadata, so resolve it through
- * the ingest-time tool_call linkage. */
 /** Persist the complete per-session vector while its normalized rows are hot
  * in the ingest transaction. Descendant rollups stay dynamic: parent reads
  * aggregate the independently cached vectors for the current subtree. */
@@ -331,10 +325,12 @@ export function materializeMissingSessionEconomics(db: Database): number {
        WHERE e.session_id IS NULL
           OR e.format_version != ?1
           OR NOT json_valid(e.vector_json)
-          OR COALESCE(json_type(e.vector_json, '$.id'), '') != 'integer'
-          OR COALESCE(json_type(e.vector_json, '$.billed_input_tokens'), '') NOT IN ('integer', 'real')
-          OR COALESCE(json_type(e.vector_json, '$.waiting_on_user_ms'), '') NOT IN ('integer', 'real')
-          OR COALESCE(json_type(e.vector_json, '$.buckets'), '') != 'object'
+          OR CASE WHEN json_valid(e.vector_json) THEN
+               COALESCE(json_type(e.vector_json, '$.id'), '') != 'integer'
+               OR COALESCE(json_type(e.vector_json, '$.billed_input_tokens'), '') NOT IN ('integer', 'real')
+               OR COALESCE(json_type(e.vector_json, '$.waiting_on_user_ms'), '') NOT IN ('integer', 'real')
+               OR COALESCE(json_type(e.vector_json, '$.buckets'), '') != 'object'
+             ELSE 0 END
      )`,
     [SESSION_ECONOMICS_FORMAT_VERSION],
   );

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -4038,31 +4038,40 @@ function SessionDetailView({ id }: { id: number }) {
   const [detail, setDetail] = useState<SessionDetailData | null>(null);
   const [economics, setEconomics] = useState<TokenEconomics | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [economicsError, setEconomicsError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setDetail(null);
     setEconomics(null);
     setError(null);
+    setEconomicsError(null);
     if (!Number.isFinite(id)) {
       setError("Invalid session id.");
       return;
     }
-    void Promise.all([
-      getJson<SessionDetailData>(
-        `/api/sessions/${id}?message_limit=${SESSION_DETAIL_MESSAGE_LIMIT}`,
-      ),
-      getJson<TokenEconomics>(`/api/sessions/${id}/token-economics`),
-    ])
-      .then(([nextDetail, nextEconomics]) => {
+    void getJson<SessionDetailData>(
+      `/api/sessions/${id}?message_limit=${SESSION_DETAIL_MESSAGE_LIMIT}`,
+    )
+      .then((nextDetail) => {
         if (!cancelled) {
           setDetail(nextDetail);
-          setEconomics(nextEconomics);
         }
       })
       .catch((err: unknown) => {
         if (!cancelled) {
           setError(errorMessage(err));
+        }
+      });
+    void getJson<TokenEconomics>(`/api/sessions/${id}/token-economics`)
+      .then((nextEconomics) => {
+        if (!cancelled) {
+          setEconomics(nextEconomics);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setEconomicsError(errorMessage(err));
         }
       });
     return () => {
@@ -4132,7 +4141,11 @@ function SessionDetailView({ id }: { id: number }) {
           subagentRuns={subagentRuns}
           title="Activity breakdown"
         />
-      ) : null}
+      ) : economicsError != null ? (
+        <div className="notice inline-notice">Activity breakdown unavailable: {economicsError}</div>
+      ) : (
+        <SessionEconomicsSkeleton />
+      )}
 
       <div className="transcript-layout">
         <aside className="toc">
@@ -4289,22 +4302,7 @@ function SessionDetailSkeleton() {
         </div>
       </header>
       <span className="skeleton-line skeleton-back" />
-      <section className="panel token-economics-panel is-compact skeleton-panel">
-        <div className="panel-heading">
-          <div>
-            <span className="skeleton-line skeleton-heading" />
-            <span className="skeleton-line skeleton-subheading" />
-          </div>
-          <span className="skeleton-line skeleton-summary" />
-        </div>
-        <div className="activity-table-wrap">
-          <div className="skeleton-table">
-            {["context", "planning", "code", "communicating"].map((key) => (
-              <span className="skeleton-line" key={key} />
-            ))}
-          </div>
-        </div>
-      </section>
+      <SessionEconomicsSkeleton />
       <div className="transcript-layout">
         <aside className="toc">
           <div className="toc-inner">
@@ -4325,6 +4323,31 @@ function SessionDetailSkeleton() {
         </div>
       </div>
     </div>
+  );
+}
+
+function SessionEconomicsSkeleton() {
+  return (
+    <section
+      aria-label="Loading activity breakdown"
+      className="panel token-economics-panel is-compact skeleton-panel"
+      role="status"
+    >
+      <div className="panel-heading">
+        <div>
+          <span className="skeleton-line skeleton-heading" />
+          <span className="skeleton-line skeleton-subheading" />
+        </div>
+        <span className="skeleton-line skeleton-summary" />
+      </div>
+      <div className="activity-table-wrap">
+        <div className="skeleton-table">
+          {["context", "planning", "code", "communicating"].map((key) => (
+            <span className="skeleton-line" key={key} />
+          ))}
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -3,7 +3,7 @@ import { copyFileSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runCli } from "../src/cli.ts";
-import { openDb } from "../src/db.ts";
+import { LATEST_SCHEMA_VERSION, openDb } from "../src/db.ts";
 
 const workDir = mkdtempSync(join(tmpdir(), "decant-cli-test-"));
 afterAll(() => rmSync(workDir, { recursive: true, force: true }));
@@ -79,7 +79,7 @@ describe("runCli", () => {
     expect(dbInfo.code).toBe(0);
     expect(JSON.parse(dbInfo.stdout)).toMatchObject({
       path: dbPath,
-      schema_version: 9,
+      schema_version: LATEST_SCHEMA_VERSION,
       sessions: 7,
     });
 

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -15,7 +15,7 @@ function freshPath(): string {
   return join(workDir, `archive-${dbCounter}.db`);
 }
 
-// Inventory of the frozen v9 baseline. Shadow tables
+// Inventory of the frozen v10 baseline. Shadow tables
 // of block_fts are excluded; they are implementation details of FTS5.
 const BASELINE_TABLES = [
   "block",
@@ -29,6 +29,7 @@ const BASELINE_TABLES = [
   "recommendation",
   "schema_migrations",
   "session",
+  "session_economics",
   "tool_call",
 ];
 const BASELINE_TRIGGERS = ["block_ad", "block_ai", "block_au"];
@@ -149,7 +150,7 @@ describe("openDb", () => {
     expect(() => openDb(path)).toThrow(/newer/i);
   });
 
-  test("migrates a v8 archive to v9", () => {
+  test("migrates a v8 archive through v10", () => {
     const path = freshPath();
     const db = new Database(path, { create: true, strict: true });
     db.exec(`
@@ -171,8 +172,36 @@ describe("openDb", () => {
           version: number;
         }
       ).version,
-    ).toBe(9);
+    ).toBe(10);
     expect(inventory(migrated, "index")).toContain("idx_session_parent");
+    expect(inventory(migrated, "table")).toContain("session_economics");
+    migrated.close();
+  });
+
+  test("migrates a v9 archive to the persisted economics cache", () => {
+    const path = freshPath();
+    const db = new Database(path, { create: true, strict: true });
+    db.exec(`
+      CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
+      CREATE TABLE session(id INTEGER PRIMARY KEY, tool TEXT NOT NULL, source_session_id TEXT NOT NULL);
+    `);
+    const insert = db.prepare(
+      "INSERT INTO schema_migrations(version, applied_at) VALUES (?1, datetime('now'))",
+    );
+    for (let version = 1; version <= 9; version += 1) {
+      insert.run(version);
+    }
+    db.close();
+
+    const migrated = openDb(path);
+    expect(inventory(migrated, "table")).toContain("session_economics");
+    expect(
+      (
+        migrated.query("SELECT MAX(version) AS version FROM schema_migrations").get() as {
+          version: number;
+        }
+      ).version,
+    ).toBe(10);
     migrated.close();
   });
 

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -130,10 +130,25 @@ describe("upsertSession", () => {
            (SELECT COUNT(*) FROM message) AS messages,
            (SELECT COUNT(*) FROM block) AS blocks,
            (SELECT COUNT(*) FROM tool_call) AS calls,
-           (SELECT COUNT(*) FROM file_ref) AS refs`,
+           (SELECT COUNT(*) FROM file_ref) AS refs,
+           (SELECT COUNT(*) FROM session_economics) AS economics`,
       )
-      .get() as { sessions: number; messages: number; blocks: number; calls: number; refs: number };
-    expect(counts).toEqual({ sessions: 1, messages: 10, blocks: 15, calls: 6, refs: 4 });
+      .get() as {
+      sessions: number;
+      messages: number;
+      blocks: number;
+      calls: number;
+      refs: number;
+      economics: number;
+    };
+    expect(counts).toEqual({
+      sessions: 1,
+      messages: 10,
+      blocks: 15,
+      calls: 6,
+      refs: 4,
+      economics: 1,
+    });
 
     const ref = db
       .query(
@@ -191,13 +206,21 @@ describe("upsertSession", () => {
            (SELECT COUNT(*) FROM session) AS sessions,
            (SELECT COUNT(*) FROM message) AS messages,
            (SELECT COUNT(*) FROM block) AS blocks,
+           (SELECT COUNT(*) FROM session_economics) AS economics,
            (SELECT source_path FROM session) AS source_path`,
       )
-      .get() as { sessions: number; messages: number; blocks: number; source_path: string };
+      .get() as {
+      sessions: number;
+      messages: number;
+      blocks: number;
+      economics: number;
+      source_path: string;
+    };
     expect(counts).toMatchObject({
       sessions: 1,
       messages: 4,
       blocks: 6,
+      economics: 1,
       source_path: "/x/sample-again.jsonl",
     });
     db.close();
@@ -245,13 +268,21 @@ describe("upsertSession", () => {
            (SELECT COUNT(*) FROM session) AS sessions,
            (SELECT COUNT(*) FROM message) AS messages,
            (SELECT COUNT(*) FROM block) AS blocks,
+           (SELECT COUNT(*) FROM session_economics) AS economics,
            (SELECT source_path FROM session) AS source_path`,
       )
-      .get() as { sessions: number; messages: number; blocks: number; source_path: string };
+      .get() as {
+      sessions: number;
+      messages: number;
+      blocks: number;
+      economics: number;
+      source_path: string;
+    };
     expect(counts).toEqual({
       sessions: 1,
       messages: 4,
       blocks: 6,
+      economics: 1,
       source_path: "/x/sample.jsonl",
     });
     db.close();
@@ -331,10 +362,15 @@ describe("sync", () => {
       (db.query("SELECT COUNT(*) AS n FROM model_pricing").get() as { n: number }).n,
     ).toBeGreaterThan(0);
 
+    // Simulate opening a migrated v9 archive whose transcripts are unchanged.
+    db.exec("DELETE FROM session_economics");
     db.query("UPDATE recommendation SET score = 12345 WHERE key = 'catalog:agents-md'").run();
     const second = sync(db, config);
     expect(second).toMatchObject({ scanned: 1, ingested: 0, skipped: 1, issues: 0, failed: 0 });
     expect((db.query("SELECT COUNT(*) AS n FROM session").get() as { n: number }).n).toBe(1);
+    expect((db.query("SELECT COUNT(*) AS n FROM session_economics").get() as { n: number }).n).toBe(
+      1,
+    );
     expect(
       (
         db.query("SELECT score FROM recommendation WHERE key = 'catalog:agents-md'").get() as {

--- a/test/token-economics.test.ts
+++ b/test/token-economics.test.ts
@@ -210,6 +210,7 @@ describe("token economics", () => {
       "claude",
     );
     const expected = tokenEconomicsForSession(db, sessionId);
+    const expectedAggregate = tokenEconomics(db);
     const stored = db
       .query(
         "SELECT format_version, json_valid(vector_json) AS valid FROM session_economics WHERE session_id = ?1",
@@ -224,10 +225,28 @@ describe("token economics", () => {
       DELETE FROM message;
     `);
     expect(tokenEconomicsForSession(db, sessionId)).toEqual(expected);
+    expect(tokenEconomics(db)).toEqual(expectedAggregate);
     db.close();
   });
 
-  test("backfills missing or stale vectors for existing sessions", () => {
+  test("server cache warmup never falls back to an uncached transcript scan", () => {
+    const db = freshDb();
+    upsertSession(
+      db,
+      parseClaudeSession("sess-enr-claude", fixture("claude", "enriched.jsonl")),
+      "/x/claude.jsonl",
+      1,
+      2,
+      "claude",
+    );
+    db.exec("DELETE FROM session_economics");
+
+    expect(computeSessionEconomicsVectors(db)).toEqual([]);
+    expect(tokenEconomics(db).totals.generation_tokens).toBeGreaterThan(0);
+    db.close();
+  });
+
+  test("backfills stale, malformed, or structurally incomplete vectors", () => {
     const db = freshDb();
     const sessionId = upsertSession(
       db,
@@ -237,7 +256,8 @@ describe("token economics", () => {
       2,
       "claude",
     );
-    db.query("UPDATE session_economics SET format_version = 0 WHERE session_id = ?1").run(
+    db.query("UPDATE session_economics SET format_version = ?1 WHERE session_id = ?2").run(
+      SESSION_ECONOMICS_FORMAT_VERSION - 1,
       sessionId,
     );
 
@@ -250,6 +270,24 @@ describe("token economics", () => {
       ).format_version,
     ).toBe(SESSION_ECONOMICS_FORMAT_VERSION);
     expect(materializeMissingSessionEconomics(db)).toBe(0);
+
+    db.query("UPDATE session_economics SET vector_json = '{' WHERE session_id = ?1").run(sessionId);
+    expect(materializeMissingSessionEconomics(db)).toBe(1);
+    expect(
+      (
+        db
+          .query(
+            "SELECT json_valid(vector_json) AS valid FROM session_economics WHERE session_id = ?1",
+          )
+          .get(sessionId) as { valid: number }
+      ).valid,
+    ).toBe(1);
+
+    db.query(
+      "UPDATE session_economics SET vector_json = json_remove(vector_json, '$.billed_input_tokens') WHERE session_id = ?1",
+    ).run(sessionId);
+    expect(materializeMissingSessionEconomics(db)).toBe(1);
+    expect(tokenEconomicsForSession(db, sessionId)).not.toBeNull();
     db.close();
   });
 

--- a/test/token-economics.test.ts
+++ b/test/token-economics.test.ts
@@ -11,6 +11,8 @@ import {
   aggregateEconomicsVectors,
   computeSessionEconomicsVectors,
   economicsVectorMatchesFilter,
+  materializeMissingSessionEconomics,
+  SESSION_ECONOMICS_FORMAT_VERSION,
   tokenEconomics,
   tokenEconomicsForSession,
 } from "../src/token-economics.ts";
@@ -194,6 +196,60 @@ describe("token economics", () => {
     expect(communicating?.generation_tokens).toBeGreaterThan(0);
     expect(communicating?.estimated_cost_usd).toBeGreaterThan(0);
     expect(communicating?.sessions).toBe(1);
+    db.close();
+  });
+
+  test("persists versioned vectors and serves economics without scanning transcript rows", () => {
+    const db = freshDb();
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("sess-enr-claude", fixture("claude", "enriched.jsonl")),
+      "/x/claude.jsonl",
+      1,
+      2,
+      "claude",
+    );
+    const expected = tokenEconomicsForSession(db, sessionId);
+    const stored = db
+      .query(
+        "SELECT format_version, json_valid(vector_json) AS valid FROM session_economics WHERE session_id = ?1",
+      )
+      .get(sessionId) as { format_version: number; valid: number };
+    expect(stored).toEqual({ format_version: SESSION_ECONOMICS_FORMAT_VERSION, valid: 1 });
+
+    db.exec(`
+      DELETE FROM file_ref;
+      DELETE FROM tool_call;
+      DELETE FROM block;
+      DELETE FROM message;
+    `);
+    expect(tokenEconomicsForSession(db, sessionId)).toEqual(expected);
+    db.close();
+  });
+
+  test("backfills missing or stale vectors for existing sessions", () => {
+    const db = freshDb();
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("sess-enr-claude", fixture("claude", "enriched.jsonl")),
+      "/x/claude.jsonl",
+      1,
+      2,
+      "claude",
+    );
+    db.query("UPDATE session_economics SET format_version = 0 WHERE session_id = ?1").run(
+      sessionId,
+    );
+
+    expect(materializeMissingSessionEconomics(db)).toBe(1);
+    expect(
+      (
+        db
+          .query("SELECT format_version FROM session_economics WHERE session_id = ?1")
+          .get(sessionId) as { format_version: number }
+      ).format_version,
+    ).toBe(SESSION_ECONOMICS_FORMAT_VERSION);
+    expect(materializeMissingSessionEconomics(db)).toBe(0);
     db.close();
   });
 


### PR DESCRIPTION
## Summary

- persist versioned per-session economics vectors as part of ingest
- backfill unchanged v8/v9 archives during the first v10 sync
- serve session and archive economics from compact derived rows
- load the transcript and activity breakdown independently in the session UI

## Root cause

Session detail rendering waited on a `Promise.all` containing both the transcript and token-economics requests. The economics path could scan the archive-wide `block` and `tool_call` tables, so a slow metrics query held the entire transcript behind it.

## Review fixes

The merge-gate review rebased this work onto the latest wall-clock attribution changes and fixed four integration issues:

- retained the billed-input transformation for session-scoped metrics
- bumped the persisted vector format so pre-rebase rows are invalidated
- repaired malformed and structurally incomplete cached vectors
- removed the raw transcript-scan fallback from server cache warmup, avoiding a duplicate full-archive scan during the first v10 backfill

## Impact

New and changed sessions materialize their economics vector inside the ingest transaction. Existing v8/v9 archives migrate to schema v10 and backfill once during sync. The server cache reads persisted rows only, while the session fallback remains scope-first for responsive reads during that initial backfill.

The transcript renders as soon as session detail arrives. Metrics show their own loading skeleton or inline error without blocking the transcript.

## Validation

- `just check`
  - 256 tests passed
  - TypeScript passed
  - Biome passed
  - distribution staging smoke passed
- 2 GB archive with 1,088 sessions
  - one-time v2 backfill: 27.7s in the background sync
  - server cache warmup: 42.5ms
  - cached session 9497 read: 0.12ms median, 0.48ms p95
  - uncached scope-first session fallback: 27.9ms
- browser smoke with the economics response deliberately delayed by 3s
  - transcript visible in 1.0s
  - independent metrics skeleton visible
  - metrics visible in 4.1s
  - 69 transcript turns rendered
  - no browser console errors
