### PR TITLE
Improve long session transcript UX

### DIFF
--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -53,6 +53,7 @@ guard reads or writes the whole archive.
 - `POST /api/sync`
 - `GET /api/sessions?from=YYYY-MM-DD&to=YYYY-MM-DD`
 - `GET /api/sessions/:id`
+- `GET /api/sessions/:id/outline`
 - `GET /api/sessions/:id/token-economics`
 - `GET /api/sessions/:id/context-window`
 - `GET /api/projects`
@@ -76,6 +77,12 @@ guard reads or writes the whole archive.
 Session and archive token-economics routes aggregate versioned per-session
 vectors persisted during ingest. The first sync after a schema upgrade
 backfills vectors for unchanged sessions.
+
+Session detail accepts `message_limit` and `message_offset` for transcript
+pagination. The outline route returns only the sequence number and a short
+excerpt from the first text block for each human/prompt turn, so the sticky
+thread navigation can cover the whole session without loading every rich
+transcript block up front.
 
 The context-window route derives per-API-call window occupancy and compaction
 events at read time from persisted per-message token columns and raw records.

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -493,11 +493,12 @@ function writeSession(
        turn_count, error_count, interruption_count, compaction_count, sidechain_message_count,
        agent_spawn_count, skill_count, command_count, thinking_block_count, thinking_chars,
        active_seconds, outcome, work_type,
-       est_reasoning_tokens, reasoning_source
+       est_reasoning_tokens, reasoning_source,
+       id
      )
      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18,
              ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, datetime('now'), ?27, ?28, ?29, ?30, ?31,
