### PR TITLE
fix(ui): keep deep links in range and guard non-HTML focus targets

### DIFF
--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -62,6 +62,7 @@ import { compactDateTime, fullDateTime } from "./date-time.ts";
 import { isFramed } from "./frame-guard.ts";
 import { planSessionLoad, shouldShowSessionSkeleton } from "./loading-state.ts";
 import {
+  isInteractiveTarget,
   nextTranscriptSeq,
   type TranscriptNavigationDirection,
   transcriptNavigationDirection,
@@ -69,6 +70,7 @@ import {
 } from "./transcript-navigation.ts";
 import {
   appendTranscriptPage,
+  clampTranscriptWindowOffset,
   runWithTranscriptRequestSlot,
   transcriptWindowOffset,
 } from "./transcript-pagination.ts";
@@ -4313,7 +4315,11 @@ function SessionDetailView({ id }: { id: number }) {
           if (current.messages.some((message) => message.seq === seq)) {
             return true;
           }
-          const offset = transcriptWindowOffset(seq);
+          const offset = clampTranscriptWindowOffset(
+            transcriptWindowOffset(seq),
+            current.summary.message_count,
+            SESSION_DETAIL_MESSAGE_PAGE_SIZE,
+          );
           setLoadingMore(true);
           setLoadMoreError(null);
           return getJson<SessionDetailData>(
@@ -4321,6 +4327,12 @@ function SessionDetailView({ id }: { id: number }) {
           )
             .then((page) => {
               if (sessionVersionRef.current !== sessionVersion) {
+                return false;
+              }
+              // Never trade a populated transcript for an empty one. The clamp
+              // above keeps the offset in range against the count we hold, but
+              // that count can lag the archive after a re-sync.
+              if (page.messages.length === 0) {
                 return false;
               }
               const nextDetail = {
@@ -4469,8 +4481,8 @@ function SessionDetailView({ id }: { id: number }) {
       if (
         direction == null ||
         event.repeat ||
-        isEditableTarget(event.target) ||
-        isEditableTarget(document.activeElement) ||
+        isInteractiveTarget(event.target) ||
+        isInteractiveTarget(document.activeElement) ||
         document.querySelector("[role='dialog']") != null
       ) {
         return;
@@ -6026,19 +6038,6 @@ function scrollTranscriptMessage(seq: number) {
     behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
     block: "start",
   });
-}
-
-function isEditableTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) {
-    return false;
-  }
-  return (
-    target.isContentEditable ||
-    target.matches("input, textarea, select") ||
-    target.closest(
-      "a, button, summary, input, textarea, select, [contenteditable='true'], [role='button'], [role='link'], [role='slider'], [role='tab']",
-    ) != null
-  );
 }
 
 async function getJson<T>(path: string, init?: RequestInit): Promise<T> {

--- a/src/ui/transcript-navigation.ts
+++ b/src/ui/transcript-navigation.ts
@@ -41,6 +41,42 @@ export function nextTranscriptSeq(
   return sequences[activeIndex + direction] ?? null;
 }
 
+const INTERACTIVE_SELECTOR =
+  "a, button, summary, input, textarea, select, [contenteditable='true'], [role='button'], [role='link'], [role='slider'], [role='tab']";
+
+/**
+ * The part of a DOM node this guard actually reads. Matched structurally rather
+ * than with `instanceof HTMLElement`, because focusable nodes outside the HTML
+ * namespace need guarding too: the compaction markers in the context-window
+ * strip are `<a>` elements inside the `<svg>`, so they are `SVGAElement` --
+ * tabbable, focusable, and carrying no `isContentEditable`.
+ */
+export interface TranscriptEventTarget {
+  isContentEditable?: boolean;
+  matches(selectors: string): boolean;
+  closest(selectors: string): unknown;
+}
+
+/**
+ * True when a keyboard event landed on something the page already handles, so
+ * transcript navigation should stand down instead of stealing the key.
+ */
+export function isInteractiveTarget(target: unknown): boolean {
+  if (target == null || typeof target !== "object") {
+    return false;
+  }
+  const candidate = target as Partial<TranscriptEventTarget>;
+  if (typeof candidate.matches !== "function" || typeof candidate.closest !== "function") {
+    return false;
+  }
+  if (candidate.isContentEditable === true) {
+    return true;
+  }
+  return (
+    candidate.matches("input, textarea, select") || candidate.closest(INTERACTIVE_SELECTOR) != null
+  );
+}
+
 export function transcriptSeqFromHash(hash: string): number | null {
   const match = hash.match(/^#message-(\d+)$/);
   if (match == null) {

--- a/src/ui/transcript-pagination.ts
+++ b/src/ui/transcript-pagination.ts
@@ -52,7 +52,33 @@ export function appendTranscriptPage<T extends SequencedTranscriptMessage>(
   return [...current, ...incoming.filter((message) => !seen.has(message.seq))];
 }
 
-/** Keep a little preceding context when opening an unloaded outline target. */
+/**
+ * Keep a little preceding context when opening an unloaded outline target.
+ *
+ * Treats `seq` as a dense, zero-based row index, because the server pages with
+ * `LIMIT/OFFSET` over `ORDER BY seq`. Both parsers currently guarantee that:
+ * every branch that increments `seq` also emits exactly one message. Nothing in
+ * the schema enforces it. A parser that ever skipped a `seq` would send outline
+ * clicks and compaction jumps to a window that does not contain the target.
+ */
 export function transcriptWindowOffset(seq: number, contextBefore = 20): number {
   return Math.max(0, Math.trunc(seq) - Math.max(0, Math.trunc(contextBefore)));
+}
+
+/**
+ * Hold a window offset inside the session so it always addresses a page with
+ * rows in it. Deep links travel between archives: `#message-1400` pasted from a
+ * longer copy of the same session would otherwise request an offset past the
+ * end, get an empty page back, and blank the transcript.
+ */
+export function clampTranscriptWindowOffset(
+  offset: number,
+  messageCount: number,
+  pageSize: number,
+): number {
+  if (!Number.isFinite(messageCount) || messageCount <= 0) {
+    return 0;
+  }
+  const lastPageOffset = Math.max(0, Math.trunc(messageCount) - Math.max(1, Math.trunc(pageSize)));
+  return Math.min(Math.max(0, Math.trunc(offset)), lastPageOffset);
 }

--- a/test/ui-transcript-navigation.test.ts
+++ b/test/ui-transcript-navigation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  isInteractiveTarget,
   nextTranscriptSeq,
   transcriptNavigationDirection,
   transcriptSeqFromHash,
@@ -26,5 +27,42 @@ describe("transcript keyboard navigation", () => {
     expect(transcriptSeqFromHash("#message-1574")).toBe(1574);
     expect(transcriptSeqFromHash("#message-nope")).toBeNull();
     expect(transcriptSeqFromHash("#turn-4")).toBeNull();
+  });
+});
+
+describe("interactive target guard", () => {
+  /** A node that reports itself as sitting inside an anchor. */
+  const insideAnchor = (extra: Record<string, unknown> = {}) => ({
+    matches: () => false,
+    closest: (selectors: string) => (selectors.includes("a,") ? {} : null),
+    ...extra,
+  });
+
+  test("guards focusable elements that are not HTMLElement", () => {
+    // The compaction markers in the context-window strip render as <a> inside
+    // the <svg>, so they are SVGAElement: focusable and tabbable, but carrying
+    // no isContentEditable. Narrowing on HTMLElement let arrow keys fall
+    // through and teleport the transcript while preventDefault() suppressed
+    // the scroll the user actually asked for.
+    expect(isInteractiveTarget(insideAnchor())).toBe(true);
+  });
+
+  test("guards form fields and contenteditable regions", () => {
+    expect(isInteractiveTarget({ matches: () => true, closest: () => null })).toBe(true);
+    expect(
+      isInteractiveTarget({ matches: () => false, closest: () => null, isContentEditable: true }),
+    ).toBe(true);
+  });
+
+  test("lets plain transcript content through", () => {
+    expect(isInteractiveTarget({ matches: () => false, closest: () => null })).toBe(false);
+  });
+
+  test("rejects anything that is not element-shaped", () => {
+    expect(isInteractiveTarget(null)).toBe(false);
+    expect(isInteractiveTarget(undefined)).toBe(false);
+    expect(isInteractiveTarget("article")).toBe(false);
+    expect(isInteractiveTarget({})).toBe(false);
+    expect(isInteractiveTarget({ matches: () => false })).toBe(false);
   });
 });

--- a/test/ui-transcript-pagination.test.ts
+++ b/test/ui-transcript-pagination.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   appendTranscriptPage,
+  clampTranscriptWindowOffset,
   runWithTranscriptRequestSlot,
   transcriptWindowOffset,
 } from "../src/ui/transcript-pagination.ts";
@@ -96,5 +97,29 @@ describe("transcript pagination", () => {
     sessionVersion = 2;
     active.resolve();
     expect(await waiting).toBe("stale");
+  });
+});
+
+describe("transcript window clamping", () => {
+  test("keeps an out-of-range deep link on the last real page", () => {
+    // A link shared from a longer archive -- /sessions/12#message-1400 where
+    // this archive's session 12 holds 200 messages -- used to request offset
+    // 1380, get an empty page back, and blank the transcript.
+    expect(clampTranscriptWindowOffset(transcriptWindowOffset(1400), 200, 160)).toBe(40);
+  });
+
+  test("leaves in-range offsets alone", () => {
+    expect(clampTranscriptWindowOffset(880, 2000, 160)).toBe(880);
+    expect(clampTranscriptWindowOffset(0, 2000, 160)).toBe(0);
+  });
+
+  test("collapses to the first page when the session is shorter than one page", () => {
+    expect(clampTranscriptWindowOffset(120, 40, 160)).toBe(0);
+  });
+
+  test("survives absent or nonsensical counts", () => {
+    expect(clampTranscriptWindowOffset(500, 0, 160)).toBe(0);
+    expect(clampTranscriptWindowOffset(500, Number.NaN, 160)).toBe(0);
+    expect(clampTranscriptWindowOffset(-5, 2000, 160)).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Two defects found by independent reviews of #43, plus one documented invariant.

- **Out-of-range deep links no longer blank the transcript.** `loadMessageWindow` derived its offset from `seq` alone with no upper bound, so a link shared from a longer copy of the same session — `/sessions/12#message-1400` against a 200-message archive — requested offset 1380, received an empty page, and replaced a populated transcript with nothing. Offsets are now clamped to the last page that actually has rows, and an empty page is never swapped in even when the cached `message_count` lags a re-sync.
- **The keyboard guard now covers focusable elements outside the HTML namespace.** `isEditableTarget` narrowed on `HTMLElement`. The compaction markers in the context-window strip render as `<a>` inside the `<svg>`, so they are `SVGAElement` — tabbable, focusable, and carrying no `isContentEditable`. Tabbing to one and pressing ArrowDown teleported the transcript while `preventDefault()` suppressed the scroll the user actually asked for.

## Why

Both were reported independently by two reviewers of #43, which is the signal that made them worth fixing now rather than filing. Neither blocks anything, but deep links are that PR's headline feature and the focus guard is something its description explicitly claims to have fixed.

The guard moves to `src/ui/transcript-navigation.ts`, where the rest of the navigation logic lives and is tested. It was the only piece left inline in `main.tsx` — which is precisely why the gap survived review. It now matches structurally on the two methods it actually calls (`matches`, `closest`) rather than on a class, which covers both namespaces and makes it testable without a DOM, matching the existing module's approach of structural interfaces over real DOM types.

## Not fixed here

The remaining review findings are tracked but out of scope: memoizing `TranscriptTurn`, backward loading on ArrowUp, the outline's hardcoded `tools: 0`, header stats mixing session and window scope, keyboard nav moving no focus for screen readers, and whether `content-visibility` placeholders make a deep `scrollIntoView` land off-target. That last one needs a browser and a jump of several hundred messages.

## Validation

- `just check` — 361 tests pass, `bunx tsc --noEmit`, `bunx biome check .`, native darwin-arm64 distribution smoke
- New tests fail against the previous implementations: the clamp cases return the unclamped offset, and the guard case returns `false` for an SVG-shaped target
- No browser verification. The SVG focus path is reasoned from the DOM spec and from how the markers are rendered, not observed.
