### PR TITLE
fix: normalize and explain session effort levels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,10 +79,10 @@ A change is ready when:
 4. **Costs are computed at ingest** with `cost::estimateCost` and stored on the
    session row. Editing pricing does not rewrite historical rows; rebuild the
    archive to recompute.
-5. **The schema baseline is v13.** Pre-v8 archives are intentionally rebuild-only:
+5. **The schema baseline is v14.** Pre-v8 archives are intentionally rebuild-only:
    delete the archive and re-ingest from the source directories. Do not add
    broad forward migrations unless that product decision changes; the narrow
-   v8-to-v13 migrations preserve existing TypeScript-cutover archives.
+   v8-to-v14 migrations preserve existing TypeScript-cutover archives.
 6. **Parsers are the extension point.** A new source tool means
    `src/sources/<tool>.ts`, synthetic fixtures, parser tests, ingest/query tests,
    and golden updates.

--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -85,8 +85,12 @@ thread navigation can cover the whole session without loading every rich
 transcript block up front.
 
 Session summaries returned by the list and detail routes include
-`reasoning_effort`. It is the provider-reported effort label, `mixed` when the
-setting changes between turns, or `null` when the source did not record one.
+`reasoning_effort` and `reasoning_effort_levels`. The first is the normalized
+provider effort label, `mixed` when the setting changes between turns, or
+`null` when the source did not record one. The levels array preserves the
+unique labels represented by `mixed`. Claude Code's `max` wire value is exposed
+as its user-facing `ultra` setting; Codex's distinct `max` and `ultra` values
+remain unchanged.
 
 The context-window route derives per-API-call window occupancy and compaction
 events at read time from persisted per-message token columns and raw records.

--- a/src/db.ts
+++ b/src/db.ts
@@ -14,7 +14,7 @@ import schemaSql from "./schema.sql" with { type: "text" };
 /// effective DDL with migrations 1..LATEST_SCHEMA_VERSION already applied
 /// and is now the frozen baseline, so a fresh archive is created in one step
 /// and stamped with the full migration history.
-export const LATEST_SCHEMA_VERSION = 13;
+export const LATEST_SCHEMA_VERSION = 14;
 
 /// Owner-only mode for the archive and its SQLite sidecars. The transcripts
 /// decant ingests sit in 0600 files under 0700 directories; the aggregate of
