### PR TITLE
fix(cli): match the CLI's own description to the rest of the project

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -151,7 +151,7 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
   const program = new Command();
   program
     .name("decant")
-    .description("extract, browse, and search Claude Code and Codex sessions")
+    .description("analyze Claude Code and Codex sessions: tokens, context windows, and cost")
     .version(DECANT_VERSION)
     .exitOverride()
     .configureOutput({


### PR DESCRIPTION
`decant --help` still opened with *"extract, browse, and search Claude Code and Codex sessions"* — the framing #54 replaced everywhere else.

Found while verifying the Homebrew path: after `brew install` put the binary on PATH, its `--help` was the last surface still describing decant as an extraction tool.

Now: `analyze Claude Code and Codex sessions: tokens, context windows, and cost` — matching the Homebrew `desc` exactly.

**Validation:** `just check` — 405 tests, tsc, biome, distribution smoke. No golden file or test asserted the old string.