### PR TITLE
fix: address OpenSSF Scorecard findings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM oven/bun:1.3.14-slim AS build
+FROM oven/bun:1.3.14-slim@sha256:d56a2534ffd262e92c12fd3249d3924d296d97086da773f821d7d0477435ea04 AS build
 
 WORKDIR /app
 
@@ -21,7 +21,7 @@ RUN case "${TARGETPLATFORM}" in \
     bun run scripts/build-binaries.ts --target "${DECANT_TARGET}" --out-dir /tmp/decant-bin --version "${DECANT_VERSION}"; \
     cp "/tmp/decant-bin/${DECANT_TARGET}/decant" /usr/local/bin/decant
 
-FROM debian:bookworm-slim AS runtime
+FROM debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818 AS runtime
 
 RUN groupadd --system decant \
     && useradd --system --gid decant --home-dir /var/lib/decant --create-home decant \

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,8 +10,9 @@ latest `main`. Until a stable release line exists, verify issues against current
 
 Do not open a public issue for security vulnerabilities.
 
-Report privately through GitHub's private vulnerability reporting flow from the
-repository's **Security** tab. Include:
+Report privately through
+[GitHub's private vulnerability reporting flow](https://github.com/dosu-ai/decant/security/advisories/new),
+reachable from the repository's **Security** tab. Include:
 
 - a description of the issue and impact,
 - steps to reproduce or a proof of concept,


### PR DESCRIPTION
Scorecard activated on the public flip and reported ten findings. Sorting the real from the noise.

## Fixed

**Both Docker base images are now digest-pinned.** `oven/bun:1.3.14-slim` and `debian:bookworm-slim` were floating tags — an image built today and one built next week could differ with no change to this repo. The `ci.yml` drift guard already permitted a digest (its regex carries an optional `(@sha256:...)` group), so nothing else needed changing. Verified the pinned image builds and reports its stamped version.

**SECURITY.md now links to the advisory form.** Scorecard scored it 4/10 with *"no linked content found"* — the file described the reporting flow but made a reporter go hunting for it.

## Deliberately not fixed

**`PinnedDependenciesID` at `release.yml:583` is a false positive.** That `npm install` takes local `.tgz` paths built earlier in the same job, not registry input.

**`FuzzingID` and `SASTID`** want tools this project doesn't use. zizmor and actionlint cover the workflow surface Scorecard can't see.

**`CodeReviewID` scored 1/10 — "Found 3/22 approved changesets" — and that's accurate.** Nearly every merge here has been an admin bypass, because the sole code owner can't approve their own PRs. That's a real weakness in how this repo is run, and the fix is a second reviewer, not a config change.

**`BranchProtectionID` scored 5/10.** The `main` ruleset (signed commits, linear history, 3 required checks, squash-only) landed after this scan. Worth re-checking on the next weekly run rather than assuming.

## Validation

- `docker build` with the pinned digests succeeds and `--version` reports the stamped value
- `ci.yml` drift guard verified against the new Dockerfile line — still matches
- `just check` — 405 tests, tsc, biome, distribution smoke