### PR TITLE
fix(codex): qualify namespaced MCP tool calls

### DIFF
--- a/src/sources/codex.ts
+++ b/src/sources/codex.ts
@@ -300,7 +300,7 @@ function parseItem(
       ordinal: 0,
       blockType: "tool_use",
       text: null,
-      toolName: asString(get(payload, "name")),
+      toolName: qualifiedToolName(payload),
       toolUseId: asString(get(payload, "call_id")),
       toolInput: callInput(payload),
       toolResult: null,
@@ -348,6 +348,15 @@ function parseItem(
     toolResult: null,
     isError: null,
   });
+}
+
+function qualifiedToolName(payload: Json): string | null {
+  const name = asString(get(payload, "name"));
+  const namespace = asString(get(payload, "namespace"));
+  if (name == null || namespace == null || namespace === "") {
+    return name;
+  }
+  return name.startsWith(`${namespace}__`) ? name : `${namespace}__${name}`;
 }
 
 function messageRole(role: string | null): Role {

--- a/src/sources/codex.ts
+++ b/src/sources/codex.ts
@@ -353,7 +353,7 @@ function parseItem(
 function qualifiedToolName(payload: Json): string | null {
   const name = asString(get(payload, "name"));
   const namespace = asString(get(payload, "namespace"));
-  if (name == null || namespace == null || namespace === "") {
+  if (name == null || name === "" || namespace == null || namespace === "") {
     return name;
   }
   return name.startsWith(`${namespace}__`) ? name : `${namespace}__${name}`;

--- a/test/codex.test.ts
+++ b/test/codex.test.ts
@@ -252,4 +252,15 @@ describe("parseCodexSession", () => {
     expect(messages[8]?.blocks[0]?.toolName).toBe("do_thing");
     expect(messages[8]?.blocks[0]?.toolInput).toEqual({ a: 1 });
   });
+
+  test("qualifies namespaced tool names but leaves empty names unchanged", () => {
+    const content = [
+      '{"type":"response_item","payload":{"type":"mcp_tool_call","namespace":"mcp__dosu","name":"read_knowledge","call_id":"c1"}}',
+      '{"type":"response_item","payload":{"type":"mcp_tool_call","namespace":"mcp__dosu","name":"","call_id":"c2"}}',
+    ].join("\n");
+    const messages = parseCodexSession("fallback", content, new Map()).session.messages;
+
+    expect(messages[0]?.blocks[0]?.toolName).toBe("mcp__dosu__read_knowledge");
+    expect(messages[1]?.blocks[0]?.toolName).toBe("");
+  });
 });

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../src/ingest.ts";
 import { getSession, listSessions } from "../src/query.ts";
 import { parseClaudeSession } from "../src/sources/claude.ts";
+import { parseCodexSession } from "../src/sources/codex.ts";
 
 const repoRoot = join(import.meta.dir, "..");
 const fixtureRoot = join(repoRoot, "fixtures");
@@ -117,6 +118,44 @@ const ROW_QUERIES = {
 } as const;
 
 describe("upsertSession", () => {
+  test("classifies namespaced Codex MCP tool calls", () => {
+    const dir = freshCase();
+    const db = openFreshDb(dir);
+    const content = [
+      JSON.stringify({
+        type: "session_meta",
+        payload: { id: "codex-mcp", cwd: "/tmp/proj" },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        payload: {
+          type: "mcp_tool_call",
+          namespace: "mcp__dosu",
+          name: "read_knowledge",
+          call_id: "call-1",
+          arguments: "{}",
+        },
+      }),
+    ].join("\n");
+    const parsed = parseCodexSession("fallback", content, new Map());
+    const sessionId = upsertSession(db, parsed, "/x/codex-mcp.jsonl", 1, 2, "hash");
+
+    expect(
+      db
+        .query(
+          `SELECT tool_kind, tool_name, mcp_server, tool_base_name
+           FROM tool_call WHERE session_id = ?1`,
+        )
+        .get(sessionId),
+    ).toEqual({
+      tool_kind: "mcp",
+      tool_name: "mcp__dosu__read_knowledge",
+      mcp_server: "dosu",
+      tool_base_name: "read_knowledge",
+    });
+    db.close();
+  });
+
   test("writes sessions, messages, blocks, tool calls, file refs, facets, and FTS rows", () => {
     const dir = freshCase();
     const db = openFreshDb(dir);

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -121,39 +121,42 @@ describe("upsertSession", () => {
   test("classifies namespaced Codex MCP tool calls", () => {
     const dir = freshCase();
     const db = openFreshDb(dir);
-    const content = [
-      JSON.stringify({
-        type: "session_meta",
-        payload: { id: "codex-mcp", cwd: "/tmp/proj" },
-      }),
-      JSON.stringify({
-        type: "response_item",
-        payload: {
-          type: "mcp_tool_call",
-          namespace: "mcp__dosu",
-          name: "read_knowledge",
-          call_id: "call-1",
-          arguments: "{}",
-        },
-      }),
-    ].join("\n");
-    const parsed = parseCodexSession("fallback", content, new Map());
-    const sessionId = upsertSession(db, parsed, "/x/codex-mcp.jsonl", 1, 2, "hash");
+    try {
+      const content = [
+        JSON.stringify({
+          type: "session_meta",
+          payload: { id: "codex-mcp", cwd: "/tmp/proj" },
+        }),
+        JSON.stringify({
+          type: "response_item",
+          payload: {
+            type: "mcp_tool_call",
+            namespace: "mcp__dosu",
+            name: "read_knowledge",
+            call_id: "call-1",
+            arguments: "{}",
+          },
+        }),
+      ].join("\n");
+      const parsed = parseCodexSession("fallback", content, new Map());
+      const sessionId = upsertSession(db, parsed, "/x/codex-mcp.jsonl", 1, 2, "hash");
 
-    expect(
-      db
-        .query(
-          `SELECT tool_kind, tool_name, mcp_server, tool_base_name
-           FROM tool_call WHERE session_id = ?1`,
-        )
-        .get(sessionId),
-    ).toEqual({
-      tool_kind: "mcp",
-      tool_name: "mcp__dosu__read_knowledge",
-      mcp_server: "dosu",
-      tool_base_name: "read_knowledge",
-    });
-    db.close();
+      expect(
+        db
+          .query(
+            `SELECT tool_kind, tool_name, mcp_server, tool_base_name
+             FROM tool_call WHERE session_id = ?1`,
+          )
+          .get(sessionId),
+      ).toEqual({
+        tool_kind: "mcp",
+        tool_name: "mcp__dosu__read_knowledge",
+        mcp_server: "dosu",
+        tool_base_name: "read_knowledge",
+      });
+    } finally {
+      db.close();
+    }
   });
 
   test("writes sessions, messages, blocks, tool calls, file refs, facets, and FTS rows", () => {


### PR DESCRIPTION
## Summary

- reconstruct qualified tool names from Codex name and namespace fields
- preserve legacy unnamespaced and already-qualified tool names
- verify namespaced calls persist as MCP usage with the correct server

## Testing

- just check