### PR TITLE
fix: preserve agent effort levels and pricing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,10 +95,10 @@ A change is ready when:
 4. **Costs are computed at ingest** with `cost::estimateCost` and stored on the
    session row. Editing pricing does not rewrite historical rows; rebuild the
    archive to recompute.
-5. **The schema baseline is v14.** Pre-v8 archives are intentionally rebuild-only:
+5. **The schema baseline is v15.** Pre-v8 archives are intentionally rebuild-only:
    delete the archive and re-ingest from the source directories. Do not add
    broad forward migrations unless that product decision changes; the narrow
-   v8-to-v14 migrations preserve existing TypeScript-cutover archives.
+   v8-to-v15 migrations preserve existing TypeScript-cutover archives.
 6. **Parsers are the extension point.** A new source tool means
    `src/sources/<tool>.ts`, synthetic fixtures, parser tests, ingest/query tests,
    and golden updates.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ transcripts never leave your machine.
 
 - One archive for Claude Code and Codex sessions.
 - Full-text search across messages and tool calls.
-- Usage, cost, tool, MCP, file-hotspot, and activity analytics.
+- Usage, [estimated cost](docs/pricing.md), tool, MCP, file-hotspot, and
+  activity analytics.
 - Deterministic `distill` artifacts from real command history: scripts, replays,
   and skill/AGENTS snippets.
 - Persisted recommendations with implemented-state tracking.
@@ -154,8 +155,8 @@ means no gateway is derived.
 deliberately want other hosts in: the `Host` header check is not an access
 control for non-browser clients, which can send `Host: localhost` freely.
 
-Archives older than schema v8 are rebuild-only. v8 through v13 archives migrate
-forward to v14 on open; the next `decant sync` backfills persisted economics
+Archives older than schema v8 are rebuild-only. v8 through v14 archives migrate
+forward to v15 on open; the next `decant sync` backfills persisted economics
 vectors and context-window rollups for unchanged sessions. Older archives should
 be deleted and rebuilt with `decant sync`. Source logs remain the source of
 truth, so nothing is lost by rebuilding.

--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -107,8 +107,9 @@ Availability remains model-dependent for both providers.
 
 Claude Code began recording the active effort on every assistant transcript
 message in v2.1.219. Earlier transcripts do not contain enough information to
-distinguish the model default from a session override, so the UI displays
-`not recorded` instead of guessing a historical effort level.
+distinguish the model default from a session override, so the UI keeps the
+placeholder `-` and explains the missing source data in a tooltip instead of
+guessing a historical effort level.
 
 The context-window route derives per-API-call window occupancy and compaction
 events at read time from persisted per-message token columns and raw records.

--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -105,6 +105,11 @@ remain unchanged. The current known values are:
 
 Availability remains model-dependent for both providers.
 
+Claude Code began recording the active effort on every assistant transcript
+message in v2.1.219. Earlier transcripts do not contain enough information to
+distinguish the model default from a session override, so the UI displays
+`not recorded` instead of guessing a historical effort level.
+
 The context-window route derives per-API-call window occupancy and compaction
 events at read time from persisted per-message token columns and raw records.
 Claude logs do not state the size, so it is inferred from the recorded model:

--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -89,9 +89,21 @@ Session summaries returned by the list and detail routes include
 `reasoning_effort` and `reasoning_effort_levels`. The first is the normalized
 provider effort label, `mixed` when the setting changes between turns, or
 `null` when the source did not record one. The levels array preserves the
