### PR TITLE
ci: harden workflows for public release, add community health files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Code owners for decant.
+#
+# The last matching pattern wins, so the global owner comes first and the
+# security-sensitive paths follow. Every path listed here exists in the tree;
+# a pattern that matches nothing silently owns nothing.
+
+* @teedole
+
+# Release and supply chain: CI workflows, packaging manifests, the npm
+# launcher, and the curl-to-shell installer all run on other people's machines.
+/.github/workflows/ @teedole
+/packaging/ @teedole
+/npm/ @teedole
+/install.sh @teedole
+
+# The only network listener in the project.
+/src/server.ts @teedole

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,114 @@
+name: Bug report
+description: decant behaves differently from what it documents.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Do not paste real session transcripts
+
+        **This issue is public.** Your Claude Code and Codex sessions contain your own
+        source code, file paths, prompts, and everything else you typed into those
+        tools. decant keeps them on your machine — pasting one here would not.
+
+        Reproduce the bug with a **synthetic** session file instead. Hand-write a small
+        JSONL file that triggers the same failure and ingest it into a scratch archive:
+
+        ```
+        decant sync --db /tmp/decant-repro.db --path ./repro.jsonl
+        decant ls --db /tmp/decant-repro.db
+        ```
+
+        The `fixtures/` directory in this repository shows the shape of both source
+        formats. If you cannot reproduce it synthetically, describe the *structure* of
+        the input that breaks — message kinds, field names, sizes, encodings — without
+        the content. Redact paths, code, and prompts from any output you paste,
+        including error messages and logs.
+
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Transcript privacy
+      options:
+        - label: This report contains no real transcript content — no source code, file paths, or prompts from my own sessions.
+          required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: The actual behavior, including the exact command you ran and any error output.
+      placeholder: |
+        $ decant search "auth bug"
+        error: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      description: What should have happened instead, and where that behavior is documented if it is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps starting from a clean archive. Inline the synthetic session file if the bug depends on input shape.
+      placeholder: |
+        1. Write ./repro.jsonl containing ...
+        2. decant sync --db /tmp/decant-repro.db --path ./repro.jsonl
+        3. decant ls --db /tmp/decant-repro.db
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: decant version
+      description: Output of `decant --version`. For archive or migration bugs, add the `schema:` line from `decant db info`.
+      placeholder: "0.1.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      options:
+        - npx / npm
+        - Homebrew
+        - install.sh
+        - Docker
+        - Built from source
+    validations:
+      required: true
+
+  - type: input
+    id: platform
+    attributes:
+      label: OS and architecture
+      description: For example `macOS 15.5 arm64`, `Ubuntu 24.04 x86_64`, or `Windows 11 x86_64 (WSL2)`.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: source-tool
+    attributes:
+      label: Source tool
+      description: Which CLI wrote the sessions involved.
+      options:
+        - Claude Code
+        - Codex
+        - Both
+        - Not applicable
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else
+      description: Relevant `DECANT_*` environment variables, non-default settings, or operational logs from `DECANT_LOG_LEVEL=debug`. Redact before pasting.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or idea
+    url: https://github.com/dosu-ai/decant/discussions
+    about: Ask how something works, or float an idea before it becomes an issue.
+  - name: Security vulnerability
+    url: https://github.com/dosu-ai/decant/security/policy
+    about: Report privately through GitHub's advisory flow. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Propose a change to what decant does.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        decant is local-first and offline: it makes no outbound runtime network calls
+        and no LLM calls. Proposals that need either are out of scope. Everything else
+        is fair game.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that decant makes hard or impossible today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should decant do instead? A command sketch or example output helps.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Existing commands, flags, or workarounds you tried, and why they fall short.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ you decided to accept. Screenshots or a short clip for UI changes.
 
 ## Archive schema
 
-The current baseline is **v14** (`LATEST_SCHEMA_VERSION` in `src/db.ts`). Check one:
+The baseline is `LATEST_SCHEMA_VERSION` in `src/db.ts`. Check one:
 
 - [ ] This change does not touch the archive schema.
 - [ ] This change bumps the schema. It ships the migration, and the summary above says what happens to archives created before it.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- What changed, in one or two sentences. -->
