### PR TITLE
fix(ui): keep session details within viewport

### DIFF
--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -438,6 +438,7 @@ nav a[aria-current="page"] {
 
 .content-wrap {
   width: min(100%, 96rem);
+  max-width: 100%;
   min-width: 0;
   margin: 0 auto;
 }
@@ -500,17 +501,24 @@ nav a[aria-current="page"] {
 }
 
 .panel {
+  max-width: 100%;
+  min-width: 0;
   overflow: hidden;
 }
 
 .panel-heading {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
   min-height: 52px;
   border-bottom: 1px solid var(--line);
   padding: 12px 16px;
+}
+
+.panel-heading > * {
+  min-width: 0;
 }
 
 .panel-heading h2 {
@@ -1447,7 +1455,11 @@ mark {
 }
 
 .activity-table-wrap {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   overflow-x: auto;
+  overscroll-behavior-inline: contain;
   padding: 6px 0 8px;
 }
 
@@ -2077,8 +2089,14 @@ mark {
 
 .session-detail {
   display: grid;
+  width: 100%;
+  max-width: 100%;
   min-width: 0;
   gap: 24px;
+}
+
+.session-detail > * {
+  min-width: 0;
 }
 
 .thread-header {
@@ -2274,6 +2292,10 @@ mark {
   gap: 24px;
 }
 
+.transcript-layout > * {
+  min-width: 0;
+}
+
 .toc {
   display: block;
 }
@@ -2437,12 +2459,17 @@ mark {
   padding-left: 14px;
 }
 
+.turn-body > * {
+  min-width: 0;
+}
+
 .text-block,
 .thinking-block p {
   margin: 0;
   color: var(--fg);
   font-size: 14px;
   line-height: 1.55;
+  overflow-wrap: anywhere;
   white-space: pre-wrap;
 }
 
@@ -2571,6 +2598,7 @@ mark {
   color: var(--muted);
   font-size: 12px;
   line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
 .special-chips {
@@ -2581,11 +2609,13 @@ mark {
 }
 
 .special-chips span {
+  max-width: 100%;
   border: 1px solid var(--line);
   border-radius: 5px;
   color: var(--faint);
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   font-size: 11px;
+  overflow-wrap: anywhere;
   padding: 2px 6px;
 }
 
@@ -2636,6 +2666,7 @@ mark {
   color: var(--fg);
   font-size: 13px;
   line-height: 1.48;
+  overflow-wrap: anywhere;
   white-space: pre-wrap;
 }
 
@@ -2776,6 +2807,16 @@ pre {
   word-break: break-word;
 }
 
+@media (max-width: 1200px) {
+  .transcript-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .toc {
+    display: none;
+  }
+}
+
 @media (max-width: 980px) {
   .mobile-only {
     display: inline-grid;
@@ -2824,13 +2865,8 @@ pre {
   .projects-stat-grid,
   .analytics-stat-grid,
   .split,
-  .catalog-grid,
-  .transcript-layout {
+  .catalog-grid {
     grid-template-columns: 1fr;
-  }
-
-  .toc {
-    display: none;
   }
 
   .catalog-card.is-featured {
@@ -2844,6 +2880,10 @@ pre {
   .section-title-row {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .panel-heading .activity-summary {
+    justify-content: flex-start;
   }
 
   .date-range-control {
@@ -2865,6 +2905,16 @@ pre {
   .session-filter,
   select {
     width: 100%;
+  }
+
+  .transcript-window-start {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .realtime-line {
+    grid-template-columns: 1fr;
+    gap: 4px;
   }
 
   .stat-grid {
@@ -2924,13 +2974,18 @@ pre {
 
 .ctx-strip-frame {
   position: relative;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .ctx-strip {
   display: block;
-  /* The base stylesheet sizes every svg at 1em for icons; auto restores this
-   * chart's own width/height attributes. */
+  /* The base stylesheet sizes every svg at 1em for icons. The intrinsic
+   * chart dimensions still drive its aspect ratio, while max-width keeps the
+   * first measured frame from escaping a narrower viewport. */
   width: auto;
+  max-width: 100%;
   height: auto;
   cursor: crosshair;
 }

--- a/test/ui-responsive-styles.test.ts
+++ b/test/ui-responsive-styles.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-const styles = readFileSync(join(import.meta.dir, "..", "src", "ui", "styles.css"), "utf8");
+const styles = readFileSync(join(import.meta.dir, "..", "src", "ui", "styles.css"), "utf8").replace(
+  /\r\n/g,
+  "\n",
+);
 
 function rule(selector: string): string {
   const start = styles.indexOf(`${selector} {`);

--- a/test/ui-responsive-styles.test.ts
+++ b/test/ui-responsive-styles.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const styles = readFileSync(join(import.meta.dir, "..", "src", "ui", "styles.css"), "utf8");
+
+function rule(selector: string): string {
+  const start = styles.indexOf(`${selector} {`);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = styles.indexOf("\n}", start);
+  expect(end).toBeGreaterThan(start);
+  return styles.slice(start, end);
+}
+
+describe("responsive session detail styles", () => {
+  test("allows the page, panels, and nested transcript tracks to shrink", () => {
+    expect(rule(".session-detail")).toContain("max-width: 100%");
+    expect(rule(".session-detail > *")).toContain("min-width: 0");
+    expect(rule(".panel")).toContain("min-width: 0");
+    expect(rule(".transcript-layout > *")).toContain("min-width: 0");
+    expect(rule(".turn-body > *")).toContain("min-width: 0");
+  });
+
+  test("wraps unbroken transcript content instead of widening the page", () => {
+    expect(rule(".text-block,\n.thinking-block p")).toContain("overflow-wrap: anywhere");
+    expect(rule(".special-block p")).toContain("overflow-wrap: anywhere");
+    expect(rule(".special-block .realtime-line p")).toContain("overflow-wrap: anywhere");
+  });
+
+  test("keeps wide data surfaces inside their panels", () => {
+    expect(rule(".activity-table-wrap")).toContain("overflow-x: auto");
+    expect(rule(".ctx-strip-frame")).toContain("overflow: hidden");
+    expect(rule(".ctx-strip")).toContain("max-width: 100%");
+  });
+
+  test("collapses the transcript navigation at laptop widths", () => {
+    const start = styles.indexOf("@media (max-width: 1200px)");
+    const end = styles.indexOf("@media (max-width: 980px)", start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const laptopRules = styles.slice(start, end);
+    expect(laptopRules).toContain(".transcript-layout");
+    expect(laptopRules).toContain("grid-template-columns: 1fr");
+    expect(laptopRules).toContain(".toc");
+    expect(laptopRules).toContain("display: none");
+  });
+});


### PR DESCRIPTION
## Summary

- let session-detail panels and nested transcript tracks shrink within the viewport
- wrap long transcript URLs and paths instead of widening the page
- contain wide economics and context-window surfaces, and collapse the thread outline at laptop widths
- stack dense transcript controls and realtime dialogue on small screens

## Validation

- bun test test/ui-responsive-styles.test.ts
- bunx tsc --noEmit
- bunx biome check .
- bun run distcheck
- full bun test: 367 passed; 2 server tests could not bind ephemeral port 0 in the Codex sandbox (EADDRINUSE)

## Notes

A rendered browser smoke was attempted, but the environment blocked both local listener access and the static browser fixture. The focused stylesheet regression tests cover the viewport constraints while CI supplies the unrestricted server-test run.