### PR TITLE
fix(ui): reject non-finite transcript window offsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,8 @@
 .playwright-mcp/
 
 # TypeScript app
-node_modules/
+# No trailing slash: a bare name also matches a symlink, which a directory
+# pattern does not. A node_modules symlink created inside a scratch worktree
+# has been committed here before.
+node_modules
 /dist/

--- a/src/ui/transcript-pagination.ts
+++ b/src/ui/transcript-pagination.ts
@@ -76,7 +76,12 @@ export function clampTranscriptWindowOffset(
   messageCount: number,
   pageSize: number,
 ): number {
-  if (!Number.isFinite(messageCount) || messageCount <= 0) {
+  if (
+    !Number.isFinite(offset) ||
+    !Number.isFinite(pageSize) ||
+    !Number.isFinite(messageCount) ||
+    messageCount <= 0
+  ) {
     return 0;
   }
   const lastPageOffset = Math.max(0, Math.trunc(messageCount) - Math.max(1, Math.trunc(pageSize)));

--- a/test/ui-transcript-pagination.test.ts
+++ b/test/ui-transcript-pagination.test.ts
@@ -122,4 +122,16 @@ describe("transcript window clamping", () => {
     expect(clampTranscriptWindowOffset(500, Number.NaN, 160)).toBe(0);
     expect(clampTranscriptWindowOffset(-5, 2000, 160)).toBe(0);
   });
+
+  test("never returns a non-finite offset", () => {
+    // NaN survives Math.trunc/max/min untouched, so an unguarded input reaches
+    // the request as `message_offset=NaN`. Every degenerate input starts the
+    // window at the beginning, which is the same place the "Start at the
+    // beginning" recovery button goes.
+    for (const offset of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      expect(clampTranscriptWindowOffset(offset, 2000, 160)).toBe(0);
+    }
+    expect(clampTranscriptWindowOffset(500, 2000, Number.NaN)).toBe(0);
+    expect(clampTranscriptWindowOffset(500, 2000, Number.POSITIVE_INFINITY)).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to review feedback on #46 that I merged without addressing. `clampTranscriptWindowOffset` guarded `messageCount` for finiteness but not `offset` or `pageSize`.

`NaN` survives `Math.trunc`, `Math.max`, and `Math.min` untouched, so a `NaN` offset propagated through the clamp and reached the server as `message_offset=NaN`. Reproduced before fixing:

```
NaN offset      -> NaN
NaN pageSize    -> NaN
Infinity offset -> 40     (already clamped correctly)
```

So `Infinity` was never the problem — `NaN` was, and guarding one of three numeric inputs was the real inconsistency. Every degenerate input now returns 0, starting the window at the beginning of the session, which is where the existing "Start at the beginning" recovery button already goes.

## Validation

- New test fails on the previous implementation with `Expected: 0, Received: NaN`
- `just check` — 362 tests pass, `bunx tsc --noEmit`, `bunx biome check .`, distribution smoke

## Process note

This was flagged by the automated reviewer on #46 and I admin-merged before reading it. I have since checked the inline comments on #43 and #44 as well: both sets were already addressed by those PRs' own follow-up commits — #44's chunked 64KB `StringDecoder` read replacing `readFileSync`, and #43's `sessionVersion` capture-and-recheck around every async boundary in `jumpToMessage` and `navigateTranscript`. This one was the only live item.