+
+## Why
+
+<!-- The problem this solves. Link the issue it closes: `Closes #123`. -->
+
+## Validation
+
+<!--
+What you ran and what it reported. Paste output for anything that failed or that
+you decided to accept. Screenshots or a short clip for UI changes.
+-->
+
+- [ ] `just check` passes (`bun test`, `bunx tsc --noEmit`, `bunx biome check .`, distribution staging smoke).
+- [ ] New behavior has focused tests. No existing test was weakened or deleted to make this pass.
+
+## Archive schema
+
+The current baseline is **v14** (`LATEST_SCHEMA_VERSION` in `src/db.ts`). Check one:
+
+- [ ] This change does not touch the archive schema.
+- [ ] This change bumps the schema. It ships the migration, and the summary above says what happens to archives created before it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,23 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+# Default-deny, then grant per job. A job that needs more than `contents: read`
+# has to say so at its own level, so widening this file later cannot silently
+# widen a job that never asked for it.
+permissions: {}
 
 jobs:
   typescript:
     name: TypeScript (biome, tsc, test)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Nothing here pushes; don't leave the token in .git/config.
+          persist-credentials: false
 
       - name: Install Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -48,8 +55,13 @@ jobs:
     name: Docker (multi-arch)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Nothing here pushes; don't leave the token in .git/config.
+          persist-credentials: false
 
       # .bun-version is the single source of truth for the Bun toolchain.
       # Dependabot bumps the Dockerfile's builder tag weekly, so drift is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,10 @@ jobs:
     steps:
       # Default shallow checkout is fine — tag data comes from a targeted fetch +
       # ls-remote, never the local clone.
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # zizmor: ignore[artipacked] — the tag guard below runs `git fetch origin`,
+      # which needs the credentials checkout persists. This job uploads no
+      # artifacts, so there is nothing for them to leak into.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 # zizmor: ignore[artipacked]
 
       - name: Derive, validate, and guard VERSION
         id: v
@@ -124,11 +127,18 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Nothing here pushes; don't leave the token in .git/config.
+          persist-credentials: false
 
       - name: Install Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
