### PR TITLE
Fix one-command development startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ point). Docs: `docs/api/routes.md` (serve routes) and `docs/distribution.md`
 
 ## Setup
 
-- Bun 1.3+; install dependencies explicitly with `bun install --frozen-lockfile`.
+- Bun 1.3+ (`bun run dev` performs a frozen install before serving).
 - Docker only if you are validating the container image.
 - No Rust, Elixir, Erlang, or Swift toolchain is required for mainline work.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,12 +16,11 @@ on-ramp.
 ```bash
 git clone https://github.com/dosu-ai/decant
 cd decant
-bun install --frozen-lockfile
 bun run dev
 ```
 
-Dependency installation is explicit. `bun run dev` starts the local UI and runs
-the startup sync. Open `http://127.0.0.1:3000`.
+`bun run dev` performs a frozen dependency install, starts the local UI, and
+runs the startup sync. Open `http://127.0.0.1:3000`.
 
 Install optional hooks after setup if you use pre-commit locally:
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,10 @@ transcripts never leave your machine.
 Use source during the pre-release TypeScript migration:
 
 ```bash
-bun install --frozen-lockfile
 bun run dev
 ```
 
-Requires Bun 1.3+. Install dependencies explicitly, then `bun run dev` starts
+Requires Bun 1.3+. `bun run dev` performs a frozen dependency install, starts
 `decant serve`, runs the startup sync, and keeps watching your source logs. The
 UI runs at `http://127.0.0.1:3000`.
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -123,10 +123,9 @@ every address inside a CIDR, reads the entire archive with no credential.
 Source remains the contributor path and the fastest dev loop:
 
 ```sh
-bun install --frozen-lockfile
 bun run dev
 ```
 
-Install dependencies explicitly. `bun run dev` starts `decant serve`, performs
-the startup sync, and keeps the archive current. Source installs require Bun;
-npm and Docker installs do not.
+`bun run dev` performs a frozen dependency install, starts `decant serve`,
+performs the startup sync, and keeps the archive current. Source installs
+require Bun; npm and Docker installs do not.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "bun": ">=1.3.0"
   },
   "scripts": {
-    "dev": "bun install --frozen-lockfile && bun run src/cli.ts serve",
+    "predev": "bun install --frozen-lockfile",
+    "dev": "bun run src/cli.ts serve",
     "start": "bun run src/cli.ts serve",
     "test": "bun test",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "bun": ">=1.3.0"
   },
   "scripts": {
-    "dev": "bun run src/cli.ts serve",
+    "dev": "bun install --frozen-lockfile && bun run src/cli.ts serve",
     "start": "bun run src/cli.ts serve",
     "test": "bun test",
     "typecheck": "tsc --noEmit",

--- a/test/distribution.test.ts
+++ b/test/distribution.test.ts
@@ -19,7 +19,8 @@ describe("distribution helpers", () => {
       scripts?: Record<string, string>;
     };
 
-    expect(pkg.scripts?.dev).toBe("bun install --frozen-lockfile && bun run src/cli.ts serve");
+    expect(pkg.scripts?.predev).toBe("bun install --frozen-lockfile");
+    expect(pkg.scripts?.dev).toBe("bun run src/cli.ts serve");
     expect(pkg.scripts?.up).toBeUndefined();
     expect(existsSync(join(root, "scripts", "dev.ts"))).toBe(false);
   });

--- a/test/distribution.test.ts
+++ b/test/distribution.test.ts
@@ -13,13 +13,13 @@ import {
 } from "../scripts/distribution.ts";
 
 describe("distribution helpers", () => {
-  test("keeps source development startup direct and dependency installation explicit", () => {
+  test("keeps source development startup direct and reproducible", () => {
     const root = join(import.meta.dir, "..");
     const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as {
       scripts?: Record<string, string>;
     };
 
-    expect(pkg.scripts?.dev).toBe("bun run src/cli.ts serve");
+    expect(pkg.scripts?.dev).toBe("bun install --frozen-lockfile && bun run src/cli.ts serve");
     expect(pkg.scripts?.up).toBeUndefined();
     expect(existsSync(join(root, "scripts", "dev.ts"))).toBe(false);
   });


### PR DESCRIPTION
## Summary

- restore `bun run dev` as the one-command local startup path
- perform `bun install --frozen-lockfile` before launching `decant serve`
- keep `just up`, `bun run up`, and `scripts/dev.ts` removed
- align contributor and distribution documentation with the restored behavior

## Root cause

The logging cleanup removed the development wrapper and changed `dev` to launch
the CLI directly. In an existing checkout with a stale `node_modules`, Bun does
not auto-install missing packages, so startup fails before the server launches.

The package script now sequences Bun's frozen install directly before the
server. This keeps the workflow reproducible without reintroducing a custom
wrapper.

## Validation

- reproduced the failure in an isolated checkout with stale dependencies:
  `Cannot find package 'commander'`
- verified `bun run dev` installs the locked dependencies, starts the watcher
  and server, completes startup sync, returns 200 from `/api/health`, and shuts
  down cleanly
- `bun test test/distribution.test.ts`
- `just check` (323 tests, TypeScript, Biome, native distribution smoke)