@@ -258,6 +258,34 @@ function migrate(db: Database, current: number): void {
       `);
       db.query(
         "INSERT INTO schema_migrations (version, applied_at) VALUES (13, datetime('now'))",
+      ).run();
+    }
+    if (current < 14) {
+      if (!hasColumn(db, "session", "reasoning_effort_levels")) {
+        db.exec(
+          "ALTER TABLE session ADD COLUMN reasoning_effort_levels TEXT NOT NULL DEFAULT '[]'",
+        );
+      }
+      db.exec(`
+        UPDATE session
+        SET reasoning_effort = 'ultra'
+        WHERE tool = 'claude_code' AND LOWER(TRIM(reasoning_effort)) = 'max';
+
+        UPDATE session
+        SET reasoning_effort_levels = CASE
+          WHEN reasoning_effort IS NULL
+            OR TRIM(reasoning_effort) = ''
+            OR LOWER(TRIM(reasoning_effort)) = 'mixed'
+          THEN '[]'
+          ELSE json_array(LOWER(TRIM(reasoning_effort)))
+        END;
+
+        UPDATE session
+        SET reasoning_effort_checked = 0
+        WHERE LOWER(TRIM(reasoning_effort)) = 'mixed';
+      `);
+      db.query(
+        "INSERT INTO schema_migrations (version, applied_at) VALUES (14, datetime('now'))",
       ).run();
     }
     db.exec("COMMIT;");

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -21,6 +21,7 @@ import {
   type Json,
   type NormalizedBlock,
   type ParsedSession,
+  reasoningEffortLevels,
   summarizeReasoningEfforts,
   type Tool,
 } from "./model.ts";
@@ -375,7 +376,7 @@ export function materializeMissingReasoningEfforts(db: Database): number {
   }
 
   const efforts = rows.map((row) => {
-    let effort: string | null = null;
+    let effort: ReasoningEffortSummary = { summary: null, levels: [] };
     if (row.source_path != null) {
       try {
         effort = reasoningEffortFromSource(row.tool, row.source_path);
@@ -383,17 +384,17 @@ export function materializeMissingReasoningEfforts(db: Database): number {
         // Missing/unreadable source files are a stable unavailable state.
       }
     }
-    return { id: row.id, effort };
+    return { id: row.id, ...effort };
   });
 
   const update = db.prepare(
     `UPDATE session
-     SET reasoning_effort = ?2, reasoning_effort_checked = 1
+     SET reasoning_effort = ?2, reasoning_effort_levels = ?3, reasoning_effort_checked = 1
      WHERE id = ?1`,
   );
   const apply = db.transaction((items: typeof efforts) => {
     for (const row of items) {
-      update.run(row.id, row.effort);
+      update.run(row.id, row.summary, canonicalJson(row.levels));
     }
   });
   apply(efforts);
@@ -403,7 +404,12 @@ export function materializeMissingReasoningEfforts(db: Database): number {
 /** Narrow source scan for the one-time effort backfill. It avoids rebuilding
  * every message/block/tool object from a potentially multi-GB archive and
  * leaves the database write transaction for the small update batch only. */
-function reasoningEffortFromSource(tool: Tool, path: string): string | null {
+interface ReasoningEffortSummary {
+  summary: string | null;
+  levels: string[];
+}
+
+function reasoningEffortFromSource(tool: Tool, path: string): ReasoningEffortSummary {
   const efforts = new Set<string>();
   const buffer = Buffer.allocUnsafe(64 * 1024);
   const decoder = new StringDecoder("utf8");
@@ -431,7 +437,8 @@ function reasoningEffortFromSource(tool: Tool, path: string): string | null {
       // Best-effort cleanup: preserve the scan result or original read error.
     }
   }
-  return summarizeReasoningEfforts(efforts);
+  const levels = reasoningEffortLevels(tool, efforts);
+  return { summary: summarizeReasoningEfforts(levels), levels };
 }
 
 function collectReasoningEffort(tool: Tool, line: string, efforts: Set<string>): void {
@@ -621,11 +628,11 @@ function writeSession(
        est_reasoning_tokens, reasoning_source,
        id,
        total_cache_creation_1h_tokens,
-       reasoning_effort, reasoning_effort_checked
+       reasoning_effort, reasoning_effort_levels, reasoning_effort_checked
      )
      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18,
              ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, datetime('now'), ?27, ?28, ?29, ?30, ?31,
-             ?32, ?33, ?34, ?35, ?36, ?37, ?38, ?39, ?40, ?41, ?42, ?43, ?44, ?45, ?46, ?47, 1)`,
+             ?32, ?33, ?34, ?35, ?36, ?37, ?38, ?39, ?40, ?41, ?42, ?43, ?44, ?45, ?46, ?47, ?48, 1)`,
   ).run(
     s.tool,
     s.sourceSessionId,
@@ -674,6 +681,7 @@ function writeSession(
     existing?.id ?? null,
     s.totals.cacheCreation1h,
     s.reasoningEffort,
+    canonicalJson(s.reasoningEffortLevels),
   );
   const sessionId = lastInsertRowid(db);
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -63,6 +63,30 @@ export function summarizeReasoningEfforts(values: Iterable<string>): string | nu
   return "mixed";
 }
 
+/** Normalize provider wire labels to the effort names users selected. Claude
+ * Code writes its highest `ultra` setting as `max`; Codex uses `max` and
+ * `ultra` as distinct labels, so that alias is intentionally provider-scoped. */
+export function normalizeReasoningEffort(tool: Tool, value: string): string | null {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "") {
+    return null;
+  }
+  return tool === "claude_code" && normalized === "max" ? "ultra" : normalized;
+}
+
+/** Unique normalized effort labels in first-seen order. This detail is kept
+ * alongside the collapsed session value so `mixed` remains explainable. */
+export function reasoningEffortLevels(tool: Tool, values: Iterable<string>): string[] {
+  const levels = new Set<string>();
+  for (const value of values) {
+    const normalized = normalizeReasoningEffort(tool, value);
+    if (normalized != null) {
+      levels.add(normalized);
+    }
+  }
+  return Array.from(levels);
+}
+
 export interface NormalizedBlock {
   ordinal: number;
   blockType: BlockType;
@@ -99,6 +123,9 @@ export interface NormalizedSession {
   model: string | null;
   /** Provider-supplied reasoning effort, or `mixed` when turns differ. */
   reasoningEffort: string | null;
+  /** Unique normalized labels behind `reasoningEffort`, including every value
+   * represented when the session summary is `mixed`. */
+  reasoningEffortLevels: string[];
   cliVersion: string | null;
   startedAt: string | null;
   endedAt: string | null;

--- a/src/query.ts
+++ b/src/query.ts
@@ -17,6 +17,7 @@ export interface SessionSummary {
   project_path: string | null;
   model: string | null;
   reasoning_effort: string | null;
+  reasoning_effort_levels: string[];
   started_at: string | null;
   ended_at: string | null;
   message_count: number;
@@ -51,14 +52,20 @@ export interface ListFilter {
 }
 
 interface SessionSummaryRow
-  extends Omit<SessionSummary, "is_archived" | "is_subagent" | "subagents"> {
+  extends Omit<
+    SessionSummary,
+    "is_archived" | "is_subagent" | "reasoning_effort_levels" | "subagents"
+  > {
   is_archived: number;
   is_subagent: number;
+  reasoning_effort_levels_json: string;
 }
 
 const SESSION_SUMMARY_SELECT = `
   SELECT s.id, s.tool, s.source_session_id, s.title, p.path AS project_path,