-unique labels represented by `mixed`. Claude Code's `max` wire value is exposed
-as its user-facing `ultra` setting; Codex's distinct `max` and `ultra` values
-remain unchanged.
+unique labels represented by `mixed`. Provider labels retain their meaning
+after whitespace trimming and canonicalization of known labels: Claude Code's
+`max` remains `max`, while Codex's distinct `max` and `ultra` values also
+remain unchanged. The current known values are:
+
+- Claude Code: `low`, `medium`, `high`, `xhigh`, and `max`. Its `auto`
+  selector resolves to the model default, while `ultracode` reports `xhigh`
+  because it is workflow orchestration layered on that effort level. Numeric
+  Agent SDK per-agent token budgets are preserved and displayed as token
+  budgets.
+- Codex: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, and
+  `ultra`. Unknown future custom values preserve their original spelling
+  rather than being discarded or rewritten.
+
+Availability remains model-dependent for both providers.
 
 The context-window route derives per-API-call window occupancy and compaction
 events at read time from persisted per-message token columns and raw records.

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -8,6 +8,8 @@ The seed table was last verified on July 25, 2026 against:
 - [OpenAI model pages](https://developers.openai.com/api/docs/models)
 - [OpenAI Codex pricing](https://developers.openai.com/codex/pricing)
 - [OpenAI model deprecations](https://developers.openai.com/api/docs/deprecations)
+- [OpenAI GPT-3.5 Turbo launch pricing](https://openai.com/index/introducing-chatgpt-and-whisper-apis/)
+- [OpenAI GPT-3.5 Turbo June 2023 price update](https://openai.com/index/function-calling-and-other-api-updates/)
 
 All dollar amounts below are USD per million tokens. A dash means that the
 provider does not publish a first-party API token price for that model slug.
@@ -43,6 +45,11 @@ cache writes at 1.25 times the uncached-input rate.
 OpenAI does not document which underlying model or rate applies. Decant leaves
 it and other unpublished Codex slugs unpriceable instead of guessing a nearby
 model's price.
+
+For `gpt-3.5-turbo-0301`, Decant uses the final published GPT-3.5 Turbo rate
+of $1.50 input and $2.00 output. OpenAI's current deprecations table displays
+$15.00 and $20.00, but those figures conflict with the contemporaneous launch
+and June 2023 pricing announcements linked above.
 
 ## Scope and historical behavior
 

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -35,7 +35,7 @@ provider does not publish a first-party API token price for that model slug.
 | GPT-5.1-Codex, GPT-5.1-Codex-Max, GPT-5-Codex | $1.25 | $0.125 | no additional fee | $10.00 |
 | GPT-5.1-Codex-mini | $0.25 | $0.025 | no additional fee | $2.00 |
 | codex-mini-latest | $1.50 | $0.375 | no additional fee | $6.00 |
-| codex-auto-review, GPT-5.3-Codex-Spark, GPT-5-Codex-mini | — | — | — | — |
+| codex-auto-review, GPT-5.3-Codex-Spark, GPT-5-Codex-mini, GPT-5.4-cyber | — | — | — | — |
 
 Claude's two cache-write figures are the 5-minute and 1-hour rates. OpenAI
 cache writes before GPT-5.6 have no additional fee; GPT-5.6 reports and bills

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -1,0 +1,61 @@
+# Pricing estimates
+
+Decant estimates token costs at ingest using published first-party API rates.
+The seed table was last verified on July 25, 2026 against:
+
+- [Anthropic model and prompt-cache pricing](https://platform.claude.com/docs/en/about-claude/pricing)
+- [OpenAI API pricing](https://developers.openai.com/api/docs/pricing)
+- [OpenAI model pages](https://developers.openai.com/api/docs/models)
+- [OpenAI Codex pricing](https://developers.openai.com/codex/pricing)
+- [OpenAI model deprecations](https://developers.openai.com/api/docs/deprecations)
+
+All dollar amounts below are USD per million tokens. A dash means that the
+provider does not publish a first-party API token price for that model slug.
+
+## Coding-agent model rates
+
+| Provider models | Input | Cached input | Cache write | Output |
+| --- | ---: | ---: | ---: | ---: |
+| Claude Fable 5, Mythos 5 | $10.00 | $1.00 | $12.50 / $20.00 | $50.00 |
+| Claude Opus 5, 4.8, 4.7, 4.6, 4.5 | $5.00 | $0.50 | $6.25 / $10.00 | $25.00 |
+| Claude Opus 4.1, 4 | $15.00 | $1.50 | $18.75 / $30.00 | $75.00 |
+| Claude Sonnet 5 through August 31, 2026 | $2.00 | $0.20 | $2.50 / $4.00 | $10.00 |
+| Claude Sonnet 4.6, 4.5, 4 | $3.00 | $0.30 | $3.75 / $6.00 | $15.00 |
+| Claude Haiku 4.5 | $1.00 | $0.10 | $1.25 / $2.00 | $5.00 |
+| Claude Haiku 3.5 | $0.80 | $0.08 | $1.00 / $1.60 | $4.00 |
+| GPT-5.6 Sol | $5.00 | $0.50 | $6.25 | $30.00 |
+| GPT-5.6 Terra | $2.50 | $0.25 | $3.125 | $15.00 |
+| GPT-5.6 Luna | $1.00 | $0.10 | $1.25 | $6.00 |
+| GPT-5.5 | $5.00 | $0.50 | no additional fee | $30.00 |
+| GPT-5.4 | $2.50 | $0.25 | no additional fee | $15.00 |
+| GPT-5.4 mini | $0.75 | $0.075 | no additional fee | $4.50 |
+| GPT-5.3-Codex, GPT-5.2-Codex | $1.75 | $0.175 | no additional fee | $14.00 |
+| GPT-5.1-Codex, GPT-5.1-Codex-Max, GPT-5-Codex | $1.25 | $0.125 | no additional fee | $10.00 |
+| GPT-5.1-Codex-mini | $0.25 | $0.025 | no additional fee | $2.00 |
+| codex-mini-latest | $1.50 | $0.375 | no additional fee | $6.00 |
+| codex-auto-review, GPT-5.3-Codex-Spark, GPT-5-Codex-mini | — | — | — | — |
+
+Claude's two cache-write figures are the 5-minute and 1-hour rates. OpenAI
+cache writes before GPT-5.6 have no additional fee; GPT-5.6 reports and bills
+cache writes at 1.25 times the uncached-input rate.
+
+`codex-auto-review` is a hidden routing slug, not a public billable model ID.
+OpenAI does not document which underlying model or rate applies. Decant leaves
+it and other unpublished Codex slugs unpriceable instead of guessing a nearby
+model's price.
+
+## Scope and historical behavior
+
+The estimates use standard global API token rates. They do not attempt to
+convert ChatGPT subscription usage or Codex credits to dollars, and they do not
+apply Batch, Flex, Priority, fast-mode, regional-processing, data-residency, or
+partner-cloud modifiers.
+
+OpenAI applies long-context rates above 272,000 prompt tokens for eligible API
+models. The Codex model catalog currently caps coding-agent context at 272,000
+tokens, so Decant's Codex sources do not cross that threshold. Claude 4.6 and
+later include their full context window at the standard rate.
+
+Costs are stored on the session row when the transcript is ingested. Updating
+the seed table does not rewrite historical rows; rebuild the archive to
+re-estimate existing sessions with a newer pricing table.

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -95,7 +95,7 @@ export function defaultPricing(): Map<string, Price> {
     ["gpt-3.5-turbo-0125", openAiPrice(0.5, null, 1.5)],
     ["gpt-3.5-turbo-1106", openAiPrice(1.0, null, 2.0)],
     ["gpt-3.5-turbo-0613", openAiPrice(1.5, null, 2.0)],
-    ["gpt-3.5-turbo-0301", openAiPrice(15.0, null, 20.0)],
+    ["gpt-3.5-turbo-0301", openAiPrice(1.5, null, 2.0)],
     ["gpt-3.5-turbo-instruct", openAiPrice(1.5, null, 2.0)],
     ["gpt-3.5-turbo-16k-0613", openAiPrice(3.0, null, 4.0)],
     ["davinci-002", openAiPrice(2.0, null, 2.0)],

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -37,7 +37,8 @@ function openAiPrice(
 export function defaultPricing(): Map<string, Price> {
   // Standard first-party API text-token rates per 1M tokens. Claude cache writes
   // carry both a 5-minute (1.25x input) and a 1-hour (2x input) rate; the split
-  // comes from usage.cache_creation.ephemeral_{5m,1h}_input_tokens.
+  // comes from usage.cache_creation.ephemeral_{5m,1h}_input_tokens. Rates and
+  // exclusions were checked against the official sources in docs/pricing.md.
   return new Map<string, Price>([
     ["claude-fable", claudePrice(10.0, 50.0)],
     ["claude-opus", claudePrice(5.0, 25.0)],
@@ -56,13 +57,20 @@ export function defaultPricing(): Map<string, Price> {
     ["gpt-5.4-mini", openAiPrice(0.75, 0.075, 4.5)],
     ["gpt-5.4-nano", openAiPrice(0.2, 0.02, 1.25)],
     ["gpt-5.4-pro", openAiPrice(30.0, null, 180.0)],
+    ["gpt-5.3-codex", openAiPrice(1.75, 0.175, 14.0)],
+    ["gpt-5.2-codex", openAiPrice(1.75, 0.175, 14.0)],
     ["gpt-5.2", openAiPrice(1.75, 0.175, 14.0)],
     ["gpt-5.2-pro", openAiPrice(21.0, null, 168.0)],
+    ["gpt-5.1-codex-max", openAiPrice(1.25, 0.125, 10.0)],
+    ["gpt-5.1-codex-mini", openAiPrice(0.25, 0.025, 2.0)],
+    ["gpt-5.1-codex", openAiPrice(1.25, 0.125, 10.0)],
     ["gpt-5.1", openAiPrice(1.25, 0.125, 10.0)],
+    ["gpt-5-codex", openAiPrice(1.25, 0.125, 10.0)],
     ["gpt-5", openAiPrice(1.25, 0.125, 10.0)],
     ["gpt-5-mini", openAiPrice(0.25, 0.025, 2.0)],
     ["gpt-5-nano", openAiPrice(0.05, 0.005, 0.4)],
     ["gpt-5-pro", openAiPrice(15.0, null, 120.0)],
+    ["codex-mini-latest", openAiPrice(1.5, 0.375, 6.0)],
     ["gpt-4.1", openAiPrice(2.0, 0.5, 8.0)],
     ["gpt-4.1-mini", openAiPrice(0.4, 0.1, 1.6)],
     ["gpt-4.1-nano", openAiPrice(0.1, 0.025, 0.4)],
@@ -87,7 +95,7 @@ export function defaultPricing(): Map<string, Price> {
     ["gpt-3.5-turbo-0125", openAiPrice(0.5, null, 1.5)],
     ["gpt-3.5-turbo-1106", openAiPrice(1.0, null, 2.0)],
     ["gpt-3.5-turbo-0613", openAiPrice(1.5, null, 2.0)],
-    ["gpt-3.5-0301", openAiPrice(1.5, null, 2.0)],
+    ["gpt-3.5-turbo-0301", openAiPrice(15.0, null, 20.0)],
     ["gpt-3.5-turbo-instruct", openAiPrice(1.5, null, 2.0)],
     ["gpt-3.5-turbo-16k-0613", openAiPrice(3.0, null, 4.0)],
     ["davinci-002", openAiPrice(2.0, null, 2.0)],
@@ -144,8 +152,16 @@ function canonicalModel(raw: string): string | null {
     return null;
   }
 
-  if (model.startsWith("codex-auto-review") || model.startsWith("gpt-5.3-codex")) {
-    return "gpt-5.2";
+  // These internal, subscription-only, or preview slugs have no published
+  // first-party API token price. Returning no price is safer than assigning a
+  // neighboring public model's rate.
+  if (
+    model.startsWith("codex-auto-review") ||
+    model.startsWith("gpt-5.3-codex-spark") ||
+    model.startsWith("gpt-5-codex-mini") ||
+    model.startsWith("gpt-5.4-cyber")
+  ) {
+    return null;
   }
 
   for (const key of [
@@ -158,9 +174,15 @@ function canonicalModel(raw: string): string | null {
     "gpt-5.4-mini",
     "gpt-5.4-pro",
     "gpt-5.4",
+    "gpt-5.3-codex",
+    "gpt-5.2-codex",
     "gpt-5.2-pro",
     "gpt-5.2",
+    "gpt-5.1-codex-max",
+    "gpt-5.1-codex-mini",
+    "gpt-5.1-codex",
     "gpt-5.1",
+    "gpt-5-codex",
     "gpt-5-mini",
     "gpt-5-nano",
     "gpt-5-pro",
@@ -190,8 +212,9 @@ function canonicalModel(raw: string): string | null {
     "gpt-3.5-turbo-0125",
     "gpt-3.5-turbo-1106",
     "gpt-3.5-turbo-0613",
-    "gpt-3.5-0301",
+    "gpt-3.5-turbo-0301",
     "gpt-3.5-turbo",
+    "codex-mini-latest",
     "davinci-002",
     "babbage-002",
   ]) {

--- a/src/db.ts
+++ b/src/db.ts
@@ -14,7 +14,7 @@ import schemaSql from "./schema.sql" with { type: "text" };
 /// effective DDL with migrations 1..LATEST_SCHEMA_VERSION already applied
 /// and is now the frozen baseline, so a fresh archive is created in one step
 /// and stamped with the full migration history.
-export const LATEST_SCHEMA_VERSION = 14;
+export const LATEST_SCHEMA_VERSION = 15;
 
 /// Owner-only mode for the archive and its SQLite sidecars. The transcripts
 /// decant ingests sit in 0600 files under 0700 directories; the aggregate of
@@ -268,10 +268,6 @@ function migrate(db: Database, current: number): void {
       }
       db.exec(`
         UPDATE session
-        SET reasoning_effort = 'ultra'
-        WHERE tool = 'claude_code' AND LOWER(TRIM(reasoning_effort)) = 'max';
-
-        UPDATE session
         SET reasoning_effort_levels = CASE
           WHEN reasoning_effort IS NULL
             OR TRIM(reasoning_effort) = ''
@@ -286,6 +282,31 @@ function migrate(db: Database, current: number): void {
       `);
       db.query(
         "INSERT INTO schema_migrations (version, applied_at) VALUES (14, datetime('now'))",
+      ).run();
+    }
+    if (current < 15) {
+      // Schema v14 incorrectly relabeled Claude Code's provider-supplied `max`
+      // effort as `ultra`. Only archives that were already opened by a v14
+      // build need repair; older archives retain their original labels while
+      // migrating directly through the corrected v14 step above.
+      if (current === 14) {
+        db.exec(`
+          UPDATE session
+          SET reasoning_effort = CASE
+                WHEN LOWER(TRIM(reasoning_effort)) = 'ultra' THEN 'max'
+                ELSE reasoning_effort
+              END,
+              reasoning_effort_levels =
+                REPLACE(reasoning_effort_levels, '"ultra"', '"max"')
+          WHERE tool = 'claude_code'
+            AND (
+              LOWER(TRIM(reasoning_effort)) = 'ultra'
+              OR reasoning_effort_levels LIKE '%"ultra"%'
+            );
+        `);
+      }
+      db.query(
+        "INSERT INTO schema_migrations (version, applied_at) VALUES (15, datetime('now'))",
       ).run();
     }
     db.exec("COMMIT;");

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -22,6 +22,7 @@ import {
   type NormalizedBlock,
   type ParsedSession,
   reasoningEffortLevels,
+  recordedReasoningEffort,
   summarizeReasoningEfforts,
   type Tool,
 } from "./model.ts";
@@ -437,7 +438,7 @@ function reasoningEffortFromSource(tool: Tool, path: string): ReasoningEffortSum
       // Best-effort cleanup: preserve the scan result or original read error.
     }
   }
-  const levels = reasoningEffortLevels(tool, efforts);
+  const levels = reasoningEffortLevels(efforts);
   return { summary: summarizeReasoningEfforts(levels), levels };
 }
 
@@ -449,8 +450,8 @@ function collectReasoningEffort(tool: Tool, line: string, efforts: Set<string>):
     const value = JSON.parse(line) as Json;
     const effort =
       tool === "claude_code"
-        ? asString(get(value, "effort"))
-        : asString(get(get(value, "payload"), "effort"));
+        ? recordedReasoningEffort(get(value, "effort"))
+        : recordedReasoningEffort(get(get(value, "payload"), "effort"));
     if (
       effort != null &&
       (tool === "claude_code" || asString(get(value, "type")) === "turn_context")

--- a/src/model.ts
+++ b/src/model.ts
@@ -47,12 +47,36 @@ export function emptyUsage(): TokenUsage {
   return { input: 0, output: 0, cacheRead: 0, cacheCreation: 0, cacheCreation1h: 0, reasoning: 0 };
 }
 
+/** Provider-defined labels whose spelling is part of the current wire format.
+ * `mixed` is Decant's own session summary value. */
+const KNOWN_REASONING_EFFORTS = new Set([
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "ultra",
+  "mixed",
+]);
+
+/** Read a provider-recorded effort value. Named levels are strings; Claude's
+ * Agent SDK also permits numeric per-agent token budgets. Keep both losslessly
+ * representable in the archive's string-valued effort columns. */
+export function recordedReasoningEffort(value: Json | undefined): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+  return typeof value === "number" && Number.isFinite(value) ? String(value) : null;
+}
+
 /** Collapse provider effort labels to one session-level value. Sessions almost
  * always use one value, but settings can change between turns; preserve that
  * distinction instead of presenting the last turn as representative. */
 export function summarizeReasoningEfforts(values: Iterable<string>): string | null {
   const efforts = new Set(
-    Array.from(values, (value) => value.trim().toLowerCase()).filter((value) => value !== ""),
+    Array.from(values, normalizeReasoningEffort).filter((value): value is string => value != null),
   );
   if (efforts.size === 0) {
     return null;
@@ -63,23 +87,23 @@ export function summarizeReasoningEfforts(values: Iterable<string>): string | nu
   return "mixed";
 }
 
-/** Normalize provider wire labels to the effort names users selected. Claude
- * Code writes its highest `ultra` setting as `max`; Codex uses `max` and
- * `ultra` as distinct labels, so that alias is intentionally provider-scoped. */
-export function normalizeReasoningEffort(tool: Tool, value: string): string | null {
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "") {
+/** Normalize known provider effort labels without changing their meaning.
+ * Future custom values may be case-sensitive, so preserve their spelling. */
+export function normalizeReasoningEffort(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed === "") {
     return null;
   }
-  return tool === "claude_code" && normalized === "max" ? "ultra" : normalized;
+  const canonical = trimmed.toLowerCase();
+  return KNOWN_REASONING_EFFORTS.has(canonical) ? canonical : trimmed;
 }
 
 /** Unique normalized effort labels in first-seen order. This detail is kept
  * alongside the collapsed session value so `mixed` remains explainable. */
-export function reasoningEffortLevels(tool: Tool, values: Iterable<string>): string[] {
+export function reasoningEffortLevels(values: Iterable<string>): string[] {
   const levels = new Set<string>();
   for (const value of values) {
-    const normalized = normalizeReasoningEffort(tool, value);
+    const normalized = normalizeReasoningEffort(value);
     if (normalized != null) {
       levels.add(normalized);
     }

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1,5 +1,5 @@
--- decant:schema_version=14
--- Effective decant schema (migrations 1..14 applied), frozen as the current
+-- decant:schema_version=15
+-- Effective decant schema (migrations 1..15 applied), frozen as the current
 -- baseline. Do not edit without updating schema tests.
 CREATE TABLE schema_migrations(
             version INTEGER PRIMARY KEY,

--- a/src/sources/claude.ts
+++ b/src/sources/claude.ts
@@ -8,6 +8,7 @@ import {
   type ParsedSession,
   type Role,
   reasoningEffortLevels,
+  recordedReasoningEffort,
   summarizeReasoningEfforts,
   type TokenUsage,
 } from "../model.ts";
@@ -100,7 +101,7 @@ export function parseClaudeSession(
     gitBranch ??= stringAt(value, "gitBranch", "git_branch");
     cliVersion ??= stringAt(value, "version", "cli_version");
     sessionModel ??= stringAt(get(value, "message"), "model") ?? stringAt(value, "model");
-    const effort = stringAt(value, "effort");
+    const effort = recordedReasoningEffort(get(value, "effort"));
     if (effort != null) {
       reasoningEfforts.add(effort);
     }
@@ -187,7 +188,7 @@ export function parseClaudeSession(
     spawnToolUseId,
     spawnDepth,
   };
-  const effortLevels = reasoningEffortLevels("claude_code", reasoningEfforts);
+  const effortLevels = reasoningEffortLevels(reasoningEfforts);
 
   return {
     session: {

--- a/src/sources/codex.ts
+++ b/src/sources/codex.ts
@@ -7,6 +7,7 @@ import {
   type ParsedSession,
   type Role,
   reasoningEffortLevels,
+  recordedReasoningEffort,
   summarizeReasoningEfforts,
   type TokenUsage,
 } from "../model.ts";
@@ -92,7 +93,7 @@ export function parseCodexSession(
       rawMeta = payload;
     } else if (typ === "turn_context") {
       model = asString(get(payload, "model")) ?? model;
-      const effort = asString(get(payload, "effort"));
+      const effort = recordedReasoningEffort(get(payload, "effort"));
       if (effort != null) {
         reasoningEfforts.add(effort);
       }
@@ -130,7 +131,7 @@ export function parseCodexSession(
   if (contextWindow != null) {
     rawMeta = { ...(isObject(rawMeta) ? rawMeta : {}), model_context_window: contextWindow };
   }
-  const effortLevels = reasoningEffortLevels("codex", reasoningEfforts);
+  const effortLevels = reasoningEffortLevels(reasoningEfforts);
 
   return {
     session: {

--- a/src/ui/effort.ts
+++ b/src/ui/effort.ts
@@ -1,12 +1,12 @@
 import { normalizeReasoningEffort } from "../model.ts";
 
-export function effortDisplayLabel(
-  effort: string | null | undefined,
-  labeled = false,
-): string | null {
+export const UNRECORDED_EFFORT_TOOLTIP =
+  "The source transcript did not record an effort level, so Decant cannot recover it reliably.";
+
+export function effortDisplayLabel(effort: string | null | undefined, labeled = false): string {
   const label = effort == null ? null : normalizeReasoningEffort(effort);
   if (label == null) {
-    return null;
+    return labeled ? "effort not recorded" : "not recorded";
   }
   const display = displayEffortLevel(label);
   return labeled && !display.startsWith("effort ") ? `effort ${display}` : display;
@@ -16,7 +16,11 @@ export function effortTooltip(
   effort: string | null | undefined,
   levels: readonly string[] | null | undefined,
 ): string | undefined {
-  if (effort == null || normalizeReasoningEffort(effort) !== "mixed") {
+  const normalized = effort == null ? null : normalizeReasoningEffort(effort);
+  if (normalized == null) {
+    return UNRECORDED_EFFORT_TOOLTIP;
+  }
+  if (normalized !== "mixed") {
     return undefined;
   }
   const mixedLevels = Array.from(

--- a/src/ui/effort.ts
+++ b/src/ui/effort.ts
@@ -6,7 +6,7 @@ export const UNRECORDED_EFFORT_TOOLTIP =
 export function effortDisplayLabel(effort: string | null | undefined, labeled = false): string {
   const label = effort == null ? null : normalizeReasoningEffort(effort);
   if (label == null) {
-    return labeled ? "effort not recorded" : "not recorded";
+    return "-";
   }
   const display = displayEffortLevel(label);
   return labeled && !display.startsWith("effort ") ? `effort ${display}` : display;

--- a/src/ui/effort.ts
+++ b/src/ui/effort.ts
@@ -4,8 +4,7 @@ export function effortDisplayLabel(
   effort: string | null | undefined,
   labeled = false,
 ): string | null {
-  const rawLabel = effort?.trim().replace(/^effort\s+/i, "");
-  const label = rawLabel == null ? null : normalizeReasoningEffort(rawLabel);
+  const label = effort == null ? null : normalizeReasoningEffort(effort);
   if (label == null) {
     return null;
   }

--- a/src/ui/effort.ts
+++ b/src/ui/effort.ts
@@ -1,16 +1,37 @@
+import { normalizeReasoningEffort } from "../model.ts";
+
+export function effortDisplayLabel(
+  effort: string | null | undefined,
+  labeled = false,
+): string | null {
+  const rawLabel = effort?.trim().replace(/^effort\s+/i, "");
+  const label = rawLabel == null ? null : normalizeReasoningEffort(rawLabel);
+  if (label == null) {
+    return null;
+  }
+  const display = displayEffortLevel(label);
+  return labeled && !display.startsWith("effort ") ? `effort ${display}` : display;
+}
+
 export function effortTooltip(
   effort: string | null | undefined,
   levels: readonly string[] | null | undefined,
 ): string | undefined {
-  if (effort?.trim().toLowerCase() !== "mixed") {
+  if (effort == null || normalizeReasoningEffort(effort) !== "mixed") {
     return undefined;
   }
   const mixedLevels = Array.from(
     new Set(
       (levels ?? [])
-        .map((level) => level.trim().toLowerCase())
-        .filter((level) => level !== "" && level !== "mixed"),
+        .map(normalizeReasoningEffort)
+        .filter((level): level is string => level != null && level !== "mixed"),
     ),
   );
-  return mixedLevels.length > 0 ? `Effort levels used: ${mixedLevels.join(", ")}` : undefined;
+  return mixedLevels.length > 0
+    ? `Effort levels used: ${mixedLevels.map(displayEffortLevel).join(", ")}`
+    : undefined;
+}
+
+function displayEffortLevel(level: string): string {
+  return /^\d+(?:\.\d+)?$/.test(level) ? `${level} tokens` : level;
 }

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -2844,9 +2844,9 @@ function EffortBadge({
   if (label == null || label === "") {
     return <span className="faint">-</span>;
   }
-  const displayLabel = effortDisplayLabel(label, labeled);
+  const displayLabel = effortDisplayLabel(effort, labeled);
   return (
-    <Badge mono title={effortTooltip(label, levels)} tone={label === "mixed" ? "warning" : "info"}>
+    <Badge mono title={effortTooltip(effort, levels)} tone={label === "mixed" ? "warning" : "info"}>
       {displayLabel}
     </Badge>
   );

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -59,7 +59,7 @@ import {
 import { layoutContextAnnotations } from "./context-window-layout.ts";
 import { contextWindowDisplayMode } from "./context-window-state.ts";
 import { compactDateTime, fullDateTime } from "./date-time.ts";
-import { effortTooltip } from "./effort.ts";
+import { effortDisplayLabel, effortTooltip } from "./effort.ts";
 import { isFramed } from "./frame-guard.ts";
 import { planSessionLoad, shouldShowSessionSkeleton } from "./loading-state.ts";
 import {
@@ -2844,9 +2844,10 @@ function EffortBadge({
   if (label == null || label === "") {
     return <span className="faint">-</span>;
   }
+  const displayLabel = effortDisplayLabel(label, labeled);
   return (
     <Badge mono title={effortTooltip(label, levels)} tone={label === "mixed" ? "warning" : "info"}>
-      {labeled ? `effort ${label}` : label}
+      {displayLabel}
     </Badge>
   );
 }

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -2841,10 +2841,14 @@ function EffortBadge({
   levels?: string[];
 }) {
   const label = effort?.trim().toLowerCase();
-  if (label == null || label === "") {
-    return <span className="faint">-</span>;
-  }
   const displayLabel = effortDisplayLabel(effort, labeled);
+  if (label == null || label === "") {
+    return (
+      <span className="faint" title={effortTooltip(effort, levels)}>
+        {displayLabel}
+      </span>
+    );
+  }
   return (
     <Badge mono title={effortTooltip(effort, levels)} tone={label === "mixed" ? "warning" : "info"}>
       {displayLabel}

--- a/test/claude.test.ts
+++ b/test/claude.test.ts
@@ -97,8 +97,8 @@ describe("parseClaudeSession", () => {
       '{"type":"assistant","effort":"max","requestId":"r1","message":{"role":"assistant","model":"claude-opus-5","usage":{"input_tokens":10,"output_tokens":20,"cache_read_input_tokens":30,"cache_creation_input_tokens":100,"cache_creation":{"ephemeral_5m_input_tokens":40,"ephemeral_1h_input_tokens":60}},"content":[{"type":"text","text":"done"}]}}',
     ].join("\n");
     const session = parseClaudeSession("effort-cache", `${content}\n`).session;
-    expect(session.reasoningEffort).toBe("ultra");
-    expect(session.reasoningEffortLevels).toEqual(["ultra"]);
+    expect(session.reasoningEffort).toBe("max");
+    expect(session.reasoningEffortLevels).toEqual(["max"]);
     expect(session.totals.cacheCreation).toBe(100);
     expect(session.totals.cacheCreation1h).toBe(60);
   });
@@ -110,7 +110,27 @@ describe("parseClaudeSession", () => {
     ].join("\n");
     const session = parseClaudeSession("mixed", content).session;
     expect(session.reasoningEffort).toBe("mixed");
-    expect(session.reasoningEffortLevels).toEqual(["high", "ultra"]);
+    expect(session.reasoningEffortLevels).toEqual(["high", "max"]);
+  });
+
+  test("preserves every current Claude Code effort label", () => {
+    const content = ["low", "medium", "high", "xhigh", "max"]
+      .map(
+        (effort) =>
+          `{"type":"assistant","effort":"${effort}","message":{"role":"assistant","content":[]}}`,
+      )
+      .join("\n");
+    const session = parseClaudeSession("all-efforts", content).session;
+    expect(session.reasoningEffort).toBe("mixed");
+    expect(session.reasoningEffortLevels).toEqual(["low", "medium", "high", "xhigh", "max"]);
+  });
+
+  test("preserves numeric Agent SDK effort budgets", () => {
+    const content =
+      '{"type":"assistant","effort":16384,"message":{"role":"assistant","content":[]}}';
+    const session = parseClaudeSession("numeric-effort", content).session;
+    expect(session.reasoningEffort).toBe("16384");
+    expect(session.reasoningEffortLevels).toEqual(["16384"]);
   });
 
   test("snake case streaming request ids de-dupe cumulative assistant usage", () => {

--- a/test/codex.test.ts
+++ b/test/codex.test.ts
@@ -53,6 +53,26 @@ describe("parseCodexSession", () => {
     expect(session.reasoningEffortLevels).toEqual(["high", "xhigh"]);
   });
 
+  test("preserves every current Codex effort label", () => {
+    const efforts = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"];
+    const content = efforts
+      .map(
+        (effort) => `{"type":"turn_context","payload":{"model":"gpt-test","effort":"${effort}"}}`,
+      )
+      .join("\n");
+    const session = parseCodexSession("all-efforts", content, new Map()).session;
+    expect(session.reasoningEffort).toBe("mixed");
+    expect(session.reasoningEffortLevels).toEqual(efforts);
+  });
+
+  test("preserves future custom Codex effort labels", () => {
+    const content =
+      '{"type":"turn_context","payload":{"model":"gpt-future","effort":"Future-Level"}}';
+    const session = parseCodexSession("future-effort", content, new Map()).session;
+    expect(session.reasoningEffort).toBe("Future-Level");
+    expect(session.reasoningEffortLevels).toEqual(["Future-Level"]);
+  });
+
   test("stamps last_token_usage onto the producing assistant without crossing compaction", () => {
     const content = [
       JSON.stringify({

--- a/test/cost.test.ts
+++ b/test/cost.test.ts
@@ -158,6 +158,7 @@ describe("estimateCost", () => {
     expect(estimateCost("gpt-3.5-turbo", u, pricing)).toBeCloseTo(2.0, 6);
     expect(estimateCost("gpt-3.5-turbo-1106", u, pricing)).toBeCloseTo(3.0, 6);
     expect(estimateCost("gpt-3.5-turbo-16k-0613", u, pricing)).toBeCloseTo(7.0, 6);
+    expect(estimateCost("gpt-3.5-turbo-0301", u, pricing)).toBeCloseTo(35.0, 6);
     expect(estimateCost("davinci-002", u, pricing)).toBeCloseTo(4.0, 6);
     expect(estimateCost("babbage-002", u, pricing)).toBeCloseTo(0.8, 6);
   });
@@ -165,9 +166,32 @@ describe("estimateCost", () => {
   test("codex models are priced", () => {
     const pricing = defaultPricing();
     const u = usage1m();
+    const cached = { ...emptyUsage(), cacheRead: 1_000_000 };
     expect(estimateCost("gpt-5.3-codex", u, pricing)).toBeCloseTo(15.75, 6);
+    expect(estimateCost("gpt-5.3-codex", cached, pricing)).toBeCloseTo(0.175, 6);
+    expect(estimateCost("gpt-5.2-codex", u, pricing)).toBeCloseTo(15.75, 6);
     expect(estimateCost("gpt-5.2", u, pricing)).toBeCloseTo(15.75, 6);
-    expect(estimateCost("codex-auto-review", u, pricing)).toBeCloseTo(15.75, 6);
+    expect(estimateCost("gpt-5.1-codex", u, pricing)).toBeCloseTo(11.25, 6);
+    expect(estimateCost("gpt-5.1-codex-max", u, pricing)).toBeCloseTo(11.25, 6);
+    expect(estimateCost("gpt-5.1-codex-mini", u, pricing)).toBeCloseTo(2.25, 6);
+    expect(estimateCost("gpt-5.1-codex-mini", cached, pricing)).toBeCloseTo(0.025, 6);
+    expect(estimateCost("gpt-5-codex", u, pricing)).toBeCloseTo(11.25, 6);
+    expect(estimateCost("codex-mini-latest", u, pricing)).toBeCloseTo(7.5, 6);
+    expect(estimateCost("codex-mini-latest", cached, pricing)).toBeCloseTo(0.375, 6);
+  });
+
+  test("unpublished Codex aliases are not assigned guessed API prices", () => {
+    const pricing = defaultPricing();
+    const u = usage1m();
+    for (const model of [
+      "codex-auto-review",
+      "gpt-5.3-codex-spark",
+      "gpt-5-codex-mini",
+      "gpt-5.4-cyber",
+    ]) {
+      expect(estimateCost(model, u, pricing)).toBe(0);
+      expect(isPriceable(model)).toBe(false);
+    }
   });
 
   test("openai models without a cached-input discount do not make cache reads free", () => {

--- a/test/cost.test.ts
+++ b/test/cost.test.ts
@@ -158,7 +158,7 @@ describe("estimateCost", () => {
     expect(estimateCost("gpt-3.5-turbo", u, pricing)).toBeCloseTo(2.0, 6);
     expect(estimateCost("gpt-3.5-turbo-1106", u, pricing)).toBeCloseTo(3.0, 6);
     expect(estimateCost("gpt-3.5-turbo-16k-0613", u, pricing)).toBeCloseTo(7.0, 6);
-    expect(estimateCost("gpt-3.5-turbo-0301", u, pricing)).toBeCloseTo(35.0, 6);
+    expect(estimateCost("gpt-3.5-turbo-0301", u, pricing)).toBeCloseTo(3.5, 6);
     expect(estimateCost("davinci-002", u, pricing)).toBeCloseTo(4.0, 6);
     expect(estimateCost("babbage-002", u, pricing)).toBeCloseTo(0.8, 6);
   });

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -24,7 +24,7 @@ function freshPath(): string {
   return join(workDir, `archive-${dbCounter}.db`);
 }
 
-// Inventory of the frozen v14 baseline. Shadow tables
+// Inventory of the frozen v15 baseline. Shadow tables
 // of block_fts are excluded; they are implementation details of FTS5.
 const BASELINE_TABLES = [
   "block",
@@ -299,7 +299,7 @@ describe("openDb", () => {
     migrated.close();
   });
 
-  test("migrates v13 effort values without conflating Codex max and ultra", () => {
+  test("migrates v13 effort values without changing provider labels", () => {
     const path = freshPath();
     const db = new Database(path, { create: true, strict: true });
     db.exec(`
@@ -314,9 +314,10 @@ describe("openDb", () => {
       INSERT INTO session(
         id, tool, source_session_id, reasoning_effort, reasoning_effort_checked
       ) VALUES
-        (1, 'claude_code', 'claude-ultra', 'max', 1),
+        (1, 'claude_code', 'claude-max', 'max', 1),
         (2, 'codex', 'codex-max', 'max', 1),
-        (3, 'codex', 'codex-mixed', 'mixed', 1);
+        (3, 'codex', 'codex-ultra', 'ultra', 1),
+        (4, 'codex', 'codex-mixed', 'mixed', 1);
     `);
     const insert = db.prepare(
       "INSERT INTO schema_migrations(version, applied_at) VALUES (?1, datetime('now'))",
@@ -337,8 +338,8 @@ describe("openDb", () => {
     ).toEqual([
       {
         tool: "claude_code",
-        reasoning_effort: "ultra",
-        reasoning_effort_levels: '["ultra"]',
+        reasoning_effort: "max",
+        reasoning_effort_levels: '["max"]',
         reasoning_effort_checked: 1,
       },
       {
@@ -349,9 +350,82 @@ describe("openDb", () => {
       },
       {
         tool: "codex",
+        reasoning_effort: "ultra",
+        reasoning_effort_levels: '["ultra"]',
+        reasoning_effort_checked: 1,
+      },
+      {
+        tool: "codex",
         reasoning_effort: "mixed",
         reasoning_effort_levels: "[]",
         reasoning_effort_checked: 0,
+      },
+    ]);
+    migrated.close();
+  });
+
+  test("repairs the v14 Claude max-to-ultra alias without changing Codex", () => {
+    const path = freshPath();
+    const db = new Database(path, { create: true, strict: true });
+    db.exec(`
+      CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
+      CREATE TABLE session(
+        id INTEGER PRIMARY KEY,
+        tool TEXT NOT NULL,
+        source_session_id TEXT NOT NULL,
+        reasoning_effort TEXT,
+        reasoning_effort_levels TEXT NOT NULL DEFAULT '[]',
+        reasoning_effort_checked INTEGER NOT NULL DEFAULT 0
+      );
+      INSERT INTO session(
+        id, tool, source_session_id, reasoning_effort,
+        reasoning_effort_levels, reasoning_effort_checked
+      ) VALUES
+        (1, 'claude_code', 'claude-max', 'ultra', '["ultra"]', 1),
+        (2, 'claude_code', 'claude-mixed', 'mixed', '["high","ultra"]', 1),
+        (3, 'codex', 'codex-max', 'max', '["max"]', 1),
+        (4, 'codex', 'codex-ultra', 'ultra', '["ultra"]', 1);
+    `);
+    const insert = db.prepare(
+      "INSERT INTO schema_migrations(version, applied_at) VALUES (?1, datetime('now'))",
+    );
+    for (let version = 1; version <= 14; version += 1) {
+      insert.run(version);
+    }
+    db.close();
+
+    const migrated = openDb(path);
+    expect(
+      migrated
+        .query(
+          `SELECT tool, reasoning_effort, reasoning_effort_levels, reasoning_effort_checked
+           FROM session ORDER BY id`,
+        )
+        .all(),
+    ).toEqual([
+      {
+        tool: "claude_code",
+        reasoning_effort: "max",
+        reasoning_effort_levels: '["max"]',
+        reasoning_effort_checked: 1,
+      },
+      {
+        tool: "claude_code",
+        reasoning_effort: "mixed",
+        reasoning_effort_levels: '["high","max"]',
+        reasoning_effort_checked: 1,
+      },
+      {
+        tool: "codex",
+        reasoning_effort: "max",
+        reasoning_effort_levels: '["max"]',
+        reasoning_effort_checked: 1,
+      },
+      {
+        tool: "codex",
+        reasoning_effort: "ultra",
+        reasoning_effort_levels: '["ultra"]',
+        reasoning_effort_checked: 1,
       },
     ]);
     migrated.close();

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -367,15 +367,15 @@ describe("upsertSession", () => {
         )
         .get(sessionId),
     ).toEqual({
-      reasoning_effort: "ultra",
-      reasoning_effort_levels: '["ultra"]',
+      reasoning_effort: "max",
+      reasoning_effort_levels: '["max"]',
       reasoning_effort_checked: 1,
       total_cache_creation_tokens: 100,
       total_cache_creation_1h_tokens: 60,
     });
     expect(getSession(db, sessionId)?.summary).toMatchObject({
-      reasoning_effort: "ultra",
-      reasoning_effort_levels: ["ultra"],
+      reasoning_effort: "max",
+      reasoning_effort_levels: ["max"],
     });
     db.close();
   });
@@ -536,6 +536,39 @@ describe("sync", () => {
     ).toEqual({
       reasoning_effort: "xhigh",
       reasoning_effort_levels: '["xhigh"]',
+      reasoning_effort_checked: 1,
+    });
+    db.close();
+  });
+
+  test("backfills numeric Claude Agent SDK effort budgets", () => {
+    const dir = freshCase();
+    const config: IngestConfig = {
+      claudeDir: join(dir, "claude"),
+      codexDir: join(dir, "codex"),
+    };
+    const sourcePath = join(config.claudeDir, "project", "numeric-effort.jsonl");
+    write(
+      sourcePath,
+      '{"type":"assistant","effort":16384,"message":{"role":"assistant","content":[]}}\n',
+    );
+    const db = openFreshDb(dir);
+    expect(sync(db, config)).toMatchObject({ ingested: 1, skipped: 0 });
+    db.exec(
+      "UPDATE session SET reasoning_effort = NULL, reasoning_effort_levels = '[]', reasoning_effort_checked = 0",
+    );
+
+    expect(sync(db, config)).toMatchObject({ ingested: 0, skipped: 1 });
+    expect(
+      db
+        .query(
+          `SELECT reasoning_effort, reasoning_effort_levels, reasoning_effort_checked
+           FROM session`,
+        )
+        .get(),
+    ).toEqual({
+      reasoning_effort: "16384",
+      reasoning_effort_levels: '["16384"]',
       reasoning_effort_checked: 1,
     });
     db.close();

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -6,6 +6,7 @@ import {
   REASONING_SOURCES,
   ROLES,
   reasoningEffortLevels,
+  recordedReasoningEffort,
   summarizeReasoningEfforts,
   TOOL_KINDS,
   TOOLS,
@@ -41,13 +42,26 @@ describe("model wire strings", () => {
     });
   });
 
+  test("provider effort accepts named levels and numeric token budgets", () => {
+    expect(recordedReasoningEffort("xhigh")).toBe("xhigh");
+    expect(recordedReasoningEffort(16_384)).toBe("16384");
+    expect(recordedReasoningEffort(null)).toBeNull();
+    expect(recordedReasoningEffort(false)).toBeNull();
+    expect(recordedReasoningEffort(Number.NaN)).toBeNull();
+  });
+
   test("reasoning effort is normalized and marks mixed sessions", () => {
     expect(summarizeReasoningEfforts([])).toBeNull();
     expect(summarizeReasoningEfforts([" XHIGH ", "xhigh"])).toBe("xhigh");
     expect(summarizeReasoningEfforts(["high", "max"])).toBe("mixed");
-    expect(normalizeReasoningEffort("claude_code", " MAX ")).toBe("ultra");
-    expect(normalizeReasoningEffort("codex", " MAX ")).toBe("max");
-    expect(reasoningEffortLevels("claude_code", ["low", "max", "MAX"])).toEqual(["low", "ultra"]);
-    expect(reasoningEffortLevels("codex", ["max", "ultra"])).toEqual(["max", "ultra"]);
+    expect(normalizeReasoningEffort(" MAX ")).toBe("max");
+    expect(normalizeReasoningEffort(" Future-Level ")).toBe("Future-Level");
+    expect(normalizeReasoningEffort("")).toBeNull();
+    expect(reasoningEffortLevels(["low", "max", "MAX"])).toEqual(["low", "max"]);
+    expect(reasoningEffortLevels(["max", "ultra", "Future-Level"])).toEqual([
+      "max",
+      "ultra",
+      "Future-Level",
+    ]);
   });
 });

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -68,11 +68,11 @@ describe("query reads", () => {
     expect(listSessions(db)[0]).toMatchObject({
       id,
       reasoning_effort: "mixed",
-      reasoning_effort_levels: ["high", "ultra"],
+      reasoning_effort_levels: ["high", "max"],
     });
     expect(getSession(db, id)?.summary).toMatchObject({
       reasoning_effort: "mixed",
-      reasoning_effort_levels: ["high", "ultra"],
+      reasoning_effort_levels: ["high", "max"],
     });
 
     db.query("UPDATE session SET reasoning_effort_levels = '' WHERE id = ?").run(id);

--- a/test/ui-effort.test.ts
+++ b/test/ui-effort.test.ts
@@ -1,10 +1,30 @@
 import { describe, expect, test } from "bun:test";
-import { effortTooltip } from "../src/ui/effort.ts";
+import { effortDisplayLabel, effortTooltip } from "../src/ui/effort.ts";
 
 describe("effort tooltip", () => {
+  test("labels every current provider effort plus numeric budgets", () => {
+    for (const effort of ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]) {
+      expect(effortDisplayLabel(effort, true)).toBe(`effort ${effort}`);
+      expect(effortDisplayLabel(effort)).toBe(effort);
+    }
+    expect(effortDisplayLabel("Future-Level", true)).toBe("effort Future-Level");
+    expect(effortDisplayLabel("Future-Level")).toBe("Future-Level");
+    expect(effortDisplayLabel("16384", true)).toBe("effort 16384 tokens");
+    expect(effortDisplayLabel("16384")).toBe("16384 tokens");
+    expect(effortDisplayLabel(" Effort XHIGH ", true)).toBe("effort xhigh");
+    expect(effortDisplayLabel("")).toBeNull();
+    expect(effortDisplayLabel(null)).toBeNull();
+  });
+
   test("explains the unique normalized levels behind a mixed session", () => {
-    expect(effortTooltip(" Mixed ", ["high", " ULTRA ", "high", "mixed", ""])).toBe(
-      "Effort levels used: high, ultra",
+    expect(effortTooltip(" Mixed ", ["high", " ULTRA ", "Future-Level", "high", "mixed", ""])).toBe(
+      "Effort levels used: high, ultra, Future-Level",
+    );
+  });
+
+  test("labels numeric budgets in mixed-session explanations", () => {
+    expect(effortTooltip("mixed", ["high", "16384"])).toBe(
+      "Effort levels used: high, 16384 tokens",
     );
   });
 

--- a/test/ui-effort.test.ts
+++ b/test/ui-effort.test.ts
@@ -11,7 +11,8 @@ describe("effort tooltip", () => {
     expect(effortDisplayLabel("Future-Level")).toBe("Future-Level");
     expect(effortDisplayLabel("16384", true)).toBe("effort 16384 tokens");
     expect(effortDisplayLabel("16384")).toBe("16384 tokens");
-    expect(effortDisplayLabel(" Effort XHIGH ", true)).toBe("effort xhigh");
+    expect(effortDisplayLabel(" XHIGH ", true)).toBe("effort xhigh");
+    expect(effortDisplayLabel("Effort Future-Level", true)).toBe("effort Effort Future-Level");
     expect(effortDisplayLabel("")).toBeNull();
     expect(effortDisplayLabel(null)).toBeNull();
   });

--- a/test/ui-effort.test.ts
+++ b/test/ui-effort.test.ts
@@ -13,9 +13,9 @@ describe("effort tooltip", () => {
     expect(effortDisplayLabel("16384")).toBe("16384 tokens");
     expect(effortDisplayLabel(" XHIGH ", true)).toBe("effort xhigh");
     expect(effortDisplayLabel("Effort Future-Level", true)).toBe("effort Effort Future-Level");
-    expect(effortDisplayLabel("")).toBe("not recorded");
-    expect(effortDisplayLabel(null)).toBe("not recorded");
-    expect(effortDisplayLabel(null, true)).toBe("effort not recorded");
+    expect(effortDisplayLabel("")).toBe("-");
+    expect(effortDisplayLabel(null)).toBe("-");
+    expect(effortDisplayLabel(null, true)).toBe("-");
   });
 
   test("explains the unique normalized levels behind a mixed session", () => {

--- a/test/ui-effort.test.ts
+++ b/test/ui-effort.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { effortDisplayLabel, effortTooltip } from "../src/ui/effort.ts";
+import { effortDisplayLabel, effortTooltip, UNRECORDED_EFFORT_TOOLTIP } from "../src/ui/effort.ts";
 
 describe("effort tooltip", () => {
   test("labels every current provider effort plus numeric budgets", () => {
@@ -13,8 +13,9 @@ describe("effort tooltip", () => {
     expect(effortDisplayLabel("16384")).toBe("16384 tokens");
     expect(effortDisplayLabel(" XHIGH ", true)).toBe("effort xhigh");
     expect(effortDisplayLabel("Effort Future-Level", true)).toBe("effort Effort Future-Level");
-    expect(effortDisplayLabel("")).toBeNull();
-    expect(effortDisplayLabel(null)).toBeNull();
+    expect(effortDisplayLabel("")).toBe("not recorded");
+    expect(effortDisplayLabel(null)).toBe("not recorded");
+    expect(effortDisplayLabel(null, true)).toBe("effort not recorded");
   });
 
   test("explains the unique normalized levels behind a mixed session", () => {
@@ -34,6 +35,10 @@ describe("effort tooltip", () => {
     expect(effortTooltip("mixed", null)).toBeUndefined();
     expect(effortTooltip("mixed", undefined)).toBeUndefined();
     expect(effortTooltip("ultra", ["ultra"])).toBeUndefined();
-    expect(effortTooltip(null, ["high", "ultra"])).toBeUndefined();
+  });
+
+  test("explains when the source did not record effort", () => {
+    expect(effortTooltip(null, ["high", "ultra"])).toBe(UNRECORDED_EFFORT_TOOLTIP);
+    expect(effortTooltip("", [])).toBe(UNRECORDED_EFFORT_TOOLTIP);
   });
 });


### PR DESCRIPTION
## Summary

- preserve provider-reported Claude Code and Codex effort values, including the complete current named-level matrices, mixed sessions, future custom Codex labels, and numeric Claude Agent SDK token budgets
- migrate archives to schema v15 and repair only the fabricated Claude `ultra` values created by the prior `max` alias, while leaving genuine Codex `max` and `ultra` values unchanged
- correct and document published coding-agent API prices, including the lower GPT-5.1-Codex-mini rate, and leave unpublished internal aliases such as `codex-auto-review` unpriceable instead of assigning a guessed rate

## Why

Decant mapped Claude Code's recorded `max` value to `ultra`, even though Claude's current effort levels end at `max`; `ultracode` is an orchestration mode that reports `xhigh`. Codex independently supports both `max` and `ultra`, so the alias produced misleading cross-provider labels.

The pricing audit also found that generic prefix matching priced GPT-5.1-Codex-mini as full GPT-5.1 and assigned a speculative GPT-5.2 rate to the hidden `codex-auto-review` slug. The corrected matrix is sourced from current official Anthropic and OpenAI pricing/model documentation and recorded in `docs/pricing.md`.

## Validation

- [x] `just check` passes (404 tests, TypeScript, Biome, and distribution staging/native-binary smoke)
- [x] New behavior has focused parser, ingest, migration, query, UI-label, and pricing tests

## Archive schema

- [ ] no schema change
- [x] schema bump plus migration/backfill is included and documented

Schema v15 adds normalized effort-level detail and repairs v14 Claude rows whose `max` value was previously rewritten as `ultra`. Codex rows are intentionally untouched.

## Research

- [Claude effort and model configuration](https://code.claude.com/docs/en/model-config)
- [Claude API pricing](https://platform.claude.com/docs/en/about-claude/pricing)
- [OpenAI API pricing](https://developers.openai.com/api/docs/pricing)
- [OpenAI Codex pricing](https://developers.openai.com/codex/pricing)
- [OpenAI model catalog](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json)