+          # No cache on the release path. A cache entry written by an earlier
+          # PR run is attacker-influenced input, and this workflow signs and
+          # publishes what it builds — a poisoned restore would ship.
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -160,11 +170,18 @@ jobs:
       VERSION: ${{ needs.meta.outputs.version }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Nothing here pushes; don't leave the token in .git/config.
+          persist-credentials: false
 
       - name: Install Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
+          # No cache on the release path. A cache entry written by an earlier
+          # PR run is attacker-influenced input, and this workflow signs and
+          # publishes what it builds — a poisoned restore would ship.
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -430,11 +447,18 @@ jobs:
       VERSION: ${{ needs.meta.outputs.version }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Nothing here pushes; don't leave the token in .git/config.
+          persist-credentials: false
 
       - name: Install Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
+          # No cache on the release path. A cache entry written by an earlier
+          # PR run is attacker-influenced input, and this workflow signs and
+          # publishes what it builds — a poisoned restore would ship.
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -480,11 +504,18 @@ jobs:
       HAS_NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Nothing here pushes; don't leave the token in .git/config.
+          persist-credentials: false
 
       - name: Install Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
+          # No cache on the release path. A cache entry written by an earlier
+          # PR run is attacker-influenced input, and this workflow signs and
+          # publishes what it builds — a poisoned restore would ship.
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -668,6 +699,9 @@ jobs:
     steps:
       # install.sh ships from the tag's tree as a release asset.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Nothing here pushes; don't leave the token in .git/config.
+          persist-credentials: false
 
       - name: Download release tarballs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -717,6 +751,9 @@ jobs:
       artifact-metadata: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Nothing here pushes; don't leave the token in .git/config.
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
@@ -782,6 +819,9 @@ jobs:
       VERSION: ${{ needs.meta.outputs.version }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Nothing here pushes; don't leave the token in .git/config.
+          persist-credentials: false
 
       - name: Download release tarballs (for SHA256SUMS)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -890,7 +930,10 @@ jobs:
     env:
       VERSION: ${{ needs.meta.outputs.version }}
     steps:
-      - name: Check out dosu-ai/homebrew-dosu
+      # zizmor: ignore[artipacked] — this job's whole purpose is pushing the
+      # rendered formula to the tap, so the credential has to persist. It
+      # uploads no artifacts.
+      - name: Check out dosu-ai/homebrew-dosu # zizmor: ignore[artipacked]
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: dosu-ai/homebrew-dosu

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,56 @@
+name: Scorecard
+
+# OpenSSF Scorecard scores this repo's supply-chain posture (pinned actions,
+# branch protection, token permissions, and so on) and publishes the result.
+# It requires a public repository — until the visibility flip this workflow
+# runs and fails harmlessly rather than reporting.
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "27 5 * * 1"
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    # Scorecard's publish step requires a public repo. Skipping while private
+    # keeps this dormant instead of red on every push, and it starts reporting
+    # by itself the moment visibility flips — no follow-up edit needed.
+    if: github.event.repository.private == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      # Upload the SARIF result to code scanning.
+      security-events: write
+      # Publish to the public Scorecard API via OIDC, no token needed.
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Scorecard's own Dangerous-Workflow and Token-Permissions checks flag
+          # workflows that leave credentials in the runner's git config.
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,69 @@
+name: Workflow lint
+
+# These files sign and publish every release artifact, and install.sh runs on
+# users' machines from a `curl | sh`. Both are easy to break in ways that only
+# surface at tag time or on someone else's laptop, so they get their own gate.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  lint:
+    name: actionlint, zizmor, shellcheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Pinned release + checksum rather than piping the upstream installer
+      # script: a linter that guards the release pipeline should not itself be
+      # fetched from a moving target.
+      - name: Install actionlint (pinned)
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP"
+          curl -fsSL --retry 3 -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
+          tar -xzf actionlint.tar.gz actionlint
+          mkdir -p "$RUNNER_TEMP/bin"
+          install -m 755 actionlint "$RUNNER_TEMP/bin/actionlint"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
+      # shellcheck is preinstalled on ubuntu-latest; actionlint shells out to it
+      # to lint every `run:` block in addition to the workflow syntax itself.
+      - name: actionlint
+        run: actionlint -color -shellcheck=shellcheck
+
+      - name: shellcheck install.sh
+        run: shellcheck -s sh install.sh
+
+      # zizmor checks for Actions-specific security problems actionlint does not
+      # model: template-injection sinks, credential persistence, overbroad
+      # permissions, cache poisoning.
+      # `regular` persona at medium severity: fails the build on real problems
+      # (cache poisoning, credential persistence, template injection) without
+      # blocking on style-level findings. Deliberate exceptions carry an inline
+      # `# zizmor: ignore[audit]` with the reason next to it.
+      # --no-online-audits keeps this from depending on network reachability of
+      # third-party services for a required check.
+      - name: zizmor
+        run: |
+          set -euo pipefail
+          pipx install zizmor
+          zizmor --persona=regular --min-severity=medium --no-online-audits .github/workflows/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainers by contacting [@teedole](https://github.com/teedole) directly. If the report concerns a maintainer, or you would rather not contact them, use [GitHub's abuse reporting](https://github.com/contact/report-abuse) instead. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,9 @@ bunx biome check .
 3. decant is local-first and offline: no outbound runtime network calls and no
    LLM calls.
 4. Never commit secrets, private transcripts, or a personal archive DB.
-5. The v8 schema is the baseline. Pre-v8 archives are rebuild-only.
+5. Pre-v8 archives are rebuild-only; v8 and newer migrate forward on open. See
+   `LATEST_SCHEMA_VERSION` in `src/db.ts` for the current baseline rather than
+   trusting a number written down here.
 
 Adding model pricing? Update `src/cost.ts`, include string normalization, and add
 tests.
@@ -59,11 +61,32 @@ tests.
 Adding a source tool? Add `src/sources/<tool>.ts`, synthetic fixtures, parser
 tests, ingest/query coverage, and golden updates.
 
+## How we work
+
+decant is trunk-based. There is one long-lived branch, `main`, and it is always
+releasable.
+
+- **Branch off `main`, keep it short-lived.** Days, not weeks. A branch that
+  lives long enough to drift is a branch that will conflict, and conflicts get
+  resolved by whoever has the least context.
+- **One PR, one concern.** A PR that mixes a feature with unrelated cleanup is
+  harder to review and much harder to revert.
+- **Squash-merge.** `main`'s history is one commit per PR. Your branch is
+  deleted on merge.
+- **`main` stays green.** Every PR needs CI passing and one approving review.
+- **Tags are the only thing that publishes.** Merging to `main` ships nothing.
+  Pushing a `v*` tag builds, signs, and publishes to npm, Homebrew, GHCR, and
+  the GitHub Release. Nothing else does. See
+  [docs/releasing.md](docs/releasing.md).
+
 ## Commits and pull requests
 
 - Use Conventional Commits: `feat:`, `fix:`, `docs:`, `test:`, `chore:`,
   `refactor:`, `style:`, `ci:` with optional scope.
-- Signing commits (`git commit -S`) is appreciated if your environment supports it.
+- **Commits must be signed.** `main` rejects unsigned commits. Either GPG or SSH
+  signing works — see
+  [GitHub's guide](https://docs.github.com/authentication/managing-commit-signature-verification)
+  — and `git config commit.gpgsign true` makes it automatic.
 - Branch off `main`, open a PR, and make sure CI is green.
 
 ## Reporting bugs and proposing features


### PR DESCRIPTION
## Summary

Public-readiness hardening: workflow linting, the findings that linting surfaced, OpenSSF Scorecard, community health files, and the trunk-based contract.

## The part that matters most

**Adding zizmor found four high-severity cache-poisoning findings on the release path.** `setup-bun` was restoring a cache that an earlier PR run could have written — in the workflow that signs and publishes every artifact. A poisoned restore would have shipped. All four now set `no-cache: true`.

Nine checkouts that never push now set `persist-credentials: false`. The two that genuinely need credentials keep them, with the reason inline:

- `meta` runs `git fetch origin` for the tag guard
- `tap-update` pushes the rendered formula

Both carry `# zizmor: ignore[artipacked]` next to the justification, so the exception is documented rather than invisible.

## The gate

`workflow-lint.yml` runs actionlint (with shellcheck on every `run:` block), shellcheck on `install.sh`, and zizmor at the `regular` persona, medium severity — strict enough to fail on cache poisoning, credential persistence, and template injection; loose enough not to block on style.

actionlint is installed from a **pinned release verified against its published SHA256**, not piped from an installer script. A linter guarding the release pipeline shouldn't itself come from a moving target.

**The gate is verified non-vacuous:** removing a single `persist-credentials: false` line makes it exit 13; restoring it returns 0.

`ci.yml` moves to `permissions: {}` with per-job grants, so widening the file later can't silently widen a job that never asked for it.

## Scorecard

Lands gated on `github.event.repository.private == false`, so it stays genuinely dormant instead of red on every push until the visibility flip — then starts reporting on its own with no follow-up edit.

## Community health files

CODEOWNERS, Contributor Covenant 2.1, issue forms, PR template. None existed before.

**The bug report form leads with a privacy warning rather than burying it.** Transcripts contain the reporter's own source code, file paths, and prompts, and a parsing bug is precisely when someone pastes real session content into a public issue. The form asks for a synthetic reproduction and requires confirming the report contains none.

## Two stale claims corrected

- CONTRIBUTING said "The v8 schema is the baseline." It's v14. It now points at `LATEST_SCHEMA_VERSION` instead of restating a number that has moved three times today.
- It called signed commits "appreciated." `main` will reject unsigned commits once the ruleset lands, so it now says so.

## Needs your input before the flip

The code of conduct's enforcement contact routes to the maintainer's GitHub profile, with GitHub's abuse reporting as the escape hatch for when the maintainer is the problem. `SECURITY.md` uses GitHub's private reporting flow and the project has no contact address anywhere — so nothing was invented. **Swap in a real address if one exists.**

## Validation

- `just check` — 388 tests, `tsc --noEmit`, `biome check .` (98 files), distribution smoke
- `actionlint -shellcheck=shellcheck` clean on all four workflows
- `shellcheck -s sh install.sh` clean
- `zizmor --persona=regular --min-severity=medium` — "No findings to report"
- All three issue forms parse as valid YAML; every CODEOWNERS path verified to exist
