### PR TITLE
docs: describe decant as observability, not an archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,16 @@
 [![CI](https://github.com/dosu-ai/decant/actions/workflows/ci.yml/badge.svg)](https://github.com/dosu-ai/decant/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-Extract Claude Code and Codex CLI sessions into a normalized,
-full-text-searchable SQLite archive, then browse, search, analyze, and distill
-that history from a fast local CLI or web UI.
+Your coding agent sessions already contain the answers — where the tokens went,
+how full the context window got, which files an agent churned on, what a run
+actually cost. That history is written to disk and then never read.
 
-decant reads the JSONL logs those tools already write
+decant reads it. It parses the JSONL logs those tools already write
 (`~/.claude/projects/*.jsonl`, `~/.codex/sessions/rollout-*.jsonl`), normalizes
-the formats into one WAL + FTS5 SQLite archive, and keeps everything local. Your
-transcripts never leave your machine.
+both formats into one WAL + FTS5 SQLite archive, and gives you full-text search,
+token economics, context-window occupancy, and phase breakdowns across your
+whole history — from a fast CLI or a local web UI. Your transcripts never leave
+your machine.
 
 ![decant serve UI showing the session archive with synthetic demo data](docs/assets/decant-serve.png)
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,15 @@
 [![CI](https://github.com/dosu-ai/decant/actions/workflows/ci.yml/badge.svg)](https://github.com/dosu-ai/decant/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-Your coding agent sessions already contain the answers — where the tokens went,
-how full the context window got, which files an agent churned on, what a run
-actually cost. That history is written to disk and then never read.
+Your coding agent sessions contain a lot of useful information. What tokens got
+spent on, how full the context window got, which files an agent worked with, and
+what a run cost. decant gives you insight into what's on disk, right now.
 
-decant reads it. It parses the JSONL logs those tools already write
+It reads the JSONL logs Claude Code and Codex already write
 (`~/.claude/projects/*.jsonl`, `~/.codex/sessions/rollout-*.jsonl`), normalizes
 both formats into one WAL + FTS5 SQLite archive, and gives you full-text search,
-token economics, context-window occupancy, and phase breakdowns across your
-whole history — from a fast CLI or a local web UI. Your transcripts never leave
-your machine.
+token economics, context-window occupancy, and phase breakdowns from a CLI or a
+local web UI. Your transcripts never leave your machine.
 
 ![decant serve UI showing the session archive with synthetic demo data](docs/assets/decant-serve.png)
 

--- a/npm/decant/README.md
+++ b/npm/decant/README.md
@@ -1,7 +1,7 @@
 # decant
 
-Local-first observability for Claude Code and Codex sessions — full-text search,
-token economics, context-window analysis, and phase breakdowns.
+Insight into your Claude Code and Codex sessions: token spend, context window,
+files touched, and cost. Local-first, from logs already on disk.
 
 `decant` is the Node-compatible launcher for the compiled `decant` CLI. It
 selects the matching optional platform package, then runs the embedded

--- a/npm/decant/README.md
+++ b/npm/decant/README.md
@@ -1,6 +1,7 @@
 # decant
 
-Local Claude Code and Codex session search, analytics, and workflow distillation.
+Local-first observability for Claude Code and Codex sessions — full-text search,
+token economics, context-window analysis, and phase breakdowns.
 
 `decant` is the Node-compatible launcher for the compiled `decant` CLI. It
 selects the matching optional platform package, then runs the embedded

--- a/npm/decant/README.md
+++ b/npm/decant/README.md
@@ -1,7 +1,7 @@
 # decant
 
-Insight into your Claude Code and Codex sessions: token spend, context window,
-files touched, and cost. Local-first, from logs already on disk.
+Local-first analysis of Claude Code and Codex sessions: token spend, context
+windows, files touched, and cost.
 
 `decant` is the Node-compatible launcher for the compiled `decant` CLI. It
 selects the matching optional platform package, then runs the embedded

--- a/npm/decant/package.json
+++ b/npm/decant/package.json
@@ -1,7 +1,7 @@
 {
   "name": "decant",
   "version": "0.0.0",
-  "description": "Local-first observability for Claude Code and Codex sessions — full-text search, token economics, context-window analysis, and phase breakdowns.",
+  "description": "Insight into your Claude Code and Codex sessions: token spend, context window, files touched, and cost. Local-first observability from logs already on disk.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/npm/decant/package.json
+++ b/npm/decant/package.json
@@ -1,7 +1,7 @@
 {
   "name": "decant",
   "version": "0.0.0",
-  "description": "Extract Claude Code and Codex CLI sessions into a normalized, full-text-searchable local SQLite archive.",
+  "description": "Local-first observability for Claude Code and Codex sessions — full-text search, token economics, context-window analysis, and phase breakdowns.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/npm/decant/package.json
+++ b/npm/decant/package.json
@@ -1,7 +1,7 @@
 {
   "name": "decant",
   "version": "0.0.0",
-  "description": "Insight into your Claude Code and Codex sessions: token spend, context window, files touched, and cost. Local-first observability from logs already on disk.",
+  "description": "Local-first analysis of Claude Code and Codex sessions: token spend, context windows, files touched, and cost.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@dosu/decant",
   "version": "0.0.0",
   "private": true,
-  "description": "Extract Claude Code and Codex CLI sessions into a normalized, full-text-searchable local SQLite archive.",
+  "description": "Local-first observability for Claude Code and Codex sessions — full-text search, token economics, context-window analysis, and phase breakdowns.",
   "license": "Apache-2.0",
   "repository": "https://github.com/dosu-ai/decant",
   "packageManager": "bun@1.3.14",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@dosu/decant",
   "version": "0.0.0",
   "private": true,
-  "description": "Insight into your Claude Code and Codex sessions: token spend, context window, files touched, and cost. Local-first observability from logs already on disk.",
+  "description": "Local-first analysis of Claude Code and Codex sessions: token spend, context windows, files touched, and cost.",
   "license": "Apache-2.0",
   "repository": "https://github.com/dosu-ai/decant",
   "packageManager": "bun@1.3.14",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@dosu/decant",
   "version": "0.0.0",
   "private": true,
-  "description": "Local-first observability for Claude Code and Codex sessions — full-text search, token economics, context-window analysis, and phase breakdowns.",
+  "description": "Insight into your Claude Code and Codex sessions: token spend, context window, files touched, and cost. Local-first observability from logs already on disk.",
   "license": "Apache-2.0",
   "repository": "https://github.com/dosu-ai/decant",
   "packageManager": "bun@1.3.14",

--- a/packaging/homebrew/decant.rb.template
+++ b/packaging/homebrew/decant.rb.template
@@ -13,7 +13,7 @@
 ##   __SHA256_LINUX_ARM64__  sha256 of decant-linux-arm64.tar.gz  (from SHA256SUMS)
 ##   __SHA256_LINUX_X64__    sha256 of decant-linux-x64.tar.gz    (from SHA256SUMS)
 class Decant < Formula
-  desc "Local-first observability for Claude Code and Codex CLI sessions"
+  desc "Insight into Claude Code and Codex sessions from logs already on disk"
   homepage "https://github.com/dosu-ai/decant"
   version "__VERSION__"
   license "Apache-2.0"

--- a/packaging/homebrew/decant.rb.template
+++ b/packaging/homebrew/decant.rb.template
@@ -13,7 +13,7 @@
 ##   __SHA256_LINUX_ARM64__  sha256 of decant-linux-arm64.tar.gz  (from SHA256SUMS)
 ##   __SHA256_LINUX_X64__    sha256 of decant-linux-x64.tar.gz    (from SHA256SUMS)
 class Decant < Formula
-  desc "Insight into Claude Code and Codex sessions from logs already on disk"
+  desc "Analyze Claude Code and Codex sessions: tokens, context windows, and cost"
   homepage "https://github.com/dosu-ai/decant"
   version "__VERSION__"
   license "Apache-2.0"

--- a/packaging/homebrew/decant.rb.template
+++ b/packaging/homebrew/decant.rb.template
@@ -13,7 +13,7 @@
 ##   __SHA256_LINUX_ARM64__  sha256 of decant-linux-arm64.tar.gz  (from SHA256SUMS)
 ##   __SHA256_LINUX_X64__    sha256 of decant-linux-x64.tar.gz    (from SHA256SUMS)
 class Decant < Formula
-  desc "Extract Claude Code and Codex CLI sessions into a searchable SQLite archive"
+  desc "Local-first observability for Claude Code and Codex CLI sessions"
   homepage "https://github.com/dosu-ai/decant"
   version "__VERSION__"
   license "Apache-2.0"


### PR DESCRIPTION
## Summary

Replaces "archive" as decant's self-description everywhere a stranger meets the project first.

Before, all four entry points led with the same string — *"Extract Claude Code and Codex CLI sessions into a normalized, full-text-searchable local SQLite archive"*:

- the GitHub repo blurb
- `package.json` and `npm/decant/package.json` (**what renders on npmjs.com**)
- the Homebrew formula `desc`
- the README's opening line

"Archive" names the mechanism, not the value.

## What the category actually calls itself

Researched comparable tools rather than guessing:

| Tool | Self-description |
|---|---|
| `iso-trace` | "Local **observability** for AI coding agent transcripts" |
| `claude-hindsight` | "**observability** tool… transforms opaque AI coding sessions into crystal-clear insights" |
| Agent Observatory | "designed for local **observability**, not control" |
| `vaportrail` | "local-first **flight recorder**… their history is write-only" |
| AgentLogs | "every session is a **black box**" |

Nothing in the space calls itself an archive. "Observability" is the settled term.

## Why the differentiators are in the description

`agentsview` is a near positional twin — local coding-agent session viewer for Claude and Codex, SQLite, FTS5, analytics dashboard, local web UI. So "searchable session store" doesn't distinguish decant from what already ships.

What does: **token economics computed at ingest**, **context-window occupancy**, and **phase breakdowns**. None of the tools above do those. The new descriptions lead with them.

## Scope

**"Archive" stays** everywhere it means the SQLite database itself — `DECANT_DB`, the WAL + FTS5 store, the exposed port, the migration docs. There it's the correct noun. Only the product's self-description changed.

The Homebrew `desc` is 64 chars (limit 80) and doesn't begin with the formula name, so `brew audit --strict` stays happy. Rendered formula passes `ruby -c`.

## Validation

- `just check` — 405 tests, `tsc --noEmit`, `biome check .` (99 files), distribution smoke
- Both modified `package.json` files re-validated as parseable JSON
- No test asserted the old description string