-         s.model, s.reasoning_effort, s.started_at, s.ended_at, s.message_count,
+         s.model, s.reasoning_effort,
+         s.reasoning_effort_levels AS reasoning_effort_levels_json,
+         s.started_at, s.ended_at, s.message_count,
          s.total_input_tokens, s.total_output_tokens, s.estimated_cost_usd,
          s.is_archived, s.is_subagent, s.parent_session_id, s.spawn_tool_use_id,
          s.agent_id, s.agent_type, s.spawn_depth,
@@ -220,7 +227,9 @@ export function getSession(
   const summaryRow = db
     .query(
       `SELECT s.id, s.tool, s.source_session_id, s.title, p.path AS project_path,
-              s.model, s.reasoning_effort, s.started_at, s.ended_at, s.message_count,
+              s.model, s.reasoning_effort,
+              s.reasoning_effort_levels AS reasoning_effort_levels_json,
+              s.started_at, s.ended_at, s.message_count,
               s.total_input_tokens, s.total_output_tokens, s.estimated_cost_usd,
               s.is_archived, s.is_subagent, s.parent_session_id, s.spawn_tool_use_id,
               s.agent_id, s.agent_type, s.spawn_depth,
@@ -480,7 +489,24 @@ export function listProjects(db: Database): ProjectSummary[] {
 }
 
 function mapSessionSummary(row: SessionSummaryRow): SessionSummary {
-  return { ...row, is_archived: row.is_archived !== 0, is_subagent: row.is_subagent !== 0 };
+  const { reasoning_effort_levels_json: levelsJson, ...summary } = row;
+  return {
+    ...summary,
+    reasoning_effort_levels: parseReasoningEffortLevels(levelsJson),
+    is_archived: row.is_archived !== 0,
+    is_subagent: row.is_subagent !== 0,
+  };
+}
+
+function parseReasoningEffortLevels(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((level): level is string => typeof level === "string" && level !== "")
+      : [];
+  } catch {
+    return [];
+  }
 }
 
 function withDisplayTitles(db: Database, sessions: SessionSummary[]): SessionSummary[] {

--- a/src/query.ts
+++ b/src/query.ts
@@ -58,7 +58,7 @@ interface SessionSummaryRow
   > {
   is_archived: number;
   is_subagent: number;
-  reasoning_effort_levels_json: string;
+  reasoning_effort_levels_json: string | null;
 }
 
 const SESSION_SUMMARY_SELECT = `
@@ -498,7 +498,10 @@ function mapSessionSummary(row: SessionSummaryRow): SessionSummary {
   };
 }
 
-function parseReasoningEffortLevels(value: string): string[] {
+function parseReasoningEffortLevels(value: string | null | undefined): string[] {
+  if (value == null || value.trim() === "") {
+    return [];
+  }
   try {
     const parsed = JSON.parse(value) as unknown;
     return Array.isArray(parsed)

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1,5 +1,5 @@
--- decant:schema_version=13
--- Effective decant schema (migrations 1..13 applied), frozen as the current
+-- decant:schema_version=14
+-- Effective decant schema (migrations 1..14 applied), frozen as the current
 -- baseline. Do not edit without updating schema tests.
 CREATE TABLE schema_migrations(
             version INTEGER PRIMARY KEY,
@@ -27,6 +27,7 @@ CREATE TABLE session (
   git_branch TEXT,
   model TEXT,
   reasoning_effort TEXT,
+  reasoning_effort_levels TEXT NOT NULL DEFAULT '[]',
   reasoning_effort_checked INTEGER NOT NULL DEFAULT 0,
   cli_version TEXT,
   started_at TEXT,

--- a/src/sources/claude.ts
+++ b/src/sources/claude.ts
@@ -7,6 +7,7 @@ import {
   type NormalizedMessage,
   type ParsedSession,
   type Role,
+  reasoningEffortLevels,
   summarizeReasoningEfforts,
   type TokenUsage,
 } from "../model.ts";
@@ -186,6 +187,7 @@ export function parseClaudeSession(
     spawnToolUseId,
     spawnDepth,
   };
+  const effortLevels = reasoningEffortLevels("claude_code", reasoningEfforts);
 
   return {
     session: {
@@ -196,7 +198,8 @@ export function parseClaudeSession(
       cwd,
       gitBranch,
       model,
-      reasoningEffort: summarizeReasoningEfforts(reasoningEfforts),
+      reasoningEffort: summarizeReasoningEfforts(effortLevels),
+      reasoningEffortLevels: effortLevels,
       cliVersion,
       startedAt,
       endedAt,

--- a/src/sources/codex.ts
+++ b/src/sources/codex.ts
@@ -6,6 +6,7 @@ import {
   type NormalizedMessage,
   type ParsedSession,
   type Role,
+  reasoningEffortLevels,
   summarizeReasoningEfforts,
   type TokenUsage,
 } from "../model.ts";
@@ -129,6 +130,7 @@ export function parseCodexSession(
   if (contextWindow != null) {
     rawMeta = { ...(isObject(rawMeta) ? rawMeta : {}), model_context_window: contextWindow };
   }
+  const effortLevels = reasoningEffortLevels("codex", reasoningEfforts);
 
   return {
     session: {
@@ -139,7 +141,8 @@ export function parseCodexSession(
       cwd,
       gitBranch: null,
       model,
-      reasoningEffort: summarizeReasoningEfforts(reasoningEfforts),
+      reasoningEffort: summarizeReasoningEfforts(effortLevels),
+      reasoningEffortLevels: effortLevels,
       cliVersion,
       startedAt,
       endedAt,

--- a/src/ui/effort.ts
+++ b/src/ui/effort.ts
@@ -1,13 +1,13 @@
 export function effortTooltip(
   effort: string | null | undefined,
-  levels: readonly string[],
+  levels: readonly string[] | null | undefined,
 ): string | undefined {
   if (effort?.trim().toLowerCase() !== "mixed") {
     return undefined;
   }
   const mixedLevels = Array.from(
     new Set(
-      levels
+      (levels ?? [])
         .map((level) => level.trim().toLowerCase())
         .filter((level) => level !== "" && level !== "mixed"),
     ),

--- a/src/ui/effort.ts
+++ b/src/ui/effort.ts
@@ -1,0 +1,16 @@
+export function effortTooltip(
+  effort: string | null | undefined,
+  levels: readonly string[],
+): string | undefined {
+  if (effort?.trim().toLowerCase() !== "mixed") {
+    return undefined;
+  }
+  const mixedLevels = Array.from(
+    new Set(
+      levels
+        .map((level) => level.trim().toLowerCase())
+        .filter((level) => level !== "" && level !== "mixed"),
+    ),
+  );
+  return mixedLevels.length > 0 ? `Effort levels used: ${mixedLevels.join(", ")}` : undefined;
+}

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -59,6 +59,7 @@ import {
 import { layoutContextAnnotations } from "./context-window-layout.ts";
 import { contextWindowDisplayMode } from "./context-window-state.ts";
 import { compactDateTime, fullDateTime } from "./date-time.ts";
+import { effortTooltip } from "./effort.ts";
 import { isFramed } from "./frame-guard.ts";
 import { planSessionLoad, shouldShowSessionSkeleton } from "./loading-state.ts";
 import {
@@ -98,6 +99,7 @@ type SessionSummary = {
   project_path: string | null;
   model: string | null;
   reasoning_effort: string | null;
+  reasoning_effort_levels: string[];
   started_at: string | null;
   message_count: number;
   total_input_tokens: number;
@@ -1295,6 +1297,7 @@ function sessionMatchesQuery(session: SessionSummary, needle: string): boolean {
       sessionDisplayTitle(session),
       displayModelLabel(session.model),
       session.reasoning_effort,
+      ...(session.reasoning_effort_levels ?? []),
       session.tool,
       session.project_path,
       session.agent_type,
@@ -1380,7 +1383,7 @@ function SessionTableRow({
         <ModelBadge model={session.model} />
       </td>
       <td>
-        <EffortBadge effort={session.reasoning_effort} />
+        <EffortBadge effort={session.reasoning_effort} levels={session.reasoning_effort_levels} />
       </td>
       <td className="numeric">
         <SessionContextPeak session={session} />
@@ -2774,16 +2777,19 @@ function Badge({
   children,
   className,
   mono = false,
+  title,
   tone = "neutral",
 }: {
   children: ReactNode;
   className?: string;
   mono?: boolean;
+  title?: string;
   tone?: BadgeTone;
 }) {
   return (
     <span
       className={`badge tone-${tone}${mono ? " is-mono" : ""}${className ? ` ${className}` : ""}`}
+      title={title}
     >
       {children}
     </span>
@@ -2828,16 +2834,18 @@ function ModelBadge({ model }: { model: string | null | undefined }) {
 function EffortBadge({
   effort,
   labeled = false,
+  levels = [],
 }: {
   effort: string | null | undefined;
   labeled?: boolean;
+  levels?: string[];
 }) {
   const label = effort?.trim().toLowerCase();
   if (label == null || label === "") {
     return <span className="faint">-</span>;
   }
   return (
-    <Badge mono tone={label === "mixed" ? "warning" : "info"}>
+    <Badge mono title={effortTooltip(label, levels)} tone={label === "mixed" ? "warning" : "info"}>
       {labeled ? `effort ${label}` : label}
     </Badge>
   );
@@ -4520,7 +4528,11 @@ function SessionDetailView({ id }: { id: number }) {
           <div className="thread-badges">
             <ToolBadge tool={detail.summary.tool} />
             <ModelBadge model={detail.summary.model} />
-            <EffortBadge effort={detail.summary.reasoning_effort} labeled />
+            <EffortBadge
+              effort={detail.summary.reasoning_effort}
+              labeled
+              levels={detail.summary.reasoning_effort_levels}
+            />
             {detail.summary.project_path != null ? (
               <span className="project-chip" title={detail.summary.project_path}>
                 <Icon name="folder" />

--- a/test/classify.test.ts
+++ b/test/classify.test.ts
@@ -59,6 +59,7 @@ function session(messages: NormalizedMessage[]): NormalizedSession {
     gitBranch: null,
     model: null,
     reasoningEffort: null,
+    reasoningEffortLevels: [],
     cliVersion: null,
     startedAt: null,
     endedAt: null,

--- a/test/claude.test.ts
+++ b/test/claude.test.ts
@@ -97,7 +97,8 @@ describe("parseClaudeSession", () => {
       '{"type":"assistant","effort":"max","requestId":"r1","message":{"role":"assistant","model":"claude-opus-5","usage":{"input_tokens":10,"output_tokens":20,"cache_read_input_tokens":30,"cache_creation_input_tokens":100,"cache_creation":{"ephemeral_5m_input_tokens":40,"ephemeral_1h_input_tokens":60}},"content":[{"type":"text","text":"done"}]}}',
     ].join("\n");
     const session = parseClaudeSession("effort-cache", `${content}\n`).session;
-    expect(session.reasoningEffort).toBe("max");
+    expect(session.reasoningEffort).toBe("ultra");
+    expect(session.reasoningEffortLevels).toEqual(["ultra"]);
     expect(session.totals.cacheCreation).toBe(100);
     expect(session.totals.cacheCreation1h).toBe(60);
   });
@@ -107,7 +108,9 @@ describe("parseClaudeSession", () => {
       '{"type":"assistant","effort":"high","message":{"role":"assistant","content":[]}}',
       '{"type":"assistant","effort":"max","message":{"role":"assistant","content":[]}}',
     ].join("\n");
-    expect(parseClaudeSession("mixed", content).session.reasoningEffort).toBe("mixed");
+    const session = parseClaudeSession("mixed", content).session;
+    expect(session.reasoningEffort).toBe("mixed");
+    expect(session.reasoningEffortLevels).toEqual(["high", "ultra"]);
   });
 
   test("snake case streaming request ids de-dupe cumulative assistant usage", () => {

--- a/test/codex.test.ts
+++ b/test/codex.test.ts
@@ -16,6 +16,7 @@ describe("parseCodexSession", () => {
     expect(session.cwd).toBe("/Users/dev/proj");
     expect(session.model).toBe("gpt-5.4");
     expect(session.reasoningEffort).toBe("high");
+    expect(session.reasoningEffortLevels).toEqual(["high"]);
     expect(session.messages).toHaveLength(4);
     expect(session.messages[0]?.role).toBe("user");
     expect(session.messages[1]?.blocks[0]?.blockType).toBe("tool_use");
@@ -47,7 +48,9 @@ describe("parseCodexSession", () => {
       '{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"high"}}',
       '{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"xhigh"}}',
     ].join("\n");
-    expect(parseCodexSession("mixed", content, new Map()).session.reasoningEffort).toBe("mixed");
+    const session = parseCodexSession("mixed", content, new Map()).session;
+    expect(session.reasoningEffort).toBe("mixed");
+    expect(session.reasoningEffortLevels).toEqual(["high", "xhigh"]);
   });
 
   test("stamps last_token_usage onto the producing assistant without crossing compaction", () => {

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -24,7 +24,7 @@ function freshPath(): string {
   return join(workDir, `archive-${dbCounter}.db`);
 }
 
-// Inventory of the frozen v13 baseline. Shadow tables
+// Inventory of the frozen v14 baseline. Shadow tables
 // of block_fts are excluded; they are implementation details of FTS5.
 const BASELINE_TABLES = [
   "block",
@@ -201,6 +201,7 @@ describe("openDb", () => {
       expect.arrayContaining([
         "total_cache_creation_1h_tokens",
         "reasoning_effort",
+        "reasoning_effort_levels",
         "reasoning_effort_checked",
       ]),
     );
@@ -294,6 +295,64 @@ describe("openDb", () => {
     ).toEqual([
       { tool: "claude_code", context_window_tokens: null, peak_context_tokens: null },
       { tool: "codex", context_window_tokens: 258400, peak_context_tokens: 120000 },
+    ]);
+    migrated.close();
+  });
+
+  test("migrates v13 effort values without conflating Codex max and ultra", () => {
+    const path = freshPath();
+    const db = new Database(path, { create: true, strict: true });
+    db.exec(`
+      CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
+      CREATE TABLE session(
+        id INTEGER PRIMARY KEY,
+        tool TEXT NOT NULL,
+        source_session_id TEXT NOT NULL,
+        reasoning_effort TEXT,
+        reasoning_effort_checked INTEGER NOT NULL DEFAULT 0
+      );
+      INSERT INTO session(
+        id, tool, source_session_id, reasoning_effort, reasoning_effort_checked
+      ) VALUES
+        (1, 'claude_code', 'claude-ultra', 'max', 1),
+        (2, 'codex', 'codex-max', 'max', 1),
+        (3, 'codex', 'codex-mixed', 'mixed', 1);
+    `);
+    const insert = db.prepare(
+      "INSERT INTO schema_migrations(version, applied_at) VALUES (?1, datetime('now'))",
+    );
+    for (let version = 1; version <= 13; version += 1) {
+      insert.run(version);
+    }
+    db.close();
+
+    const migrated = openDb(path);
+    expect(
+      migrated
+        .query(
+          `SELECT tool, reasoning_effort, reasoning_effort_levels, reasoning_effort_checked
+           FROM session ORDER BY id`,
+        )
+        .all(),
+    ).toEqual([
+      {
+        tool: "claude_code",
+        reasoning_effort: "ultra",
+        reasoning_effort_levels: '["ultra"]',
+        reasoning_effort_checked: 1,
+      },
+      {
+        tool: "codex",
+        reasoning_effort: "max",
+        reasoning_effort_levels: '["max"]',
+        reasoning_effort_checked: 1,
+      },
+      {
+        tool: "codex",
+        reasoning_effort: "mixed",
+        reasoning_effort_levels: "[]",
+        reasoning_effort_checked: 0,
+      },
     ]);
     migrated.close();
   });

--- a/test/enrich.test.ts
+++ b/test/enrich.test.ts
@@ -47,6 +47,7 @@ function oneBlockSession(tool: Tool, block: NormalizedBlock): NormalizedSession 
     gitBranch: null,
     model: null,
     reasoningEffort: null,
+    reasoningEffortLevels: [],
     cliVersion: null,
     startedAt: null,
     endedAt: null,

--- a/test/golden/cli/ls.json
+++ b/test/golden/cli/ls.json
@@ -6,6 +6,9 @@
     "project_path": "/Users/dev/proj",
     "model": "gpt-5.4",
     "reasoning_effort": "high",
+    "reasoning_effort_levels": [
+      "high"
+    ],
     "started_at": "2026-05-06T09:00:00.000Z",
     "ended_at": "2026-05-06T09:00:10.000Z",
     "message_count": 8,
@@ -32,6 +35,7 @@
     "project_path": "/Users/dev/proj",
     "model": "claude-opus-4-7",
     "reasoning_effort": null,
+    "reasoning_effort_levels": [],
     "started_at": "2026-05-05T10:00:00.000Z",
     "ended_at": "2026-05-05T10:04:00.000Z",
     "message_count": 8,
@@ -58,6 +62,7 @@
     "project_path": "/Users/dev/proj",
     "model": "claude-opus-4-7",
     "reasoning_effort": null,
+    "reasoning_effort_levels": [],
     "started_at": "2026-05-05T10:00:00.000Z",
     "ended_at": "2026-05-05T10:00:10.000Z",
     "message_count": 4,
@@ -84,6 +89,9 @@
     "project_path": "/Users/dev/proj",
     "model": "gpt-5.4",
     "reasoning_effort": "high",
+    "reasoning_effort_levels": [
+      "high"
+    ],
     "started_at": "2026-05-04T09:00:00.000Z",
     "ended_at": "2026-05-04T09:00:10.000Z",
     "message_count": 7,
@@ -110,6 +118,7 @@
     "project_path": "/Users/dev/proj",
     "model": "claude-opus-4-7",
     "reasoning_effort": null,
+    "reasoning_effort_levels": [],
     "started_at": "2026-05-03T10:00:00.000Z",
     "ended_at": "2026-05-03T10:13:10.000Z",
     "message_count": 10,
@@ -136,6 +145,9 @@
     "project_path": "/Users/dev/proj",
     "model": "gpt-5.4",
     "reasoning_effort": "high",
+    "reasoning_effort_levels": [
+      "high"
+    ],
     "started_at": "2026-05-02T09:00:00.000Z",
     "ended_at": "2026-05-02T09:00:08.000Z",
     "message_count": 4,
@@ -162,6 +174,7 @@
     "project_path": "/Users/dev/proj",
     "model": "claude-opus-4-7",
     "reasoning_effort": null,
+    "reasoning_effort_levels": [],
     "started_at": "2026-05-01T10:00:00.000Z",
     "ended_at": "2026-05-01T10:00:10.000Z",
     "message_count": 4,

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -319,18 +319,22 @@ describe("upsertSession", () => {
     expect(
       db
         .query(
-          `SELECT reasoning_effort, reasoning_effort_checked,
+          `SELECT reasoning_effort, reasoning_effort_levels, reasoning_effort_checked,
                   total_cache_creation_tokens, total_cache_creation_1h_tokens
            FROM session WHERE id = ?1`,
         )
         .get(sessionId),
     ).toEqual({
-      reasoning_effort: "max",
+      reasoning_effort: "ultra",
+      reasoning_effort_levels: '["ultra"]',
       reasoning_effort_checked: 1,
       total_cache_creation_tokens: 100,
       total_cache_creation_1h_tokens: 60,
     });
-    expect(getSession(db, sessionId)?.summary.reasoning_effort).toBe("max");
+    expect(getSession(db, sessionId)?.summary).toMatchObject({
+      reasoning_effort: "ultra",
+      reasoning_effort_levels: ["ultra"],
+    });
     db.close();
   });
 });
@@ -483,11 +487,15 @@ describe("sync", () => {
     expect(
       db
         .query(
-          `SELECT reasoning_effort, reasoning_effort_checked
+          `SELECT reasoning_effort, reasoning_effort_levels, reasoning_effort_checked
            FROM session WHERE source_session_id = 'effort-session'`,
         )
         .get(),
-    ).toEqual({ reasoning_effort: "xhigh", reasoning_effort_checked: 1 });
+    ).toEqual({
+      reasoning_effort: "xhigh",
+      reasoning_effort_levels: '["xhigh"]',
+      reasoning_effort_checked: 1,
+    });
     db.close();
   });
 
@@ -523,11 +531,15 @@ describe("sync", () => {
     expect(
       db
         .query(
-          `SELECT reasoning_effort, reasoning_effort_checked
+          `SELECT reasoning_effort, reasoning_effort_levels, reasoning_effort_checked
            FROM session WHERE source_session_id = 'large-effort-session'`,
         )
         .get(),
-    ).toEqual({ reasoning_effort: "max", reasoning_effort_checked: 1 });
+    ).toEqual({
+      reasoning_effort: "max",
+      reasoning_effort_levels: '["max"]',
+      reasoning_effort_checked: 1,
+    });
     db.close();
   });
 

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from "bun:test";
 import {
   BLOCK_TYPES,
   emptyUsage,
+  normalizeReasoningEffort,
   REASONING_SOURCES,
   ROLES,
+  reasoningEffortLevels,
   summarizeReasoningEfforts,
   TOOL_KINDS,
   TOOLS,
@@ -43,5 +45,9 @@ describe("model wire strings", () => {
     expect(summarizeReasoningEfforts([])).toBeNull();
     expect(summarizeReasoningEfforts([" XHIGH ", "xhigh"])).toBe("xhigh");
     expect(summarizeReasoningEfforts(["high", "max"])).toBe("mixed");
+    expect(normalizeReasoningEffort("claude_code", " MAX ")).toBe("ultra");
+    expect(normalizeReasoningEffort("codex", " MAX ")).toBe("max");
+    expect(reasoningEffortLevels("claude_code", ["low", "max", "MAX"])).toEqual(["low", "ultra"]);
+    expect(reasoningEffortLevels("codex", ["max", "ultra"])).toEqual(["max", "ultra"]);
   });
 });

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -74,6 +74,10 @@ describe("query reads", () => {
       reasoning_effort: "mixed",
       reasoning_effort_levels: ["high", "ultra"],
     });
+
+    db.query("UPDATE session SET reasoning_effort_levels = '' WHERE id = ?").run(id);
+    expect(listSessions(db)[0]?.reasoning_effort_levels).toEqual([]);
+    expect(getSession(db, id)?.summary.reasoning_effort_levels).toEqual([]);
     db.close();
   });
 

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -54,6 +54,29 @@ describe("query reads", () => {
     db.close();
   });
 
+  test("returns the normalized levels behind a mixed effort summary", () => {
+    const db = freshDb();
+    const parsed = parseClaudeSession(
+      "mixed-effort",
+      [
+        '{"type":"assistant","effort":"high","message":{"role":"assistant","content":[]}}',
+        '{"type":"assistant","effort":"max","message":{"role":"assistant","content":[]}}',
+      ].join("\n"),
+    );
+    const id = upsertSession(db, parsed, "/mixed.jsonl", 1, 2, "mixed");
+
+    expect(listSessions(db)[0]).toMatchObject({
+      id,
+      reasoning_effort: "mixed",
+      reasoning_effort_levels: ["high", "ultra"],
+    });
+    expect(getSession(db, id)?.summary).toMatchObject({
+      reasoning_effort: "mixed",
+      reasoning_effort_levels: ["high", "ultra"],
+    });
+    db.close();
+  });
+
   test("pages session messages and returns a lightweight complete prompt outline", () => {
     const db = seeded();
     const id = listSessions(db)[0]?.id ?? 0;

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -300,7 +300,11 @@ describe("server routes", () => {
     expect(sessions.body).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ tool: "claude_code" }),
-        expect.objectContaining({ tool: "codex", reasoning_effort: "high" }),
+        expect.objectContaining({
+          tool: "codex",
+          reasoning_effort: "high",
+          reasoning_effort_levels: ["high"],
+        }),
       ]),
     );
     const id = (sessions.body as { id: number }[])[0]?.id ?? 0;
@@ -308,7 +312,11 @@ describe("server routes", () => {
     const detail = await route(config, `/api/sessions/${id}`);
     expect(detail.status).toBe(200);
     expect(detail.body).toMatchObject({
-      summary: { id, reasoning_effort: expect.any(String) },
+      summary: {
+        id,
+        reasoning_effort: expect.any(String),
+        reasoning_effort_levels: expect.any(Array),
+      },
       messages: expect.any(Array),
     });
     const firstMessagePage = await route(

--- a/test/ui-effort.test.ts
+++ b/test/ui-effort.test.ts
@@ -10,6 +10,8 @@ describe("effort tooltip", () => {
 
   test("stays absent when there is nothing useful to explain", () => {
     expect(effortTooltip("mixed", [])).toBeUndefined();
+    expect(effortTooltip("mixed", null)).toBeUndefined();
+    expect(effortTooltip("mixed", undefined)).toBeUndefined();
     expect(effortTooltip("ultra", ["ultra"])).toBeUndefined();
     expect(effortTooltip(null, ["high", "ultra"])).toBeUndefined();
   });

--- a/test/ui-effort.test.ts
+++ b/test/ui-effort.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { effortTooltip } from "../src/ui/effort.ts";
+
+describe("effort tooltip", () => {
+  test("explains the unique normalized levels behind a mixed session", () => {
+    expect(effortTooltip(" Mixed ", ["high", " ULTRA ", "high", "mixed", ""])).toBe(
+      "Effort levels used: high, ultra",
+    );
+  });
+
+  test("stays absent when there is nothing useful to explain", () => {
+    expect(effortTooltip("mixed", [])).toBeUndefined();
+    expect(effortTooltip("ultra", ["ultra"])).toBeUndefined();
+    expect(effortTooltip(null, ["high", "ultra"])).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What does this do?

- Maps Claude Code's raw `max` effort to the user-facing `ultra` level while preserving distinct Codex `max` and `ultra` values.
- Persists the exact normalized effort levels behind a `mixed` session summary.
- Shows those levels when hovering over `mixed` badges in the session list and detail view.
- Migrates v13 archives to v14 and backfills affected sessions from their source logs.

## Why?

Decant was displaying provider wire values without provider-aware normalization. It also collapsed sessions whose effort changed to `mixed` without preserving enough information to explain which levels were used.

## How was this tested?

- `just check`
  - 365 tests
  - TypeScript typecheck
  - Biome check
  - native Darwin arm64 distribution smoke
- Playwright smoke against an isolated synthetic archive, including a real hover over `mixed` and the rendered `Effort levels used: high, ultra` tooltip.
- Live archive/API readback confirming Claude `max` is exposed as `ultra`, Codex values remain distinct, and mixed rows carry their exact levels.

## Risk and rollback

The change is limited to additive session metadata plus a one-time source rescan for previously mixed sessions. Rolling back to an older binary requires rebuilding the archive because older builds intentionally reject newer schema versions.

## Screenshots or recordings

Not included; the hover behavior is covered by focused unit tests and the Playwright smoke above.

## Checklist

- [x] Focused parser, migration, query, API, and UI tests added.
- [x] Full local quality gate passes.
- [x] No real transcripts or personal archive data committed.

## Related

Fixes incorrect `max`/`ultra` display and makes mixed effort summaries inspectable.