-             ?32, ?33, ?34, ?35, ?36, ?37, ?38, ?39, ?40, ?41, ?42, ?43, ?44)`,
+             ?32, ?33, ?34, ?35, ?36, ?37, ?38, ?39, ?40, ?41, ?42, ?43, ?44, ?45)`,
   ).run(
     s.tool,
     s.sourceSessionId,
@@ -543,6 +544,7 @@ function writeSession(
     gotWorkType,
     s.estReasoningTokens,
     s.reasoningSource,
+    existing?.id ?? null,
   );
   const sessionId = lastInsertRowid(db);
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -182,6 +182,15 @@ export interface SessionReadOptions {
   messageOffset?: number | null;
 }
 
+export interface SessionOutlineItem {
+  seq: number;
+  text: string;
+}
+
+interface SessionOutlineRow extends SessionOutlineItem {
+  raw_meta: string | null;
+}
+
 interface MessageBlockRow {
   message_id: number;
   seq: number;
@@ -349,6 +358,44 @@ export function getSession(
     has_more_messages:
       messageLimit != null ? messageOffset + messages.length < summaryRow.message_count : undefined,
   };
+}
+
+/**
+ * Return the lightweight prompt outline independently from paged transcript
+ * bodies. This keeps every turn reachable from the sticky navigation without
+ * loading every rich block, tool result, and code sample up front.
+ */
+export function getSessionOutline(db: Database, id: number): SessionOutlineItem[] | null {
+  const session = db.query("SELECT 1 AS present FROM session WHERE id = ?1").get(id);
+  if (session == null) {
+    return null;
+  }
+  const rows = db
+    .query(
+      `SELECT m.seq,
+              (
+                SELECT SUBSTR(b.text, 1, 240)
+                FROM block b
+                WHERE b.message_id = m.id AND b.type = 'text'
+                  AND TRIM(COALESCE(b.text, '')) != ''
+                ORDER BY b.ordinal
+                LIMIT 1
+              ) AS text,
+              ${MESSAGE_RAW_META_SQL} AS raw_meta
+       FROM message m
+       WHERE m.session_id = ?1 AND m.role = 'user'
+         AND EXISTS (
+           SELECT 1
+           FROM block b
+           WHERE b.message_id = m.id AND b.type = 'text'
+             AND TRIM(COALESCE(b.text, '')) != ''
+         )
+       ORDER BY m.seq`,
+    )
+    .all(id) as SessionOutlineRow[];
+  return rows
+    .filter((row) => !parseMessageRawMeta(row.raw_meta).isCompactSummary)
+    .map(({ seq, text }) => ({ seq, text }));
 }
 
 function buildSubagentDetails(

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@ import type { Operation } from "./enrich.ts";
 import type { sync as ingestSync } from "./ingest.ts";
 import { canLaunch, launchAgent, command as launchCommand, openIde } from "./launcher.ts";
 import { exceptionAttributes, logHttpRequest, type StructuredLogger } from "./logging.ts";
-import { getSession, listProjects, listSessions, search } from "./query.ts";
+import { getSession, getSessionOutline, listProjects, listSessions, search } from "./query.ts";
 import {
   list as listRecommendations,
   markImplemented,
@@ -216,6 +216,13 @@ export async function handleRequest(
       return withDb(config, context, (db) => {
         const timeline = contextWindowForSession(db, Number(contextWindowMatch[1]));
         return timeline == null ? json({ error: "session not found" }, 404) : json(timeline);
+      });
+    }
+    const sessionOutlineMatch = url.pathname.match(/^\/api\/sessions\/(\d+)\/outline$/);
+    if (request.method === "GET" && sessionOutlineMatch != null) {
+      return withDb(config, context, (db) => {
+        const outline = getSessionOutline(db, Number(sessionOutlineMatch[1]));
+        return outline == null ? json({ error: "session not found" }, 404) : json(outline);
       });
     }
     const sessionMatch = url.pathname.match(/^\/api\/sessions\/(\d+)$/);

--- a/src/ui/context-window-state.ts
+++ b/src/ui/context-window-state.ts
@@ -1,0 +1,18 @@
+export type ContextWindowDisplayMode = "hidden" | "unavailable" | "chart";
+
+export interface ContextWindowDisplayInput {
+  window_tokens: number | null;
+  points: readonly unknown[];
+}
+
+export function contextWindowDisplayMode(
+  timeline: ContextWindowDisplayInput | null,
+): ContextWindowDisplayMode {
+  if (timeline == null) {
+    return "hidden";
+  }
+  if (timeline.window_tokens == null || timeline.points.length === 0) {
+    return "unavailable";
+  }
+  return "chart";
+}

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -67,7 +67,11 @@ import {
   transcriptNavigationDirection,
   transcriptSeqFromHash,
 } from "./transcript-navigation.ts";
-import { appendTranscriptPage, transcriptWindowOffset } from "./transcript-pagination.ts";
+import {
+  appendTranscriptPage,
+  runWithTranscriptRequestSlot,
+  transcriptWindowOffset,
+} from "./transcript-pagination.ts";
 import {
   type StructuredTranscriptKind,
   type StructuredTranscriptLine,
@@ -4268,69 +4272,78 @@ function SessionDetailView({ id }: { id: number }) {
 
   const loadMessageWindow = useCallback(
     async (seq: number): Promise<boolean> => {
-      const activeRequest = loadMorePromiseRef.current;
-      if (activeRequest != null) {
-        await activeRequest;
-      }
-      const current = detailRef.current;
-      if (current?.messages.some((message) => message.seq === seq) === true) {
-        return true;
-      }
       const sessionVersion = sessionVersionRef.current;
-      const offset = transcriptWindowOffset(seq);
-      setLoadingMore(true);
-      setLoadMoreError(null);
-      const request = getJson<SessionDetailData>(
-        `/api/sessions/${id}?message_limit=${SESSION_DETAIL_MESSAGE_PAGE_SIZE}&message_offset=${offset}`,
-      )
-        .then((page) => {
-          if (sessionVersionRef.current !== sessionVersion) {
+      return runWithTranscriptRequestSlot(
+        loadMorePromiseRef,
+        () => sessionVersionRef.current === sessionVersion,
+        false,
+        async () => {
+          const current = detailRef.current;
+          if (current == null || current.summary.id !== id) {
             return false;
           }
-          const nextDetail = {
-            ...page,
-            message_offset: page.message_offset ?? offset,
-            message_limit: SESSION_DETAIL_MESSAGE_PAGE_SIZE,
-          };
-          detailRef.current = nextDetail;
-          setDetail(nextDetail);
-          return nextDetail.messages.some((message) => message.seq === seq);
-        })
-        .catch((err: unknown) => {
-          if (sessionVersionRef.current === sessionVersion) {
-            setLoadMoreError(errorMessage(err));
+          if (current.messages.some((message) => message.seq === seq)) {
+            return true;
           }
-          return false;
-        })
-        .finally(() => {
-          if (loadMorePromiseRef.current === request) {
-            loadMorePromiseRef.current = null;
-          }
-          if (sessionVersionRef.current === sessionVersion) {
-            setLoadingMore(false);
-          }
-        });
-      loadMorePromiseRef.current = request;
-      return request;
+          const offset = transcriptWindowOffset(seq);
+          setLoadingMore(true);
+          setLoadMoreError(null);
+          return getJson<SessionDetailData>(
+            `/api/sessions/${id}?message_limit=${SESSION_DETAIL_MESSAGE_PAGE_SIZE}&message_offset=${offset}`,
+          )
+            .then((page) => {
+              if (sessionVersionRef.current !== sessionVersion) {
+                return false;
+              }
+              const nextDetail = {
+                ...page,
+                message_offset: page.message_offset ?? offset,
+                message_limit: SESSION_DETAIL_MESSAGE_PAGE_SIZE,
+              };
+              detailRef.current = nextDetail;
+              setDetail(nextDetail);
+              return nextDetail.messages.some((message) => message.seq === seq);
+            })
+            .catch((err: unknown) => {
+              if (sessionVersionRef.current === sessionVersion) {
+                setLoadMoreError(errorMessage(err));
+              }
+              return false;
+            })
+            .finally(() => {
+              if (sessionVersionRef.current === sessionVersion) {
+                setLoadingMore(false);
+              }
+            });
+        },
+      );
     },
     [id],
   );
 
   const jumpToMessage = useCallback(
     async (seq: number) => {
+      const sessionVersion = sessionVersionRef.current;
       const hash = `#message-${seq}`;
       handledMessageHashRef.current = `${id}:${seq}`;
       window.history.replaceState(null, "", hash);
       setJumpingToSeq(seq);
       try {
-        await loadMessageWindow(seq);
+        const loaded = await loadMessageWindow(seq);
+        if (!loaded || sessionVersionRef.current !== sessionVersion) {
+          return;
+        }
         activeMessageSeqRef.current = seq;
         setActiveMessageSeq(seq);
         requestAnimationFrame(() => {
-          scrollTranscriptMessage(seq);
+          if (sessionVersionRef.current === sessionVersion) {
+            scrollTranscriptMessage(seq);
+          }
         });
       } finally {
-        setJumpingToSeq((current) => (current === seq ? null : current));
+        if (sessionVersionRef.current === sessionVersion) {
+          setJumpingToSeq((current) => (current === seq ? null : current));
+        }
       }
     },
     [id, loadMessageWindow],
@@ -4383,6 +4396,7 @@ function SessionDetailView({ id }: { id: number }) {
 
   const navigateTranscript = useCallback(
     async (direction: TranscriptNavigationDirection) => {
+      const sessionVersion = sessionVersionRef.current;
       let current = detailRef.current;
       if (current == null) {
         return;
@@ -4395,6 +4409,9 @@ function SessionDetailView({ id }: { id: number }) {
       let targetSeq = nextTranscriptSeq(sequences, activeSeq, direction);
       if (targetSeq == null && direction === 1 && current.has_more_messages === true) {
         await loadMoreMessages();
+        if (sessionVersionRef.current !== sessionVersion) {
+          return;
+        }
         current = detailRef.current;
         sequences =
           current == null
@@ -4410,7 +4427,9 @@ function SessionDetailView({ id }: { id: number }) {
       handledMessageHashRef.current = `${id}:${targetSeq}`;
       window.history.replaceState(null, "", `#message-${targetSeq}`);
       requestAnimationFrame(() => {
-        scrollTranscriptMessage(targetSeq);
+        if (sessionVersionRef.current === sessionVersion) {
+          scrollTranscriptMessage(targetSeq);
+        }
       });
     },
     [id, loadMoreMessages],

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -57,9 +57,22 @@ import {
   prepareAnalyticsChartState,
 } from "./chart-state.ts";
 import { layoutContextAnnotations } from "./context-window-layout.ts";
+import { contextWindowDisplayMode } from "./context-window-state.ts";
 import { compactDateTime, fullDateTime } from "./date-time.ts";
 import { isFramed } from "./frame-guard.ts";
 import { planSessionLoad, shouldShowSessionSkeleton } from "./loading-state.ts";
+import {
+  nextTranscriptSeq,
+  type TranscriptNavigationDirection,
+  transcriptNavigationDirection,
+  transcriptSeqFromHash,
+} from "./transcript-navigation.ts";
+import { appendTranscriptPage, transcriptWindowOffset } from "./transcript-pagination.ts";
+import {
+  type StructuredTranscriptKind,
+  type StructuredTranscriptLine,
+  structuredTranscriptBlock,
+} from "./transcript-presentation.ts";
 import "./styles.css";
 
 type Summary = {
@@ -436,7 +449,7 @@ const ANTHROPIC_ICON_PATH =
   "M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z";
 
 const SESSION_PAGE_SIZE = 50;
-const SESSION_DETAIL_MESSAGE_LIMIT = 160;
+const SESSION_DETAIL_MESSAGE_PAGE_SIZE = 160;
 const SESSION_TABLE_SKELETON_KEYS = Array.from(
   { length: 10 },
   (_, index) => `session-row-skeleton-${index}`,
@@ -4114,27 +4127,50 @@ function SettingSelect({
 
 function SessionDetailView({ id }: { id: number }) {
   const [detail, setDetail] = useState<SessionDetailData | null>(null);
+  const [outline, setOutline] = useState<SessionOutlineItemData[] | null>(null);
   const [economics, setEconomics] = useState<TokenEconomics | null>(null);
   const [contextWindow, setContextWindow] = useState<ContextWindowTimelineData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [economicsError, setEconomicsError] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
+  const [jumpingToSeq, setJumpingToSeq] = useState<number | null>(null);
+  const [activeMessageSeq, setActiveMessageSeq] = useState<number | null>(null);
+  const detailRef = useRef<SessionDetailData | null>(null);
+  const activeMessageSeqRef = useRef<number | null>(null);
+  const handledMessageHashRef = useRef<string | null>(null);
+  const loadMoreSentinelRef = useRef<HTMLDivElement | null>(null);
+  const loadMorePromiseRef = useRef<Promise<boolean> | null>(null);
+  const sessionVersionRef = useRef(0);
 
   useEffect(() => {
+    const sessionVersion = sessionVersionRef.current + 1;
+    sessionVersionRef.current = sessionVersion;
     let cancelled = false;
     setDetail(null);
+    detailRef.current = null;
+    loadMorePromiseRef.current = null;
+    setOutline(null);
     setEconomics(null);
     setContextWindow(null);
     setError(null);
     setEconomicsError(null);
+    setLoadingMore(false);
+    setLoadMoreError(null);
+    setJumpingToSeq(null);
+    activeMessageSeqRef.current = null;
+    handledMessageHashRef.current = null;
+    setActiveMessageSeq(null);
     if (!Number.isFinite(id)) {
       setError("Invalid session id.");
       return;
     }
     void getJson<SessionDetailData>(
-      `/api/sessions/${id}?message_limit=${SESSION_DETAIL_MESSAGE_LIMIT}`,
+      `/api/sessions/${id}?message_limit=${SESSION_DETAIL_MESSAGE_PAGE_SIZE}`,
     )
       .then((nextDetail) => {
-        if (!cancelled) {
+        if (!cancelled && sessionVersionRef.current === sessionVersion) {
+          detailRef.current = nextDetail;
           setDetail(nextDetail);
         }
       })
@@ -4142,6 +4178,15 @@ function SessionDetailView({ id }: { id: number }) {
         if (!cancelled) {
           setError(errorMessage(err));
         }
+      });
+    void getJson<SessionOutlineItemData[]>(`/api/sessions/${id}/outline`)
+      .then((nextOutline) => {
+        if (!cancelled && sessionVersionRef.current === sessionVersion) {
+          setOutline(nextOutline);
+        }
+      })
+      .catch(() => {
+        // The loaded transcript still supplies a progressive outline.
       });
     void getJson<TokenEconomics>(`/api/sessions/${id}/token-economics`)
       .then((nextEconomics) => {
@@ -4168,6 +4213,228 @@ function SessionDetailView({ id }: { id: number }) {
     };
   }, [id]);
 
+  const loadMoreMessages = useCallback((): Promise<boolean> => {
+    if (loadMorePromiseRef.current != null) {
+      return loadMorePromiseRef.current;
+    }
+    const current = detailRef.current;
+    if (current == null || current.has_more_messages !== true) {
+      return Promise.resolve(false);
+    }
+    const sessionVersion = sessionVersionRef.current;
+    const offset = (current.message_offset ?? 0) + current.messages.length;
+    setLoadingMore(true);
+    setLoadMoreError(null);
+    const request = getJson<SessionDetailData>(
+      `/api/sessions/${id}?message_limit=${SESSION_DETAIL_MESSAGE_PAGE_SIZE}&message_offset=${offset}`,
+    )
+      .then((page) => {
+        if (sessionVersionRef.current !== sessionVersion) {
+          return false;
+        }
+        const latest = detailRef.current;
+        if (latest == null || latest.summary.id !== id) {
+          return false;
+        }
+        const messages = appendTranscriptPage(latest.messages, page.messages);
+        const nextDetail = {
+          ...latest,
+          messages,
+          message_offset: latest.message_offset ?? 0,
+          message_limit: SESSION_DETAIL_MESSAGE_PAGE_SIZE,
+          has_more_messages: page.has_more_messages === true,
+        };
+        detailRef.current = nextDetail;
+        setDetail(nextDetail);
+        return page.has_more_messages === true;
+      })
+      .catch((err: unknown) => {
+        if (sessionVersionRef.current === sessionVersion) {
+          setLoadMoreError(errorMessage(err));
+        }
+        return false;
+      })
+      .finally(() => {
+        if (loadMorePromiseRef.current === request) {
+          loadMorePromiseRef.current = null;
+        }
+        if (sessionVersionRef.current === sessionVersion) {
+          setLoadingMore(false);
+        }
+      });
+    loadMorePromiseRef.current = request;
+    return request;
+  }, [id]);
+
+  const loadMessageWindow = useCallback(
+    async (seq: number): Promise<boolean> => {
+      const activeRequest = loadMorePromiseRef.current;
+      if (activeRequest != null) {
+        await activeRequest;
+      }
+      const current = detailRef.current;
+      if (current?.messages.some((message) => message.seq === seq) === true) {
+        return true;
+      }
+      const sessionVersion = sessionVersionRef.current;
+      const offset = transcriptWindowOffset(seq);
+      setLoadingMore(true);
+      setLoadMoreError(null);
+      const request = getJson<SessionDetailData>(
+        `/api/sessions/${id}?message_limit=${SESSION_DETAIL_MESSAGE_PAGE_SIZE}&message_offset=${offset}`,
+      )
+        .then((page) => {
+          if (sessionVersionRef.current !== sessionVersion) {
+            return false;
+          }
+          const nextDetail = {
+            ...page,
+            message_offset: page.message_offset ?? offset,
+            message_limit: SESSION_DETAIL_MESSAGE_PAGE_SIZE,
+          };
+          detailRef.current = nextDetail;
+          setDetail(nextDetail);
+          return nextDetail.messages.some((message) => message.seq === seq);
+        })
+        .catch((err: unknown) => {
+          if (sessionVersionRef.current === sessionVersion) {
+            setLoadMoreError(errorMessage(err));
+          }
+          return false;
+        })
+        .finally(() => {
+          if (loadMorePromiseRef.current === request) {
+            loadMorePromiseRef.current = null;
+          }
+          if (sessionVersionRef.current === sessionVersion) {
+            setLoadingMore(false);
+          }
+        });
+      loadMorePromiseRef.current = request;
+      return request;
+    },
+    [id],
+  );
+
+  const jumpToMessage = useCallback(
+    async (seq: number) => {
+      const hash = `#message-${seq}`;
+      handledMessageHashRef.current = `${id}:${seq}`;
+      window.history.replaceState(null, "", hash);
+      setJumpingToSeq(seq);
+      try {
+        await loadMessageWindow(seq);
+        activeMessageSeqRef.current = seq;
+        setActiveMessageSeq(seq);
+        requestAnimationFrame(() => {
+          scrollTranscriptMessage(seq);
+        });
+      } finally {
+        setJumpingToSeq((current) => (current === seq ? null : current));
+      }
+    },
+    [id, loadMessageWindow],
+  );
+
+  const loadedMessageCount = detail?.messages.length ?? 0;
+  useEffect(() => {
+    if (detail == null) {
+      return;
+    }
+    const followMessageHash = () => {
+      const seq = transcriptSeqFromHash(window.location.hash);
+      if (seq == null) {
+        return;
+      }
+      const key = `${id}:${seq}`;
+      if (handledMessageHashRef.current === key) {
+        return;
+      }
+      handledMessageHashRef.current = key;
+      void jumpToMessage(seq);
+    };
+    followMessageHash();
+    window.addEventListener("hashchange", followMessageHash);
+    return () => window.removeEventListener("hashchange", followMessageHash);
+  }, [detail, id, jumpToMessage]);
+
+  useEffect(() => {
+    const sentinel = loadMoreSentinelRef.current;
+    if (
+      sentinel == null ||
+      loadedMessageCount === 0 ||
+      detail?.has_more_messages !== true ||
+      loadMoreError != null ||
+      typeof IntersectionObserver === "undefined"
+    ) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          void loadMoreMessages();
+        }
+      },
+      { rootMargin: "700px 0px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [detail?.has_more_messages, loadedMessageCount, loadMoreError, loadMoreMessages]);
+
+  const navigateTranscript = useCallback(
+    async (direction: TranscriptNavigationDirection) => {
+      let current = detailRef.current;
+      if (current == null) {
+        return;
+      }
+      let sequences = renderableMessages(current.messages).map((message) => message.seq);
+      let activeSeq = activeMessageSeqRef.current;
+      if (activeSeq == null || !sequences.includes(activeSeq)) {
+        activeSeq = nearestTranscriptSeq(sequences);
+      }
+      let targetSeq = nextTranscriptSeq(sequences, activeSeq, direction);
+      if (targetSeq == null && direction === 1 && current.has_more_messages === true) {
+        await loadMoreMessages();
+        current = detailRef.current;
+        sequences =
+          current == null
+            ? sequences
+            : renderableMessages(current.messages).map((message) => message.seq);
+        targetSeq = nextTranscriptSeq(sequences, activeSeq, direction);
+      }
+      if (targetSeq == null) {
+        return;
+      }
+      activeMessageSeqRef.current = targetSeq;
+      setActiveMessageSeq(targetSeq);
+      handledMessageHashRef.current = `${id}:${targetSeq}`;
+      window.history.replaceState(null, "", `#message-${targetSeq}`);
+      requestAnimationFrame(() => {
+        scrollTranscriptMessage(targetSeq);
+      });
+    },
+    [id, loadMoreMessages],
+  );
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const direction = transcriptNavigationDirection(event);
+      if (
+        direction == null ||
+        event.repeat ||
+        isEditableTarget(event.target) ||
+        isEditableTarget(document.activeElement) ||
+        document.querySelector("[role='dialog']") != null
+      ) {
+        return;
+      }
+      event.preventDefault();
+      void navigateTranscript(direction);
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [navigateTranscript]);
+
   if (error != null) {
     return <div className="notice danger">Unable to load session: {error}</div>;
   }
@@ -4177,11 +4444,10 @@ function SessionDetailView({ id }: { id: number }) {
   }
 
   const messages = renderableMessages(detail.messages);
-  const toc = threadToc(messages);
+  const toc = outline == null ? threadToc(messages) : threadTocFromOutline(outline);
   const stats = threadStats(detail.summary, messages, toc, contextWindow?.turn_count);
   const subagentsByToolUse = subagentMap(detail.subagents);
   const subagentRuns = countSubagentRuns(detail.subagents);
-  const indexBySeq = new Map(messages.map((message, index) => [message.seq, index] as const));
   const compactionBySeq = new Map(
     (contextWindow?.compactions ?? []).map((compaction) => [compaction.seq, compaction] as const),
   );
@@ -4241,19 +4507,40 @@ function SessionDetailView({ id }: { id: number }) {
         <SessionEconomicsSkeleton />
       )}
 
-      <ContextWindowPanel indexBySeq={indexBySeq} timeline={contextWindow} />
+      <ContextWindowPanel onJump={jumpToMessage} timeline={contextWindow} />
 
       <div className="transcript-layout">
         <aside className="toc">
           <div className="toc-inner">
             <div className="toc-title">In this thread</div>
+            <div className="toc-hotkeys">
+              <span>
+                <kbd>↑</kbd>
+                <kbd>↓</kbd>
+              </span>
+              Move through messages
+            </div>
             {toc.length === 0 ? <p>No prompts to list</p> : null}
             {toc.map((item) => (
-              <a href={`#turn-${item.index}`} key={item.index}>
+              <a
+                className={[
+                  jumpingToSeq === item.seq ? "is-loading" : null,
+                  activeMessageSeq === item.seq ? "is-current" : null,
+                ]
+                  .filter(isPresent)
+                  .join(" ")}
+                href={`#message-${item.seq}`}
+                key={item.seq}
+                onClick={(event) => {
+                  event.preventDefault();
+                  void jumpToMessage(item.seq);
+                }}
+              >
                 <span className="toc-icon">
                   <Icon name={item.icon} />
                 </span>
                 <span>{item.label}</span>
+                {jumpingToSeq === item.seq ? <b>loading</b> : null}
                 {item.tools > 0 ? <b>{item.tools}</b> : null}
               </a>
             ))}
@@ -4261,11 +4548,26 @@ function SessionDetailView({ id }: { id: number }) {
         </aside>
 
         <div className="transcript-column">
-          {messages.map((message, index) => (
+          {(detail.message_offset ?? 0) > 0 ? (
+            <div className="transcript-window-start">
+              <span>
+                Viewing from message {formatInt((detail.message_offset ?? 0) + 1)} of{" "}
+                {formatInt(detail.summary.message_count)}
+              </span>
+              <button
+                className="button small secondary"
+                onClick={() => void jumpToMessage(0)}
+                type="button"
+              >
+                Start at the beginning
+              </button>
+            </div>
+          ) : null}
+          {messages.map((message) => (
             <TranscriptTurn
+              active={activeMessageSeq === message.seq}
               compaction={compactionBySeq.get(message.seq) ?? null}
-              index={index}
-              key={messageKey(message, index)}
+              key={messageKey(message)}
               message={message}
               sessionIsSubagent={detail.summary.is_subagent}
               subagentsByToolUse={subagentsByToolUse}
@@ -4274,11 +4576,39 @@ function SessionDetailView({ id }: { id: number }) {
             />
           ))}
           {detail.has_more_messages === true ? (
-            <div className="transcript-slice-note">
-              Showing the first {formatInt(detail.messages.length)} of{" "}
-              {formatInt(detail.summary.message_count)} messages for fast loading.
+            <div
+              aria-live="polite"
+              className="transcript-load-more"
+              ref={loadMoreSentinelRef}
+              role="status"
+            >
+              {loadMoreError != null ? (
+                <>
+                  <span>Couldn’t load the next messages: {loadMoreError}</span>
+                  <button
+                    className="button small secondary"
+                    onClick={() => void loadMoreMessages()}
+                    type="button"
+                  >
+                    Try again
+                  </button>
+                </>
+              ) : (
+                <span>
+                  {loadingMore ? "Loading more messages…" : "Keep scrolling to load more"}
+                  <small>
+                    {formatInt(detail.messages.length)} of {formatInt(detail.summary.message_count)}
+                  </small>
+                </span>
+              )}
             </div>
-          ) : null}
+          ) : (
+            <div className="transcript-end">
+              {(detail.message_offset ?? 0) === 0
+                ? `All ${formatInt(detail.summary.message_count)} messages loaded`
+                : "Reached the end of this session"}
+            </div>
+          )}
         </div>
       </div>
     </div>
@@ -4305,6 +4635,11 @@ type SessionDetailData = {
   message_offset?: number;
   message_limit?: number | null;
   has_more_messages?: boolean;
+};
+
+type SessionOutlineItemData = {
+  seq: number;
+  text: string;
 };
 
 type ContextWindowPointData = {
@@ -4356,16 +4691,16 @@ type TranscriptBlockData = {
 };
 
 function TranscriptTurn({
+  active,
   compaction,
-  index,
   message,
   sessionIsSubagent,
   subagentsByToolUse,
   tool,
   windowTokens,
 }: {
+  active: boolean;
   compaction: ContextWindowCompactionData | null;
-  index: number;
   message: SessionDetailData["messages"][number];
   sessionIsSubagent: boolean;
   subagentsByToolUse: Map<string, SubagentDetailData[]>;
@@ -4373,7 +4708,14 @@ function TranscriptTurn({
   windowTokens: number | null;
 }) {
   if (message.is_compact_boundary) {
-    return <CompactionTurn compaction={compaction} index={index} message={message} />;
+    return (
+      <CompactionTurn
+        active={active}
+        anchorId={`message-${message.seq}`}
+        compaction={compaction}
+        message={message}
+      />
+    );
   }
   const contextTokens =
     message.role === "assistant" && (!message.is_sidechain || sessionIsSubagent)
@@ -4384,16 +4726,20 @@ function TranscriptTurn({
       block={block}
       key={blockKey(block, blockIndex)}
       subagents={subagentsByToolUse.get(block.tool_use_id ?? "") ?? []}
+      tool={tool}
     />
   ));
+  const providerClass =
+    message.role === "assistant" ? ` provider-${providerIdentity(tool).key}` : "";
   return (
     <article
-      className={`turn${message.is_compact_summary ? " compact-summary-turn" : ""}`}
-      id={`turn-${index}`}
+      aria-current={active ? "true" : undefined}
+      className={`turn${message.is_compact_summary ? " compact-summary-turn" : ""}${
+        active ? " is-keyboard-active" : ""
+      }${providerClass}`}
+      id={`message-${message.seq}`}
     >
-      <Badge mono tone={message.is_compact_summary ? "accent" : roleTone(message.role)}>
-        {message.is_compact_summary ? "Summary" : roleLabel(message.role, tool)}
-      </Badge>
+      <TranscriptIdentityBadge message={message} tool={tool} />
       <div className="turn-meta">
         {message.model != null ? <ModelBadge model={message.model} /> : null}
         {message.timestamp != null ? <span>{relativeTime(message.timestamp)}</span> : null}
@@ -4416,19 +4762,25 @@ function TranscriptTurn({
 }
 
 function CompactionTurn({
+  active = false,
+  anchorId,
   compaction,
-  index,
   message,
 }: {
+  active?: boolean;
+  anchorId?: string;
   compaction: ContextWindowCompactionData | null;
-  index: number;
   message: SessionDetailData["messages"][number];
 }) {
   const trigger = compaction?.trigger ?? message.compact_trigger;
   const pre = compaction?.pre_tokens ?? message.compact_pre_tokens;
   const post = compaction?.post_tokens ?? null;
   return (
-    <article className="turn compaction-turn" id={`turn-${index}`}>
+    <article
+      aria-current={active ? "true" : undefined}
+      className={`turn compaction-turn${active ? " is-keyboard-active" : ""}`}
+      id={anchorId}
+    >
       <Badge mono tone="accent">
         Compacted
       </Badge>
@@ -4497,30 +4849,71 @@ const STRIP_ANNOTATION_LABEL_YS = [28, 41] as const;
 const STRIP_AUTO_COMPACT_ZONE = 0.8;
 
 function ContextWindowPanel({
-  indexBySeq,
+  onJump,
   timeline,
 }: {
-  indexBySeq: Map<number, number>;
+  onJump: (seq: number) => void | Promise<void>;
   timeline: ContextWindowTimelineData | null;
 }) {
-  if (timeline == null || timeline.window_tokens == null || timeline.points.length < 2) {
+  const mode = contextWindowDisplayMode(timeline);
+  if (mode === "hidden" || timeline == null) {
     return null;
   }
+  if (mode === "unavailable" || timeline.window_tokens == null) {
+    return <ContextWindowUnavailable timeline={timeline} />;
+  }
   return (
-    <ContextWindowStrip
-      indexBySeq={indexBySeq}
-      timeline={timeline}
-      windowTokens={timeline.window_tokens}
-    />
+    <ContextWindowStrip onJump={onJump} timeline={timeline} windowTokens={timeline.window_tokens} />
+  );
+}
+
+function ContextWindowUnavailable({ timeline }: { timeline: ContextWindowTimelineData }) {
+  const hasUsage = timeline.points.length > 0;
+  return (
+    <section className="panel context-window-panel">
+      <div className="panel-heading">
+        <div>
+          <h2>Context window</h2>
+          <p>How full the model's context window was at each API call across the session.</p>
+        </div>
+        <div className="activity-summary">
+          {timeline.window_tokens != null ? (
+            <span>
+              <strong>{compact(timeline.window_tokens)}</strong>
+              capacity
+            </span>
+          ) : null}
+          {hasUsage ? (
+            <span>
+              <strong>{compact(timeline.peak_tokens)}</strong>
+              peak tokens
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <div className="ctx-unavailable">
+        <Icon name="info" />
+        <div>
+          <strong>
+            {hasUsage ? "Window capacity wasn’t recorded" : "Per-call usage wasn’t recorded"}
+          </strong>
+          <p>
+            {hasUsage
+              ? "The transcript includes token usage, but this source did not record the model’s total context capacity, so a trustworthy percentage is unavailable."
+              : "This source session does not include the per-call token readings needed to reconstruct context usage."}
+          </p>
+        </div>
+      </div>
+    </section>
   );
 }
 
 function ContextWindowStrip({
-  indexBySeq,
+  onJump,
   timeline,
   windowTokens,
 }: {
-  indexBySeq: Map<number, number>;
+  onJump: (seq: number) => void | Promise<void>;
   timeline: ContextWindowTimelineData;
   windowTokens: number;
 }) {
@@ -4686,10 +5079,7 @@ function ContextWindowStrip({
     if (hovered == null) {
       return;
     }
-    const turnIndex = indexBySeq.get(hovered.seq);
-    if (turnIndex != null) {
-      window.location.hash = `#turn-${turnIndex}`;
-    }
+    void onJump(hovered.seq);
   };
 
   let previousTickLabelX = Number.NEGATIVE_INFINITY;
@@ -4809,7 +5199,6 @@ function ContextWindowStrip({
                   })}
                 </g>
                 {compactionMarks.map(({ compaction, x }, compactionIndex) => {
-                  const turnIndex = indexBySeq.get(compaction.seq);
                   const label = compactionLabels[compactionIndex];
                   const marker = (
                     <g className="ctx-strip-compaction" key={`marker-${compaction.seq}`}>
@@ -4832,12 +5221,17 @@ function ContextWindowStrip({
                       </rect>
                     </g>
                   );
-                  return turnIndex != null ? (
-                    <a href={`#turn-${turnIndex}`} key={`compaction-${compaction.seq}`}>
+                  return (
+                    <a
+                      href={`#message-${compaction.seq}`}
+                      key={`compaction-${compaction.seq}`}
+                      onClick={(event) => {
+                        event.preventDefault();
+                        void onJump(compaction.seq);
+                      }}
+                    >
                       {marker}
                     </a>
-                  ) : (
-                    <g key={`compaction-${compaction.seq}`}>{marker}</g>
                   );
                 })}
                 {peakPoint != null && peakIndex !== lastIndex ? (
@@ -4947,9 +5341,11 @@ function compactionLabel(compaction: ContextWindowCompactionData): string {
 function TranscriptBlock({
   block,
   subagents = [],
+  tool = "",
 }: {
   block: TranscriptBlockData;
   subagents?: SubagentDetailData[];
+  tool?: string;
 }) {
   if (block.block_type === "tool_use") {
     return (
@@ -4998,7 +5394,7 @@ function TranscriptBlock({
   }
   const special = specialTranscriptBlock(block.text);
   if (special != null) {
-    return <SpecialTranscriptBlock block={special} />;
+    return <SpecialTranscriptBlock block={special} tool={tool} />;
   }
   return <p className="text-block">{block.text}</p>;
 }
@@ -5073,10 +5469,20 @@ type SpecialTranscriptBlockData = {
   tooltip: string;
   icon: IconName;
   chips: string[];
+  kind?: StructuredTranscriptKind;
+  dialogue?: StructuredTranscriptLine[];
 };
 
 function specialTranscriptBlock(text: string): SpecialTranscriptBlockData | null {
   const trimmed = text.trimStart();
+  const structured = structuredTranscriptBlock(text);
+  if (structured != null) {
+    return {
+      ...structured,
+      icon: structuredTranscriptIcon(structured.kind),
+      tooltip: structuredTranscriptTooltip(structured.kind),
+    };
+  }
   if (isPermissionsText(text)) {
     const sandbox = matchText(text, /`sandbox_mode`\s+is\s+`([^`]+)`/);
     const approval = matchText(text, /Approval policy is currently ([^.]+)\./);
@@ -5173,11 +5579,20 @@ function specialTranscriptBlock(text: string): SpecialTranscriptBlockData | null
   return null;
 }
 
-function SpecialTranscriptBlock({ block }: { block: SpecialTranscriptBlockData }) {
+function SpecialTranscriptBlock({
+  block,
+  tool,
+}: {
+  block: SpecialTranscriptBlockData;
+  tool: string;
+}) {
   return (
     <Tooltip content={block.tooltip}>
       {(tooltipProps) => (
-        <div className="special-block" {...tooltipProps}>
+        <div
+          className={`special-block${block.kind != null ? ` is-${block.kind}` : ""}`}
+          {...tooltipProps}
+        >
           <span className="special-icon">
             <Icon name={block.icon} />
           </span>
@@ -5196,11 +5611,53 @@ function SpecialTranscriptBlock({ block }: { block: SpecialTranscriptBlockData }
                 ))}
               </div>
             ) : null}
+            {block.dialogue != null && block.dialogue.length > 0 ? (
+              <div className="realtime-dialogue">
+                {keyedTranscriptLines(block.dialogue).map(({ key, line }) => (
+                  <div className={`realtime-line is-${line.speaker}`} key={key}>
+                    <TranscriptSpeakerBadge speaker={line.speaker} tool={tool} />
+                    <p>{line.text}</p>
+                  </div>
+                ))}
+              </div>
+            ) : null}
           </div>
         </div>
       )}
     </Tooltip>
   );
+}
+
+function structuredTranscriptIcon(kind: StructuredTranscriptKind): IconName {
+  if (kind === "realtime-ended") {
+    return "clock";
+  }
+  if (kind === "realtime-handoff") {
+    return "messages";
+  }
+  return "cpu";
+}
+
+function keyedTranscriptLines(
+  lines: readonly StructuredTranscriptLine[],
+): { key: string; line: StructuredTranscriptLine }[] {
+  const occurrences = new Map<string, number>();
+  return lines.map((line) => {
+    const base = `${line.speaker}:${line.text}`;
+    const occurrence = (occurrences.get(base) ?? 0) + 1;
+    occurrences.set(base, occurrence);
+    return { key: `${base}:${occurrence}`, line };
+  });
+}
+
+function structuredTranscriptTooltip(kind: StructuredTranscriptKind): string {
+  if (kind === "realtime-ended") {
+    return "Marks the point where a realtime voice conversation returned to normal typed chat.";
+  }
+  if (kind === "realtime-handoff") {
+    return "A structured voice-mode envelope rendered as readable dialogue instead of raw runtime markup.";
+  }
+  return "Agent coordination instructions supplied by the runtime, summarized without the raw internal boilerplate.";
 }
 
 function matchText(value: string, pattern: RegExp): string | null {
@@ -5241,27 +5698,26 @@ function SubagentCard({ subagent }: { subagent: SubagentDetailData }) {
         </div>
       ) : (
         <div className="subagent-transcript">
-          {messages.map((message, index) =>
+          {messages.map((message) =>
             message.is_compact_boundary ? (
-              <CompactionTurn
-                compaction={null}
-                index={index}
-                key={messageKey(message, index)}
-                message={message}
-              />
+              <CompactionTurn compaction={null} key={messageKey(message)} message={message} />
             ) : (
-              <article className="turn is-subagent" key={messageKey(message, index)}>
-                <Badge mono tone={message.is_compact_summary ? "accent" : roleTone(message.role)}>
-                  {message.is_compact_summary
-                    ? "Summary"
-                    : roleLabel(message.role, subagent.summary.tool)}
-                </Badge>
+              <article
+                className={`turn is-subagent${
+                  message.role === "assistant"
+                    ? ` provider-${providerIdentity(subagent.summary.tool).key}`
+                    : ""
+                }`}
+                key={messageKey(message)}
+              >
+                <TranscriptIdentityBadge message={message} tool={subagent.summary.tool} />
                 <div className="turn-body">
                   {message.blocks.map((block, blockIndex) => (
                     <TranscriptBlock
                       block={block}
                       key={blockKey(block, blockIndex)}
                       subagents={nested.get(block.tool_use_id ?? "") ?? []}
+                      tool={subagent.summary.tool}
                     />
                   ))}
                 </div>
@@ -5314,7 +5770,7 @@ function renderableMessages(
 }
 
 function threadToc(messages: SessionDetailData["messages"]): ThreadTocItem[] {
-  return messages.flatMap((message, index) => {
+  return messages.flatMap((message) => {
     // Compact summaries are machine-generated continuations, not prompts.
     if (message.role !== "user" || message.is_compact_summary) {
       return [];
@@ -5327,7 +5783,7 @@ function threadToc(messages: SessionDetailData["messages"]): ThreadTocItem[] {
     }
     return [
       {
-        index,
+        seq: message.seq,
         ...tocPresentation(label),
         tools: message.blocks.filter((block) => block.block_type === "tool_use").length,
       },
@@ -5335,8 +5791,16 @@ function threadToc(messages: SessionDetailData["messages"]): ThreadTocItem[] {
   });
 }
 
+function threadTocFromOutline(outline: SessionOutlineItemData[]): ThreadTocItem[] {
+  return outline.map((item) => ({
+    seq: item.seq,
+    ...tocPresentation(item.text),
+    tools: 0,
+  }));
+}
+
 type ThreadTocItem = {
-  index: number;
+  seq: number;
   label: string;
   tools: number;
   icon: IconName;
@@ -5357,7 +5821,7 @@ function threadStats(
   fullTurnCount?: number | null,
 ) {
   return {
-    turns: fullTurnCount ?? toc.length,
+    turns: fullTurnCount != null && fullTurnCount > 0 ? fullTurnCount : toc.length,
     replies: messages.filter((message) => message.role === "assistant").length,
     toolCalls: messages.reduce(
       (sum, message) =>
@@ -5368,14 +5832,8 @@ function threadStats(
   };
 }
 
-function messageKey(message: SessionDetailData["messages"][number], index: number): string {
-  return [
-    index,
-    message.role,
-    message.timestamp ?? "no-time",
-    message.model ?? "no-model",
-    message.blocks.map((block) => `${block.ordinal}:${block.block_type}`).join(","),
-  ].join("|");
+function messageKey(message: SessionDetailData["messages"][number]): string {
+  return `${message.seq}:${message.role}`;
 }
 
 function blockKey(block: TranscriptBlockData, index: number): string {
@@ -5388,24 +5846,151 @@ function blockKey(block: TranscriptBlockData, index: number): string {
   ].join("|");
 }
 
-function roleTone(role: string): BadgeTone {
-  return role === "assistant" ? "accent" : role === "tool" ? "info" : "neutral";
+function TranscriptIdentityBadge({
+  message,
+  tool,
+}: {
+  message: SessionDetailData["messages"][number];
+  tool: string;
+}) {
+  if (message.is_compact_summary) {
+    return (
+      <Badge mono tone="accent">
+        <Icon name="refresh" />
+        Summary
+      </Badge>
+    );
+  }
+  const specialKind = messageSpecialKind(message);
+  if (specialKind != null) {
+    const realtime = specialKind === "realtime-ended" || specialKind === "realtime-handoff";
+    return (
+      <Badge tone={realtime ? "info" : "neutral"}>
+        <Icon name={realtime ? "messages" : "shield"} />
+        {realtime ? "Realtime" : "Runtime"}
+      </Badge>
+    );
+  }
+  if (message.role === "assistant") {
+    const provider = providerIdentity(tool);
+    return (
+      <Badge tone={provider.tone}>
+        {provider.icon == null ? <Icon name="cpu" /> : <BrandMark name={provider.icon} />}
+        {provider.label}
+      </Badge>
+    );
+  }
+  if (message.role === "tool") {
+    return (
+      <Badge tone="info">
+        <Icon name="tools" />
+        Tool
+      </Badge>
+    );
+  }
+  if (message.role === "system") {
+    return (
+      <Badge>
+        <Icon name="shield" />
+        System
+      </Badge>
+    );
+  }
+  return <Badge>You</Badge>;
 }
 
-function roleLabel(role: string, tool: string): string {
-  if (role === "user") {
-    return "You";
+function TranscriptSpeakerBadge({
+  speaker,
+  tool,
+}: {
+  speaker: StructuredTranscriptLine["speaker"];
+  tool: string;
+}) {
+  if (speaker === "user") {
+    return <span className="realtime-speaker">You</span>;
   }
-  if (role === "assistant") {
-    return tool === "codex" ? "Codex" : "Claude";
+  const provider = providerIdentity(tool);
+  return (
+    <span className={`realtime-speaker tone-${provider.tone}`}>
+      {provider.icon == null ? <Icon name="cpu" /> : <BrandMark name={provider.icon} />}
+      {provider.label}
+    </span>
+  );
+}
+
+function messageSpecialKind(
+  message: SessionDetailData["messages"][number],
+): StructuredTranscriptKind | "runtime" | null {
+  const blocks = message.blocks.filter(
+    (block) => block.block_type === "text" && isPresent(block.text),
+  );
+  if (blocks.length === 0 || blocks.length !== message.blocks.length) {
+    return null;
   }
-  if (role === "tool") {
-    return "Tool";
+  let kind: StructuredTranscriptKind | "runtime" | null = null;
+  for (const block of blocks) {
+    const special = specialTranscriptBlock(block.text ?? "");
+    if (special == null) {
+      return null;
+    }
+    kind ??= special.kind ?? "runtime";
   }
-  if (role === "system") {
-    return "System";
+  return kind;
+}
+
+function providerIdentity(tool: string): {
+  key: "assistant" | "claude" | "openai";
+  label: string;
+  tone: BadgeTone;
+  icon: BrandIconName | null;
+} {
+  if (tool === "claude_code") {
+    return { key: "claude", label: "Claude", tone: "claude", icon: "claude" };
   }
-  return role;
+  if (tool === "codex") {
+    return { key: "openai", label: "Codex", tone: "openai", icon: "openai" };
+  }
+  return { key: "assistant", label: "Assistant", tone: "accent", icon: null };
+}
+
+function nearestTranscriptSeq(sequences: readonly number[]): number | null {
+  let nearest: { distance: number; seq: number } | null = null;
+  const readingLine = 184;
+  for (const seq of sequences) {
+    const element = document.getElementById(`message-${seq}`);
+    if (element == null) {
+      continue;
+    }
+    const bounds = element.getBoundingClientRect();
+    if (bounds.bottom < readingLine) {
+      continue;
+    }
+    const distance = Math.abs(bounds.top - readingLine);
+    if (nearest == null || distance < nearest.distance) {
+      nearest = { distance, seq };
+    }
+  }
+  return nearest?.seq ?? sequences[0] ?? null;
+}
+
+function scrollTranscriptMessage(seq: number) {
+  document.getElementById(`message-${seq}`)?.scrollIntoView({
+    behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
+    block: "start",
+  });
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  return (
+    target.isContentEditable ||
+    target.matches("input, textarea, select") ||
+    target.closest(
+      "a, button, summary, input, textarea, select, [contenteditable='true'], [role='button'], [role='link'], [role='slider'], [role='tab']",
+    ) != null
+  );
 }
 
 async function getJson<T>(path: string, init?: RequestInit): Promise<T> {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2309,6 +2309,42 @@ mark {
   color: var(--fg);
 }
 
+.toc a.is-loading {
+  background: color-mix(in oklab, var(--accent) 9%, transparent);
+  color: var(--accent);
+}
+
+.toc a.is-current {
+  background: color-mix(in oklab, var(--accent) 12%, transparent);
+  color: var(--fg);
+}
+
+.toc-hotkeys {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: -2px 0 7px;
+  color: var(--faint);
+  font-size: 10px;
+}
+
+.toc-hotkeys > span {
+  display: inline-flex;
+  gap: 3px;
+}
+
+.toc-hotkeys kbd {
+  min-width: 19px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--muted);
+  font-family: inherit;
+  font-size: 10px;
+  line-height: 17px;
+  text-align: center;
+}
+
 .toc-icon {
   display: inline-grid;
   width: 18px;
@@ -2351,8 +2387,27 @@ mark {
 }
 
 .turn {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 180px;
   min-width: 0;
+  border-radius: 8px;
   scroll-margin-top: 176px;
+  transition:
+    box-shadow 160ms ease,
+    background-color 160ms ease;
+}
+
+.turn.is-keyboard-active {
+  background: color-mix(in oklab, var(--accent) 4%, transparent);
+  box-shadow: 0 0 0 6px color-mix(in oklab, var(--accent) 9%, transparent);
+}
+
+.provider-claude {
+  --turn-rail: color-mix(in oklab, var(--claude) 62%, var(--line));
+}
+
+.provider-openai {
+  --turn-rail: color-mix(in oklab, var(--fg) 38%, var(--line));
 }
 
 .turn-meta {
@@ -2370,7 +2425,7 @@ mark {
   min-width: 0;
   gap: 8px;
   margin-top: 8px;
-  border-left: 2px solid var(--line);
+  border-left: 2px solid var(--turn-rail, var(--line));
   padding-left: 14px;
 }
 
@@ -2470,6 +2525,23 @@ mark {
   height: 15px;
 }
 
+.special-block.is-realtime-ended,
+.special-block.is-realtime-handoff {
+  border-color: color-mix(in oklab, var(--info) 24%, var(--line));
+  background: color-mix(in oklab, var(--info) 5%, var(--elevated));
+}
+
+.special-block.is-realtime-ended .special-icon,
+.special-block.is-realtime-handoff .special-icon {
+  background: color-mix(in oklab, var(--info) 14%, transparent);
+  color: var(--info);
+}
+
+.special-block.is-collaboration,
+.special-block.is-collaboration-mode {
+  border-color: color-mix(in oklab, var(--accent) 22%, var(--line));
+}
+
 .special-heading {
   display: flex;
   min-width: 0;
@@ -2507,6 +2579,56 @@ mark {
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   font-size: 11px;
   padding: 2px 6px;
+}
+
+.realtime-dialogue {
+  display: grid;
+  overflow: hidden;
+  margin-top: 10px;
+  border: 1px solid color-mix(in oklab, var(--info) 18%, var(--line));
+  border-radius: 7px;
+  background: color-mix(in oklab, var(--canvas) 42%, transparent);
+}
+
+.realtime-line {
+  display: grid;
+  grid-template-columns: 74px minmax(0, 1fr);
+  align-items: start;
+  gap: 10px;
+  border-bottom: 1px solid var(--line);
+  padding: 8px 10px;
+}
+
+.realtime-line:last-child {
+  border-bottom: 0;
+}
+
+.realtime-line.is-user {
+  background: color-mix(in oklab, var(--surface) 55%, transparent);
+}
+
+.realtime-speaker {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.realtime-speaker svg {
+  width: 13px;
+  height: 13px;
+  flex: 0 0 auto;
+  fill: currentColor;
+}
+
+.special-block .realtime-line p {
+  margin: 0;
+  color: var(--fg);
+  font-size: 13px;
+  line-height: 1.48;
+  white-space: pre-wrap;
 }
 
 .subagent-card {
@@ -2586,13 +2708,50 @@ mark {
   border-left-color: var(--line);
 }
 
-.transcript-slice-note {
+.transcript-load-more,
+.transcript-end,
+.transcript-window-start {
+  display: flex;
+  min-height: 64px;
+  align-items: center;
+  justify-content: center;
   border: 1px solid var(--line);
   border-radius: 8px;
   background: var(--surface);
   color: var(--muted);
   font-size: 12px;
   padding: 10px 12px;
+  text-align: center;
+}
+
+.transcript-window-start {
+  min-height: 44px;
+  justify-content: space-between;
+  gap: 12px;
+  border-style: dashed;
+  background: transparent;
+  text-align: left;
+}
+
+.transcript-load-more {
+  gap: 12px;
+}
+
+.transcript-load-more > span {
+  display: grid;
+  gap: 3px;
+}
+
+.transcript-load-more small {
+  color: var(--faint);
+  font-variant-numeric: tabular-nums;
+}
+
+.transcript-end {
+  min-height: 44px;
+  border-style: dashed;
+  background: transparent;
+  color: var(--faint);
 }
 
 pre {
@@ -2725,6 +2884,34 @@ pre {
 
 .context-window-panel .ctx-strip-wrap {
   padding: 6px 16px 10px;
+}
+
+.ctx-unavailable {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  align-items: start;
+  gap: 10px;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  padding: 14px 16px 16px;
+}
+
+.ctx-unavailable > svg {
+  width: 18px;
+  height: 18px;
+  margin-top: 1px;
+  color: var(--faint);
+}
+
+.ctx-unavailable strong {
+  color: var(--fg);
+  font-size: 13px;
+}
+
+.ctx-unavailable p {
+  margin: 3px 0 0;
+  font-size: 12px;
+  line-height: 1.5;
 }
 
 .ctx-strip-frame {

--- a/src/ui/transcript-navigation.ts
+++ b/src/ui/transcript-navigation.ts
@@ -1,0 +1,51 @@
+export type TranscriptNavigationDirection = -1 | 1;
+
+export interface TranscriptNavigationKey {
+  key: string;
+  altKey?: boolean;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  shiftKey?: boolean;
+}
+
+export function transcriptNavigationDirection(
+  event: TranscriptNavigationKey,
+): TranscriptNavigationDirection | null {
+  if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+    return null;
+  }
+  if (event.key === "ArrowDown") {
+    return 1;
+  }
+  if (event.key === "ArrowUp") {
+    return -1;
+  }
+  return null;
+}
+
+export function nextTranscriptSeq(
+  sequences: readonly number[],
+  activeSeq: number | null,
+  direction: TranscriptNavigationDirection,
+): number | null {
+  if (sequences.length === 0) {
+    return null;
+  }
+  if (activeSeq == null) {
+    return direction === 1 ? (sequences[0] ?? null) : (sequences.at(-1) ?? null);
+  }
+  const activeIndex = sequences.indexOf(activeSeq);
+  if (activeIndex === -1) {
+    return direction === 1 ? (sequences[0] ?? null) : (sequences.at(-1) ?? null);
+  }
+  return sequences[activeIndex + direction] ?? null;
+}
+
+export function transcriptSeqFromHash(hash: string): number | null {
+  const match = hash.match(/^#message-(\d+)$/);
+  if (match == null) {
+    return null;
+  }
+  const seq = Number(match[1]);
+  return Number.isSafeInteger(seq) ? seq : null;
+}

--- a/src/ui/transcript-pagination.ts
+++ b/src/ui/transcript-pagination.ts
@@ -1,0 +1,23 @@
+export interface SequencedTranscriptMessage {
+  seq: number;
+}
+
+/**
+ * Append a transcript page without duplicating rows if a retry overlaps the
+ * previous page. Message sequence numbers are unique within a session.
+ */
+export function appendTranscriptPage<T extends SequencedTranscriptMessage>(
+  current: readonly T[],
+  incoming: readonly T[],
+): T[] {
+  if (incoming.length === 0) {
+    return [...current];
+  }
+  const seen = new Set(current.map((message) => message.seq));
+  return [...current, ...incoming.filter((message) => !seen.has(message.seq))];
+}
+
+/** Keep a little preceding context when opening an unloaded outline target. */
+export function transcriptWindowOffset(seq: number, contextBefore = 20): number {
+  return Math.max(0, Math.trunc(seq) - Math.max(0, Math.trunc(contextBefore)));
+}

--- a/src/ui/transcript-pagination.ts
+++ b/src/ui/transcript-pagination.ts
@@ -2,6 +2,41 @@ export interface SequencedTranscriptMessage {
   seq: number;
 }
 
+export interface TranscriptRequestRef<T> {
+  current: Promise<T> | null;
+}
+
+/**
+ * Wait for the shared transcript request slot, then claim it before yielding.
+ * Re-checking the ref after every await serializes callers that resume from the
+ * same request.
+ */
+export async function runWithTranscriptRequestSlot<T>(
+  requestRef: TranscriptRequestRef<T>,
+  isCurrent: () => boolean,
+  staleValue: T,
+  startRequest: () => Promise<T>,
+): Promise<T> {
+  while (requestRef.current != null) {
+    await requestRef.current;
+    if (!isCurrent()) {
+      return staleValue;
+    }
+  }
+  if (!isCurrent()) {
+    return staleValue;
+  }
+  const request = startRequest();
+  requestRef.current = request;
+  try {
+    return await request;
+  } finally {
+    if (requestRef.current === request) {
+      requestRef.current = null;
+    }
+  }
+}
+
 /**
  * Append a transcript page without duplicating rows if a retry overlaps the
  * previous page. Message sequence numbers are unique within a session.

--- a/src/ui/transcript-presentation.ts
+++ b/src/ui/transcript-presentation.ts
@@ -1,0 +1,145 @@
+export type StructuredTranscriptKind =
+  | "collaboration"
+  | "collaboration-mode"
+  | "realtime-ended"
+  | "realtime-handoff";
+
+export type StructuredTranscriptSpeaker = "assistant" | "user";
+
+export interface StructuredTranscriptLine {
+  speaker: StructuredTranscriptSpeaker;
+  text: string;
+}
+
+export interface StructuredTranscriptBlock {
+  kind: StructuredTranscriptKind;
+  title: string;
+  description: string;
+  chips: string[];
+  dialogue: StructuredTranscriptLine[];
+}
+
+export function structuredTranscriptBlock(text: string): StructuredTranscriptBlock | null {
+  const trimmed = text.trim();
+  if (/^<realtime_conversation>/i.test(trimmed)) {
+    const reason = matchText(trimmed, /(?:^|\n)Reason:\s*([^\r\n<]+)/i);
+    return {
+      kind: "realtime-ended",
+      title: "Realtime conversation ended",
+      description:
+        reason?.toLowerCase() === "inactive"
+          ? "Voice mode ended after a period of inactivity. The conversation continued in text."
+          : "Voice mode ended and the conversation continued in text.",
+      chips: ["voice", reason == null ? "ended" : reason],
+      dialogue: [],
+    };
+  }
+
+  if (/^<realtime_delegation>/i.test(trimmed)) {
+    const source = tagContents(trimmed, "source");
+    const input = tagContents(trimmed, "input");
+    const delta = tagContents(trimmed, "transcript_delta");
+    const dialogue =
+      delta == null
+        ? directVoiceInput(input)
+        : parseTranscriptDialogue(decodeXmlEntities(delta).trim());
+    const tailFlush = source === "transcript_tail_flush";
+    return {
+      kind: "realtime-handoff",
+      title: tailFlush ? "Realtime handoff" : "Voice input",
+      description: tailFlush
+        ? "The final voice exchange was handed back to the agent before returning to text."
+        : "Spoken input captured during the realtime conversation.",
+      chips: [
+        "voice",
+        tailFlush ? "final exchange" : "live input",
+        dialogue.length === 0
+          ? null
+          : `${dialogue.length} ${dialogue.length === 1 ? "message" : "messages"}`,
+      ].filter((value): value is string => value != null),
+      dialogue,
+    };
+  }
+
+  if (
+    /^You are `\/root`, the primary agent in a team of agents collaborating/i.test(trimmed) ||
+    (trimmed.includes("collaboration tools cannot be called from inside") &&
+      trimmed.includes("All agents share the same directory"))
+  ) {
+    const slots = matchText(trimmed, /There are\s+(\d+)\s+available concurrency slots/i);
+    return {
+      kind: "collaboration",
+      title: "Multi-agent collaboration",
+      description:
+        "This session uses a primary coordinator that can delegate work to agents sharing the same workspace.",
+      chips: ["primary agent", slots == null ? null : `${slots} slots`, "shared workspace"].filter(
+        (value): value is string => value != null,
+      ),
+      dialogue: [],
+    };
+  }
+
+  if (/^<multi_agent_mode>/i.test(trimmed)) {
+    const delegationDisabled = /do not spawn sub-agents unless/i.test(trimmed);
+    return {
+      kind: "collaboration-mode",
+      title: "Collaboration mode",
+      description: delegationDisabled
+        ? "Subagent delegation is disabled unless the user or repository instructions request it."
+        : "Runtime guidance for how this session may delegate work to other agents.",
+      chips: [delegationDisabled ? "delegation on request" : "agent coordination"],
+      dialogue: [],
+    };
+  }
+
+  return null;
+}
+
+export function parseTranscriptDialogue(value: string): StructuredTranscriptLine[] {
+  const marker = /(?:^|\n)\s*(assistant|user):\s*/gi;
+  const matches = [...value.matchAll(marker)];
+  return matches.flatMap((match, index) => {
+    const speaker = match[1]?.toLowerCase();
+    const start = (match.index ?? 0) + match[0].length;
+    const end = matches[index + 1]?.index ?? value.length;
+    const text = value.slice(start, end).trim();
+    if ((speaker !== "assistant" && speaker !== "user") || text === "") {
+      return [];
+    }
+    return [{ speaker, text }];
+  });
+}
+
+function directVoiceInput(input: string | null): StructuredTranscriptLine[] {
+  if (
+    input == null ||
+    input === "" ||
+    /^The user just ended their realtime session\./i.test(input)
+  ) {
+    return [];
+  }
+  const text = decodeXmlEntities(stripTags(input)).trim();
+  return text === "" ? [] : [{ speaker: "user", text }];
+}
+
+function tagContents(value: string, tag: string): string | null {
+  const match = value.match(new RegExp(`<${tag}>([\\s\\S]*?)<\\/${tag}>`, "i"));
+  return match?.[1]?.trim() ?? null;
+}
+
+function matchText(value: string, pattern: RegExp): string | null {
+  return value.match(pattern)?.[1]?.trim() ?? null;
+}
+
+function stripTags(value: string): string {
+  return value.replace(/<[^>]+>/g, " ");
+}
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&amp;", "&");
+}

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -197,8 +197,8 @@ describe("upsertSession", () => {
     const db = openFreshDb(dir);
     const parsed = parseClaudeSession("sample", fixture("claude", "sample.jsonl"));
 
-    upsertSession(db, parsed, "/x/sample.jsonl", 1, 2, "a");
-    upsertSession(db, parsed, "/x/sample-again.jsonl", 3, 4, "b");
+    const firstId = upsertSession(db, parsed, "/x/sample.jsonl", 1, 2, "a");
+    const replacedId = upsertSession(db, parsed, "/x/sample-again.jsonl", 3, 4, "b");
 
     const counts = db
       .query(
@@ -223,6 +223,7 @@ describe("upsertSession", () => {
       economics: 1,
       source_path: "/x/sample-again.jsonl",
     });
+    expect(replacedId).toBe(firstId);
     db.close();
   });
 

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -227,6 +227,25 @@ describe("upsertSession", () => {
     db.close();
   });
 
+  test("preserves the numeric session id when replacing an existing natural session", () => {
+    const dir = freshCase();
+    const db = openFreshDb(dir);
+    const parsed = parseClaudeSession("sample", fixture("claude", "sample.jsonl"));
+    const sibling = parseClaudeSession("sibling", fixture("claude", "sample.jsonl"));
+
+    const firstId = upsertSession(db, parsed, "/x/sample.jsonl", 1, 2, "a");
+    // A second session has to exist for this to prove anything. With only one
+    // row, SQLite's default `max(rowid) + 1` allocation hands back the same id
+    // after the delete whether or not it was preserved, so the assertion below
+    // would pass even with the preservation removed.
+    upsertSession(db, sibling, "/x/sibling.jsonl", 1, 2, "c");
+    const replacedId = upsertSession(db, parsed, "/x/sample-again.jsonl", 3, 4, "b");
+
+    expect(firstId).toBe(1);
+    expect(replacedId).toBe(firstId);
+    db.close();
+  });
+
   test("writes a session without creating a project when no project path is present", () => {
     const dir = freshCase();
     const db = openFreshDb(dir);

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -5,7 +5,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { openDb } from "../src/db.ts";
 import { upsertSession } from "../src/ingest.ts";
-import { getSession, type ListFilter, listProjects, listSessions, search } from "../src/query.ts";
+import {
+  getSession,
+  getSessionOutline,
+  type ListFilter,
+  listProjects,
+  listSessions,
+  search,
+} from "../src/query.ts";
 import { parseClaudeSession } from "../src/sources/claude.ts";
 import { preview } from "../src/tools.ts";
 
@@ -44,6 +51,27 @@ describe("query reads", () => {
     const hits = search(db, "auth", 10);
     expect(hits.length).toBeGreaterThan(0);
     expect(hits[0]?.tool).toBe("claude_code");
+    db.close();
+  });
+
+  test("pages session messages and returns a lightweight complete prompt outline", () => {
+    const db = seeded();
+    const id = listSessions(db)[0]?.id ?? 0;
+
+    expect(getSession(db, id, { messageLimit: 2, messageOffset: 0 })).toMatchObject({
+      messages: [{ seq: 0 }, { seq: 1 }],
+      message_offset: 0,
+      message_limit: 2,
+      has_more_messages: true,
+    });
+    expect(getSession(db, id, { messageLimit: 2, messageOffset: 2 })).toMatchObject({
+      messages: [{ seq: 2 }, { seq: 3 }],
+      message_offset: 2,
+      message_limit: 2,
+      has_more_messages: false,
+    });
+    expect(getSessionOutline(db, id)).toEqual([{ seq: 0, text: "Fix the failing auth test" }]);
+    expect(getSessionOutline(db, 999_999)).toBeNull();
     db.close();
   });
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -308,6 +308,34 @@ describe("server routes", () => {
       summary: { id },
       messages: expect.any(Array),
     });
+    const firstMessagePage = await route(
+      config,
+      `/api/sessions/${id}?message_limit=2&message_offset=0`,
+    );
+    expect(firstMessagePage.body).toMatchObject({
+      messages: [{ seq: 0 }, { seq: 1 }],
+      message_offset: 0,
+      message_limit: 2,
+      has_more_messages: true,
+    });
+    const messageCount = (detail.body as { summary: { message_count: number } }).summary
+      .message_count;
+    const lastMessagePage = await route(
+      config,
+      `/api/sessions/${id}?message_limit=2&message_offset=${Math.max(0, messageCount - 1)}`,
+    );
+    expect(lastMessagePage.body).toMatchObject({
+      messages: expect.any(Array),
+      message_offset: Math.max(0, messageCount - 1),
+      message_limit: 2,
+      has_more_messages: false,
+    });
+    const outline = await route(config, `/api/sessions/${id}/outline`);
+    expect(outline.status).toBe(200);
+    expect(outline.body).toEqual([
+      expect.objectContaining({ seq: expect.any(Number), text: expect.any(String) }),
+    ]);
+    expect((await route(config, "/api/sessions/999999/outline")).status).toBe(404);
 
     const search = await route(config, "/api/search", {
       method: "POST",

--- a/test/ui-context-window-state.test.ts
+++ b/test/ui-context-window-state.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { contextWindowDisplayMode } from "../src/ui/context-window-state.ts";
+
+describe("context window display state", () => {
+  test("renders a chart for a valid single-call timeline", () => {
+    expect(contextWindowDisplayMode({ window_tokens: 258_400, points: [{ seq: 2 }] })).toBe(
+      "chart",
+    );
+  });
+
+  test("explains incomplete source data instead of silently hiding the panel", () => {
+    expect(contextWindowDisplayMode({ window_tokens: null, points: [{ seq: 2 }] })).toBe(
+      "unavailable",
+    );
+    expect(contextWindowDisplayMode({ window_tokens: 258_400, points: [] })).toBe("unavailable");
+    expect(contextWindowDisplayMode(null)).toBe("hidden");
+  });
+});

--- a/test/ui-transcript-navigation.test.ts
+++ b/test/ui-transcript-navigation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import {
+  nextTranscriptSeq,
+  transcriptNavigationDirection,
+  transcriptSeqFromHash,
+} from "../src/ui/transcript-navigation.ts";
+
+describe("transcript keyboard navigation", () => {
+  test("maps unmodified arrow keys and leaves modified shortcuts alone", () => {
+    expect(transcriptNavigationDirection({ key: "ArrowDown" })).toBe(1);
+    expect(transcriptNavigationDirection({ key: "ArrowUp" })).toBe(-1);
+    expect(transcriptNavigationDirection({ key: "ArrowDown", metaKey: true })).toBeNull();
+    expect(transcriptNavigationDirection({ key: "ArrowUp", shiftKey: true })).toBeNull();
+    expect(transcriptNavigationDirection({ key: "Enter" })).toBeNull();
+  });
+
+  test("moves through sparse message sequences in either direction", () => {
+    const sequences = [4, 7, 43, 56];
+    expect(nextTranscriptSeq(sequences, null, 1)).toBe(4);
+    expect(nextTranscriptSeq(sequences, 7, 1)).toBe(43);
+    expect(nextTranscriptSeq(sequences, 43, -1)).toBe(7);
+    expect(nextTranscriptSeq(sequences, 56, 1)).toBeNull();
+  });
+
+  test("recognizes stable message anchors without accepting malformed hashes", () => {
+    expect(transcriptSeqFromHash("#message-1574")).toBe(1574);
+    expect(transcriptSeqFromHash("#message-nope")).toBeNull();
+    expect(transcriptSeqFromHash("#turn-4")).toBeNull();
+  });
+});

--- a/test/ui-transcript-pagination.test.ts
+++ b/test/ui-transcript-pagination.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, test } from "bun:test";
-import { appendTranscriptPage, transcriptWindowOffset } from "../src/ui/transcript-pagination.ts";
+import {
+  appendTranscriptPage,
+  runWithTranscriptRequestSlot,
+  transcriptWindowOffset,
+} from "../src/ui/transcript-pagination.ts";
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve = () => {};
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function nextMicrotask(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 describe("transcript pagination", () => {
   test("appends a page in order and removes retry overlap by sequence", () => {
@@ -28,5 +45,56 @@ describe("transcript pagination", () => {
   test("opens unloaded outline targets with bounded preceding context", () => {
     expect(transcriptWindowOffset(1_574)).toBe(1_554);
     expect(transcriptWindowOffset(8)).toBe(0);
+  });
+
+  test("serializes callers that were waiting on the same active request", async () => {
+    const requestRef: { current: Promise<void> | null } = { current: null };
+    const initial = deferred();
+    requestRef.current = initial.promise.then(() => {
+      requestRef.current = null;
+    });
+    const started: { label: string; resolve: () => void }[] = [];
+
+    const startWindow = async (label: string) => {
+      await runWithTranscriptRequestSlot(
+        requestRef,
+        () => true,
+        undefined,
+        async () => {
+          const gate = deferred();
+          started.push({ label, resolve: gate.resolve });
+          await gate.promise;
+        },
+      );
+    };
+
+    const first = startWindow("first");
+    const second = startWindow("second");
+    initial.resolve();
+    await nextMicrotask();
+    expect(started.map((item) => item.label)).toEqual(["first"]);
+
+    started[0]?.resolve();
+    await nextMicrotask();
+    expect(started.map((item) => item.label)).toEqual(["first", "second"]);
+
+    started[1]?.resolve();
+    await Promise.all([first, second]);
+  });
+
+  test("abandons a queued request when its session version becomes stale", async () => {
+    const active = deferred();
+    const requestRef = { current: active.promise as Promise<unknown> | null };
+    let sessionVersion = 1;
+    const waiting = runWithTranscriptRequestSlot(
+      requestRef,
+      () => sessionVersion === 1,
+      "stale",
+      async () => "started",
+    );
+
+    sessionVersion = 2;
+    active.resolve();
+    expect(await waiting).toBe("stale");
   });
 });

--- a/test/ui-transcript-pagination.test.ts
+++ b/test/ui-transcript-pagination.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { appendTranscriptPage, transcriptWindowOffset } from "../src/ui/transcript-pagination.ts";
+
+describe("transcript pagination", () => {
+  test("appends a page in order and removes retry overlap by sequence", () => {
+    const current = [
+      { seq: 0, text: "first" },
+      { seq: 1, text: "second" },
+    ];
+    const incoming = [
+      { seq: 1, text: "duplicate retry" },
+      { seq: 2, text: "third" },
+    ];
+
+    expect(appendTranscriptPage(current, incoming)).toEqual([
+      { seq: 0, text: "first" },
+      { seq: 1, text: "second" },
+      { seq: 2, text: "third" },
+    ]);
+  });
+
+  test("does not mutate the existing message array", () => {
+    const current = [{ seq: 0 }];
+    expect(appendTranscriptPage(current, [])).not.toBe(current);
+    expect(current).toEqual([{ seq: 0 }]);
+  });
+
+  test("opens unloaded outline targets with bounded preceding context", () => {
+    expect(transcriptWindowOffset(1_574)).toBe(1_554);
+    expect(transcriptWindowOffset(8)).toBe(0);
+  });
+});

--- a/test/ui-transcript-presentation.test.ts
+++ b/test/ui-transcript-presentation.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseTranscriptDialogue,
+  structuredTranscriptBlock,
+} from "../src/ui/transcript-presentation.ts";
+
+describe("structured transcript presentation", () => {
+  test("turns realtime lifecycle metadata into a compact event", () => {
+    expect(
+      structuredTranscriptBlock(`<realtime_conversation>
+Realtime conversation ended.
+
+Reason: inactive
+</realtime_conversation>`),
+    ).toEqual({
+      kind: "realtime-ended",
+      title: "Realtime conversation ended",
+      description:
+        "Voice mode ended after a period of inactivity. The conversation continued in text.",
+      chips: ["voice", "inactive"],
+      dialogue: [],
+    });
+  });
+
+  test("extracts a readable multi-speaker realtime handoff", () => {
+    const block = structuredTranscriptBlock(`<realtime_delegation>
+  <source>transcript_tail_flush</source>
+  <input>Internal handoff instruction.</input>
+  <transcript_delta>assistant: Got it.
+user: Please add a Stream Deck button.
+assistant: Bring the profile grid to the foreground.</transcript_delta>
+</realtime_delegation>`);
+
+    expect(block).toMatchObject({
+      kind: "realtime-handoff",
+      title: "Realtime handoff",
+      chips: ["voice", "final exchange", "3 messages"],
+      dialogue: [
+        { speaker: "assistant", text: "Got it." },
+        { speaker: "user", text: "Please add a Stream Deck button." },
+        { speaker: "assistant", text: "Bring the profile grid to the foreground." },
+      ],
+    });
+  });
+
+  test("uses direct delegation input as a voice message", () => {
+    expect(
+      structuredTranscriptBlock(`<realtime_delegation>
+  <input>How can I fix the audio utilities?</input>
+</realtime_delegation>`),
+    ).toMatchObject({
+      kind: "realtime-handoff",
+      title: "Voice input",
+      dialogue: [{ speaker: "user", text: "How can I fix the audio utilities?" }],
+    });
+  });
+
+  test("summarizes primary-agent instructions instead of exposing boilerplate", () => {
+    expect(
+      structuredTranscriptBlock(`You are \`/root\`, the primary agent in a team of agents collaborating to fulfill the user's goals.
+
+All agents share the same directory.
+There are 4 available concurrency slots.`),
+    ).toEqual({
+      kind: "collaboration",
+      title: "Multi-agent collaboration",
+      description:
+        "This session uses a primary coordinator that can delegate work to agents sharing the same workspace.",
+      chips: ["primary agent", "4 slots", "shared workspace"],
+      dialogue: [],
+    });
+  });
+
+  test("keeps ordinary conversation untouched", () => {
+    expect(structuredTranscriptBlock("Please fix the pagination bug.")).toBeNull();
+  });
+});
+
+describe("realtime dialogue parsing", () => {
+  test("preserves wrapped content until the next speaker marker", () => {
+    expect(
+      parseTranscriptDialogue("user: first line\ncontinues here\nassistant: response"),
+    ).toEqual([
+      { speaker: "user", text: "first line\ncontinues here" },
+      { speaker: "assistant", text: "response" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- replace the fixed transcript cap with efficient 160-message pagination, automatic loading near the end, a complete lightweight prompt outline, and bounded deep-link loading
- make long sessions easier to inspect with smooth Up/Down navigation, active-message highlighting, stable message anchors, and interactive-focus guards
- render realtime lifecycle/delegation payloads and multi-agent runtime instructions as readable semantic cards instead of raw protocol text
- add provider-aware Codex/OpenAI and Claude identity treatments, and show honest context-window states for single-call and unavailable legacy data
- preserve numeric session IDs when sync replaces an existing natural session so open session URLs do not sporadically become 404s

## Why

Session detail pages only requested the first page of messages, silently hid some valid or incomplete context-window states, and rendered several runtime payloads as raw plaintext. Reingest also deleted and reinserted session rows without preserving their numeric ID, invalidating bookmarked or already-open `/sessions/:id` routes.

## Review fixes

The final PR-style review found and fixed two additional navigation issues:

- direct `#message-N` URLs could race the asynchronous session render and fail to scroll to the target
- arrow navigation could still fire while a link or other interactive control held focus

Initial hashes now resolve after the session is available, and keyboard navigation checks both the event target and the currently focused element.

## Validation

- `just check`
  - 338 tests passed
  - `bunx tsc --noEmit`
  - `bunx biome check .`
  - native Darwin ARM64 distribution smoke
- live browser smoke on a real long Codex transcript
  - direct `#message-96` navigation loaded and highlighted the target
  - focused outline links ignored ArrowDown
  - blurred ArrowUp moved smoothly to the preceding message
  - realtime protocol tags were absent from the rendered transcript
- repeated CLI sync smoke confirmed the same session retained numeric ID `1` after its source file changed
