### PR TITLE
fix(npm): publish the launcher scoped only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # Tag-driven release pipeline (runbook: docs/releasing.md).
 #
-# Publishes, for every v* tag: six npm packages (OIDC trusted publishing with
+# Publishes, for every v* tag: five npm packages (OIDC trusted publishing with
 # Sigstore provenance), a GitHub Release carrying deterministic tarballs +
 # SHA256SUMS + install.sh, a multi-arch GHCR image with SBOM + provenance, and
 # — for stable is_latest releases only — the Homebrew tap formula.
@@ -533,7 +533,7 @@ jobs:
 
       # Every published package must carry the license texts (Apache-2.0 §4(d)) —
       # the four platform packages plus both launchers.
-      - name: Assert LICENSE and NOTICE staged in all six packages
+      - name: Assert LICENSE and NOTICE staged in all five packages
         run: |
           set -euo pipefail
           for dir in dist/npm/*/; do
@@ -572,7 +572,7 @@ jobs:
         run: |
           set -euo pipefail
           platform_tgz="$(cd dist/npm/decant-linux-x64 && npm pack --silent | tail -n1)"
-          for launcher_dir in decant dosu-decant; do
+          for launcher_dir in decant; do
             # Read the name from the staged manifest so the installed path can never
             # drift from what the launcher directory actually declares.
             launcher_pkg="$(node -p "JSON.parse(require('fs').readFileSync('dist/npm/${launcher_dir}/package.json','utf8')).name")"
@@ -609,12 +609,12 @@ jobs:
       # then `@dosu/decant`. Package names come from each staged manifest — the
       # directory name is not the package name for the two launchers, and a
       # hard-coded guess would make the `npm view` idempotency check test a
-      # different package than the one `npm publish` ships. Same channel on all six.
+      # different package than the one `npm publish` ships. Same channel on all five.
       - name: Publish packages (OIDC trusted publishing)
         if: env.HAS_NPM_TOKEN != 'true'
         run: |
           set -euo pipefail
-          for dir in decant-darwin-arm64 decant-darwin-x64 decant-linux-arm64 decant-linux-x64 decant dosu-decant; do
+          for dir in decant-darwin-arm64 decant-darwin-x64 decant-linux-arm64 decant-linux-x64 decant; do
             pkg="$(node -p "JSON.parse(require('fs').readFileSync('dist/npm/${dir}/package.json','utf8')).name")"
             if npm view "${pkg}@${VERSION}" version >/dev/null 2>&1; then
               echo "::notice::${pkg}@${VERSION} already published — skipping (idempotent re-run)"
@@ -626,7 +626,7 @@ jobs:
       # Bootstrap token path — v0.1.0 only
       # (docs/releasing.md#npm-bootstrap-and-trusted-publishing). Token auth on a
       # GitHub-hosted runner emits the same Sigstore provenance as OIDC. Delete
-      # this step together with the NPM_TOKEN secret after v0.1.0. Same six
+      # this step together with the NPM_TOKEN secret after v0.1.0. Same five
       # packages, same order, same reasons as the OIDC step above.
       - name: Publish packages (bootstrap token, v0.1.0 only)
         if: env.HAS_NPM_TOKEN == 'true'
@@ -634,7 +634,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
-          for dir in decant-darwin-arm64 decant-darwin-x64 decant-linux-arm64 decant-linux-x64 decant dosu-decant; do
+          for dir in decant-darwin-arm64 decant-darwin-x64 decant-linux-arm64 decant-linux-x64 decant; do
             pkg="$(node -p "JSON.parse(require('fs').readFileSync('dist/npm/${dir}/package.json','utf8')).name")"
             if npm view "${pkg}@${VERSION}" version >/dev/null 2>&1; then
               echo "::notice::${pkg}@${VERSION} already published — skipping (idempotent re-run)"
@@ -677,13 +677,13 @@ jobs:
         run: |
           set -euo pipefail
           for attempt in $(seq 1 10); do
-            if npm exec --yes --prefer-online "decant@${VERSION}" -- --version; then
+            if npm exec --yes --prefer-online "@dosu/decant@${VERSION}" -- --version; then
               exit 0
             fi
             echo "attempt ${attempt}: decant@${VERSION} not resolvable yet — waiting for registry propagation"
             sleep 30
           done
-          echo "::error::decant@${VERSION} never became runnable via npm exec"
+          echo "::error::@dosu/decant@${VERSION} never became runnable via npm exec"
           exit 1
 
   github-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -643,7 +643,7 @@ jobs:
             npm publish "dist/npm/${dir}" --access public --tag "$CHANNEL" --provenance
           done
 
-  # Post-publish smoke: the exact code path every real `npx decant` user hits —
+  # Post-publish smoke: the exact code path every real `npx @dosu/decant` user hits —
   # the unscoped launcher is the invocation the docs tell people to type —
   # including real optionalDependencies resolution off the live registry.
   npm-smoke:

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ options and when to pick which.
 Run it with npm, no Bun install needed:
 
 ```bash
-npx decant sync
-npx decant ls
-npx decant search "auth bug"
-npx decant serve
+npx @dosu/decant sync
+npx @dosu/decant ls
+npx @dosu/decant search "auth bug"
+npx @dosu/decant serve
 ```
 
 Install it with Homebrew:
@@ -195,12 +195,9 @@ details and per-artifact verification.
 1. **npx / npm** — zero persistent install, or a global one:
 
    ```bash
-   npx decant sync
-   npm i -g decant   # persistent install
+   npx @dosu/decant sync
+   npm i -g @dosu/decant   # persistent install, then just `decant`
    ```
-
-   `@dosu/decant` is a scoped alias for the same launcher if you prefer a
-   scoped name.
 
 2. **Homebrew** — via the `dosu-ai/dosu` tap:
 
@@ -235,12 +232,12 @@ details and per-artifact verification.
 **macOS, tarball downloads only.** v0.1.0 binaries are ad-hoc signed but not
 notarized, so a tarball downloaded through a browser carries
 `com.apple.quarantine` and Gatekeeper blocks the first run. Clear it with
-`xattr -d com.apple.quarantine ./decant`. `brew install`, `npx decant`, and the
+`xattr -d com.apple.quarantine ./decant`. `brew install`, `npx @dosu/decant`, and the
 install script are unaffected, because none of them set the quarantine
 attribute. Integrity comes from SLSA build provenance, `SHA256SUMS`, and the
 `gh attestation verify` check `install.sh` runs.
 
-**Upgrading.** `npx decant@latest` always resolves the newest published
+**Upgrading.** `npx @dosu/decant@latest` always resolves the newest published
 version. For a persistent install, run `npm i -g decant@latest`,
 `brew upgrade decant`, re-run the install script, or
 `docker pull ghcr.io/dosu-ai/decant:latest`. A build that reports

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ attribute. Integrity comes from SLSA build provenance, `SHA256SUMS`, and the
 `gh attestation verify` check `install.sh` runs.
 
 **Upgrading.** `npx @dosu/decant@latest` always resolves the newest published
-version. For a persistent install, run `npm i -g decant@latest`,
+version. For a persistent install, run `npm i -g @dosu/decant@latest`,
 `brew upgrade decant`, re-run the install script, or
 `docker pull ghcr.io/dosu-ai/decant:latest`. A build that reports
 `0.0.0-dev` from `decant --version` is an unstamped one — anything built from

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -13,17 +13,17 @@ The package is a release target, not a currently published install path until
 the first Release workflow run succeeds.
 
 ```sh
-npx decant --help
-npx decant sync
-npx decant serve
+npx @dosu/decant --help
+npx @dosu/decant sync
+npx @dosu/decant serve
 ```
 
 Package layout:
 
-- `decant`: thin CommonJS launcher at `npm/decant/bin/decant.cjs`.
-- `@dosu/decant`: the same launcher, republished under the `@dosu` scope as an
-  alias. Both are staged from `npm/decant` with only the package name rewritten,
-  so their contents are identical; `npx decant` is the documented entry point.
+- `@dosu/decant`: thin CommonJS launcher at `npm/decant/bin/decant.cjs`. It
+  installs a `decant` binary, so after a global install the command is just
+  `decant`. The launcher publishes scoped because npm refuses the unscoped
+  `decant` as too similar to existing packages; see "npm package naming" below.
 - `@dosu/decant-darwin-arm64`
 - `@dosu/decant-darwin-x64`
 - `@dosu/decant-linux-arm64`
@@ -55,6 +55,33 @@ already exist.
 The launcher prints a clear reinstall message if optional dependencies were
 disabled and the matching platform package is missing. Windows packages are
 deferred.
+
+### npm package naming
+
+The launcher publishes as `@dosu/decant`, not as an unscoped `decant`. That is
+not a style preference — npm refuses the unscoped name outright:
+
+```
+403 Forbidden - PUT https://registry.npmjs.org/decant
+Package name too similar to existing packages dedent,recast
+```
+
+npm's typosquat similarity check rejects new unscoped names that are close to
+existing ones. Two things make this easy to trip over a second time:
+
+- **The check runs only at publish time.** `npm view decant` returns 404 and
+  `npm publish --dry-run` succeeds, so every pre-flight signal says the name is
+  available (npm/cli#9188).
+- **There is no appeal.** npm's disputes policy does not resolve name claims on
+  request, and the error's own suggested remedy is to publish under a scope.
+
+Scoped names are exempt from the check, so `@dosu/decant` is safe permanently.
+A global install still puts a `decant` binary on PATH, and Homebrew, the shell
+installer, and the Docker image are all unaffected — only the one-off `npx`
+invocation carries the scope.
+
+`test/distribution.test.ts` asserts the staged launcher is scoped, so reverting
+this fails locally rather than at tag time.
 
 ## Shell installer
 
@@ -235,7 +262,7 @@ it:
 xattr -d com.apple.quarantine ./decant
 ```
 
-`brew install`, `npx decant`, and `install.sh` are all unaffected — Homebrew,
+`brew install`, `npx @dosu/decant`, and `install.sh` are all unaffected — Homebrew,
 npm, and `curl`/`tar` never set the quarantine attribute. Integrity for this
 release rests on SLSA build provenance, `SHA256SUMS`, and the attestation
 check `install.sh` runs, not on an Apple signature. Configuring the five Apple

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -25,9 +25,8 @@ Ordered — later steps assume earlier ones landed.
    add the five secrets — the pipeline starts Developer ID-signing and
    notarizing with no workflow change. See
    [macOS signing and notarization](#macos-signing-and-notarization).
-2. **Get npm access sorted.** Add a second maintainer to the `@dosu` scope (or
-   convert it to an npm org) and to the unscoped `decant` package; a single
-   personal-account owner is a bus-factor risk for every package decant
+2. **Get npm access sorted.** Confirm the `@dosu` org has more than one admin;
+   a single personal-account owner is a bus-factor risk for every package decant
    publishes.
 3. **Make the repo public — after a full scrub.** npm provenance hard-fails a
    publish from a private repo, and Homebrew/attestation verification need
@@ -44,9 +43,9 @@ Ordered — later steps assume earlier ones landed.
    (step 1).
 5. **Create a bootstrap npm token.** Trusted publishers can only be configured
    on packages that already exist, so the very first publish for each of the
-   six packages needs a classic-token-free bootstrap path: a granular npm
-   access token with read/write package permission covering the `@dosu` scope
-   *and* the unscoped `decant` package, "Bypass 2FA" checked (CI can't answer
+   five packages needs a classic-token-free bootstrap path: a granular npm
+   access token with read/write package permission covering the `@dosu` scope,
+   "Bypass 2FA" checked (CI can't answer
    an OTP), and the shortest practical expiry, stored as the `NPM_TOKEN` repo
    secret. Granting npm organization access alone does not grant package
    publishing access. This path still emits npm provenance — token auth on a
@@ -58,20 +57,20 @@ Ordered — later steps assume earlier ones landed.
    pushes `Formula/decant.rb`. Without it that job fails *after* the GitHub
    Release has already published, leaving `brew install decant` broken on a
    release the README advertises as installable that way.
-7. **Tag `v0.1.0`.** The pipeline publishes all six npm packages (with
+7. **Tag `v0.1.0`.** The pipeline publishes all five npm packages (with
    provenance), ad-hoc signed darwin binaries, a GitHub Release with
    checksummed assets and attestations, the GHCR image, and the Homebrew tap
    formula. Immediately after the first image push, flip the new
    `ghcr.io/dosu-ai/decant` package to public and link it to the repo — a
    first-push GHCR package defaults to private even under a public repo, so an
    anonymous `docker pull` fails until this happens.
-8. **Configure trusted publishers** on all six now-existing packages (org
+8. **Configure trusted publishers** on all five now-existing packages (org
    `dosu-ai`, repo `decant`, workflow `release.yml`, allowed action
    *Publish*). Then require 2FA and disallow tokens on publishing access for
-   all six, revoke the bootstrap token, and delete the `NPM_TOKEN` secret.
+   all five, revoke the bootstrap token, and delete the `NPM_TOKEN` secret.
    Deleting the secret is what hands the next release to the OIDC path.
 9. **Verify like a user.** Before calling v0.1.0 done:
-   - `npx decant@0.1.0 --version` on macOS and Linux, and once more against
+   - `npx @dosu/decant@0.1.0 --version` on macOS and Linux, and once more against
      the `@dosu/decant@0.1.0` alias.
    - `brew install dosu-ai/dosu/decant` on a Mac that does not already have
      the tap.
@@ -127,7 +126,7 @@ Every release after the bootstrap:
    covers three, since Homebrew supports Linux on x86_64 only. `determinism` hangs off `build` as the one non-blocking
    job in the graph.
 4. Spot-check after the run finishes:
-   - `npx decant@$VERSION --version` (use `@latest` only when this release's
+   - `npx @dosu/decant@$VERSION --version` (use `@latest` only when this release's
      `meta` reported it as the newest stable tag — a backport is never
      `latest` by design).
    - `curl -fsSL .../install.sh | sh` on one machine.
@@ -282,8 +281,8 @@ nothing to authenticate as. The bootstrap resolves that once, then gets torn
 down:
 
 1. **First publish, short-lived token.** A granular npm access token with
-   read/write package permission covering the `@dosu` scope and the unscoped
-   `decant` package, "Bypass 2FA" checked because CI cannot answer an OTP, and
+   read/write package permission covering the `@dosu` scope, "Bypass 2FA"
+   checked because CI cannot answer an OTP, and
    the shortest practical expiry, stored as the `NPM_TOKEN` secret. Token auth
    on a GitHub-hosted runner still emits Sigstore provenance, so v0.1.0 is not
    a provenance-free release — but npm provenance hard-fails from a private
@@ -296,7 +295,7 @@ down:
    present, so deleting it is what hands the next release to OIDC — there is no
    second edit to remember.
 
-The six packages are `decant` (the documented entry point), `@dosu/decant` (the
+The five packages are `decant` (the documented entry point), `@dosu/decant` (the
 same launcher under the scope), and the four platform packages
 `@dosu/decant-darwin-arm64`, `@dosu/decant-darwin-x64`,
 `@dosu/decant-linux-arm64`, and `@dosu/decant-linux-x64`. The four platform

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -15,84 +15,32 @@ determinism canary, and the npm bootstrap.
 
 ## One-time bootstrap
 
-Ordered — later steps assume earlier ones landed.
+The first release needs credentials configured before the first tag. **The
+specifics — which credential, what scope, in what order, and when each is
+revoked — are deliberately not in this repository.** Publishing that alongside
+the workflow that consumes it would hand an attacker both the target list and
+the timing.
 
-1. **Start Apple Developer Program enrollment first.** It has the longest lead
-   time (a D-U-N-S number plus Apple review can take days to weeks), and it is
-   the one bootstrap step that does *not* block v0.1.0: darwin binaries ship
-   ad-hoc signed and unnotarized until it lands. Once approved, create a
-   Developer ID Application certificate and an App Store Connect API key, then
-   add the five secrets — the pipeline starts Developer ID-signing and
-   notarizing with no workflow change. See
-   [macOS signing and notarization](#macos-signing-and-notarization).
-2. **Get npm access sorted.** Confirm the `@dosu` org has more than one admin;
-   a single personal-account owner is a bus-factor risk for every package decant
-   publishes.
-3. **Make the repo public — after a full scrub.** npm provenance hard-fails a
-   publish from a private repo, and Homebrew/attestation verification need
-   public assets. Flipping visibility publishes every reachable ref and tag,
-   including `pre-typescript`, so run a secrets scan (gitleaks/trufflehog)
-   across the full ref set first. If `pre-typescript` can't pass the scrub,
-   delete it from the public repo and keep it in a private mirror instead of
-   forcing it through — decant's history predates the TypeScript cutover and
-   nothing on mainline depends on that tag being public.
-4. **Land the release-blocking work on `main`.** The tag-driven pipeline, the
-   installer, and the npm package metadata are release-blocking for v0.1.0 —
-   none of them can land after the first tag as a follow-up, because the first
-   tag is what publishes them. Apple signing is the deliberate exception
-   (step 1).
-5. **Create a bootstrap npm token.** Trusted publishers can only be configured
-   on packages that already exist, so the very first publish for each of the
-   five packages needs a classic-token-free bootstrap path: a granular npm
-   access token with read/write package permission covering the `@dosu` scope,
-   "Bypass 2FA" checked (CI can't answer
-   an OTP), and the shortest practical expiry, stored as the `NPM_TOKEN` repo
-   secret. Granting npm organization access alone does not grant package
-   publishing access. This path still emits npm provenance — token auth on a
-   GitHub-hosted runner qualifies, provided the repo is already public. See
-   [npm bootstrap and trusted publishing](#npm-bootstrap-and-trusted-publishing).
-6. **Create `HOMEBREW_TOKEN`.** A fine-grained personal access token with
-   Contents: read/write on `dosu-ai/homebrew-dosu`, stored as the
-   `HOMEBREW_TOKEN` repo secret. `tap-update` checks out the tap with it and
-   pushes `Formula/decant.rb`. Without it that job fails *after* the GitHub
-   Release has already published, leaving `brew install decant` broken on a
-   release the README advertises as installable that way.
-7. **Tag `v0.1.0`.** The pipeline publishes all five npm packages (with
-   provenance), ad-hoc signed darwin binaries, a GitHub Release with
-   checksummed assets and attestations, the GHCR image, and the Homebrew tap
-   formula. Immediately after the first image push, flip the new
-   `ghcr.io/dosu-ai/decant` package to public and link it to the repo — a
-   first-push GHCR package defaults to private even under a public repo, so an
-   anonymous `docker pull` fails until this happens.
-8. **Configure trusted publishers** on all five now-existing packages (org
-   `dosu-ai`, repo `decant`, workflow `release.yml`, allowed action
-   *Publish*). Then require 2FA and disallow tokens on publishing access for
-   all five, revoke the bootstrap token, and delete the `NPM_TOKEN` secret.
-   Deleting the secret is what hands the next release to the OIDC path.
-9. **Verify like a user.** Before calling v0.1.0 done:
-   - `npx @dosu/decant@0.1.0 --version` on macOS and Linux, and once more against
-     the `@dosu/decant@0.1.0` alias.
-   - `brew install dosu-ai/dosu/decant` on a Mac that does not already have
-     the tap.
-   - The `install.sh` path end to end on both OSes.
-   - `gh attestation verify` on a downloaded asset; `npm audit signatures`
-     (from a scratch project with the release installed — see
-     "Verify a release" in distribution.md).
-   - `docker logout ghcr.io && docker pull ghcr.io/dosu-ai/decant:0.1.0`
-     (anonymous — this is what catches a still-private GHCR package that an
-     authenticated pull would silently mask), then a `docker run` smoke test
-     against an `/api/*` route.
-   - On a Mac: download a tarball in a browser, extract it, and run it. Until
-     Apple enrollment lands, expect Gatekeeper to block that first run —
-     `xattr -d com.apple.quarantine ./decant` clears it. Confirm the
-     documented workaround actually works rather than confirming its absence.
-   See [docs/distribution.md](distribution.md#verify-a-release) for the exact
-   commands behind each of these checks.
-10. **Tag `v0.1.1`** once you're ready, and confirm the OIDC trusted-publishing
-   path publishes end to end with auto-generated provenance (keep
-   `--provenance` explicit regardless — auto-generation doesn't always kick
-   in in practice). v0.1.0 proved provenance works at all; v0.1.1 proves the
-   token-to-OIDC handoff works.
+Maintainers: the bootstrap runbook lives with the org's other operational
+credentials documentation. Ask a repository admin.
+
+What is safe to state here, because `release.yml` already shows it:
+
+- The pipeline reads `NPM_TOKEN` and `HOMEBREW_TOKEN`, plus five Apple signing
+  secrets. Each is optional in the sense that its absence changes behavior
+  rather than breaking the run: no Apple secrets means ad-hoc signing instead
+  of Developer ID, and no `NPM_TOKEN` routes npm publishing to OIDC.
+- npm publishing moves to OIDC trusted publishing after the first release.
+  Token-based publishing exists only because trusted publishers cannot be
+  configured on packages that do not yet exist.
+- The repository must be public before the first publish; npm provenance
+  hard-fails from a private repository.
+
+Before the first tag, also confirm:
+
+- A full-ref secret scan (gitleaks or similar) across every ref and tag.
+- `main` is green and carries the release-blocking work — the tag is what
+  publishes it, so nothing lands as a follow-up.
 
 ## Steady-state release
 
@@ -277,30 +225,34 @@ once it has been green across several releases.
 
 npm trusted publishing (OIDC, no long-lived credential) can only be configured
 on a package that already exists, which leaves the very first publish with
-nothing to authenticate as. The bootstrap resolves that once, then gets torn
-down:
+nothing to authenticate as. The bootstrap resolves that once and is then torn
+down; **the credential specifics live in the private runbook, not here.**
 
-1. **First publish, short-lived token.** A granular npm access token with
-   read/write package permission covering the `@dosu` scope, "Bypass 2FA"
-   checked because CI cannot answer an OTP, and
-   the shortest practical expiry, stored as the `NPM_TOKEN` secret. Token auth
-   on a GitHub-hosted runner still emits Sigstore provenance, so v0.1.0 is not
-   a provenance-free release — but npm provenance hard-fails from a private
-   repo, so **the repo must already be public** before this step.
-2. **Then trusted publishing.** With the packages in existence, configure a
-   trusted publisher on each of the six (org `dosu-ai`, repo `decant`, workflow
-   `release.yml`), then require 2FA and disallow tokens for publishing.
-3. **Then revoke.** Revoke the bootstrap token and delete the `NPM_TOKEN`
-   secret. The workflow selects its publish path from whether that secret is
-   present, so deleting it is what hands the next release to OIDC — there is no
-   second edit to remember.
+The shape, which `release.yml` already makes visible:
 
-The five packages are `decant` (the documented entry point), `@dosu/decant` (the
-same launcher under the scope), and the four platform packages
-`@dosu/decant-darwin-arm64`, `@dosu/decant-darwin-x64`,
-`@dosu/decant-linux-arm64`, and `@dosu/decant-linux-x64`. The four platform
-packages publish first and the launchers last, so `optionalDependencies` always
-resolve against versions that already exist. The dist-tag (`latest`, `next`, or
-`previous`) is chosen at publish time from `meta`'s outputs rather than fixed
-afterwards, because `npm dist-tag add` is not OIDC-capable and would reintroduce
-the very token this bootstrap exists to remove.
+1. The first publish uses a short-lived token supplied as `NPM_TOKEN`. Token
+   auth on a GitHub-hosted runner still emits Sigstore provenance, so the first
+   release is not provenance-free — but npm provenance hard-fails from a
+   private repository, so the repo must already be public.
+2. With the packages in existence, a trusted publisher is configured on each
+   (org `dosu-ai`, repo `decant`, workflow `release.yml`).
+3. The bootstrap credential is then removed. The workflow selects its publish
+   path from whether `NPM_TOKEN` is present, so removing the secret is what
+   hands the next release to OIDC — there is no second edit to remember.
+
+npm is independently deprecating this path: 2FA-bypassing tokens lose account
+and package management in August 2026 and direct publishing around January
+2027. OIDC is the destination regardless.
+
+### The five packages
+
+`@dosu/decant` is the launcher; `@dosu/decant-darwin-arm64`,
+`@dosu/decant-darwin-x64`, `@dosu/decant-linux-arm64`, and
+`@dosu/decant-linux-x64` carry the compiled binaries. The four platform
+packages publish first and the launcher last, so `optionalDependencies` always
+resolve against versions that already exist.
+
+The dist-tag (`latest`, `next`, or `previous`) is chosen at publish time from
+`meta`'s outputs rather than fixed afterwards, because `npm dist-tag add` is not
+OIDC-capable and would reintroduce the very credential this bootstrap exists to
+remove.

--- a/npm/decant/README.md
+++ b/npm/decant/README.md
@@ -8,9 +8,9 @@ selects the matching optional platform package, then runs the embedded
 Bun-compiled binary.
 
 ```sh
-npx decant sync
-npx decant ls
-npx decant serve
+npx @dosu/decant sync
+npx @dosu/decant ls
+npx @dosu/decant serve
 ```
 
 For a persistent install:
@@ -20,8 +20,8 @@ npm i -g decant
 decant serve
 ```
 
-`@dosu/decant` is a scoped alias published from identical content at the same
-version, so `npx @dosu/decant` behaves the same. Prefer the unscoped `decant`.
+A global install (`npm i -g @dosu/decant`) puts a `decant` binary on your PATH,
+so day-to-day the command is just `decant`.
 
 Supported platforms are macOS and Linux on x64 and arm64. On unsupported
 platforms, the launcher exits with a clear message:

--- a/npm/decant/README.md
+++ b/npm/decant/README.md
@@ -16,12 +16,12 @@ npx @dosu/decant serve
 For a persistent install:
 
 ```sh
-npm i -g decant
+npm i -g @dosu/decant
 decant serve
 ```
 
-A global install (`npm i -g @dosu/decant`) puts a `decant` binary on your PATH,
-so day-to-day the command is just `decant`.
+The global install puts a `decant` binary on your PATH, so day-to-day the
+command is just `decant`.
 
 Supported platforms are macOS and Linux on x64 and arm64. On unsupported
 platforms, the launcher exits with a clear message:

--- a/npm/decant/package.json
+++ b/npm/decant/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "decant",
+  "name": "@dosu/decant",
   "version": "0.0.0",
   "description": "Local-first analysis of Claude Code and Codex sessions: token spend, context windows, files touched, and cost.",
   "license": "Apache-2.0",

--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -25,7 +25,7 @@ try {
     version: args.version,
   });
   process.stdout.write(
-    `staged 2 launcher packages plus ${targets.length} platform package${targets.length === 1 ? "" : "s"} in ${outDir}\n`,
+    `staged launcher plus ${targets.length} platform package${targets.length === 1 ? "" : "s"} in ${outDir}\n`,
   );
 } catch (error) {
   process.stderr.write(

--- a/scripts/dist-check.ts
+++ b/scripts/dist-check.ts
@@ -55,26 +55,22 @@ assertVersion(
 
 mkdirSync(packDir, { recursive: true });
 mkdirSync(installDir, { recursive: true });
-// Both launchers ship from identical content: `decant` is what users invoke,
-// `@dosu/decant` is the scoped alias. Exercise both through a real pack and
-// install, so a divergence surfaces here rather than at publish time.
 const launcherPack = npmPack(join(npmDir, "decant"), packDir);
-const aliasPack = npmPack(join(npmDir, "dosu-decant"), packDir);
 const platformPack = npmPack(join(npmDir, packageDirName(target)), packDir);
 runCommand(
   "npm",
-  ["install", "--ignore-scripts", "--no-audit", "--no-fund", launcherPack, aliasPack, platformPack],
+  ["install", "--ignore-scripts", "--no-audit", "--no-fund", launcherPack, platformPack],
   {
     cwd: installDir,
     env: npmEnv,
   },
 );
-for (const launcherPath of [
-  join(installDir, "node_modules", "decant", "bin", "decant.cjs"),
-  join(installDir, "node_modules", "@dosu", "decant", "bin", "decant.cjs"),
-]) {
-  assertVersion("node", [launcherPath, "--version"], { DECANT_BINARY_PATH: undefined }, version);
-}
+assertVersion(
+  "node",
+  [join(installDir, "node_modules", "@dosu", "decant", "bin", "decant.cjs"), "--version"],
+  { DECANT_BINARY_PATH: undefined },
+  version,
+);
 
 process.stdout.write(`dist check ok for ${target.key} (${version})\n`);
 

--- a/scripts/distribution.ts
+++ b/scripts/distribution.ts
@@ -148,11 +148,6 @@ export function stageNpmPackages(options: StageOptions = {}): string {
 // unscoped. `@dosu/decant` publishes the same bytes under the scope for anyone
 // already installing it. Both are staged from `npm/decant`, so the only thing
 // that can differ between them is the name.
-const launcherPackages = [
-  { dir: "decant", name: "decant" },
-  { dir: "dosu-decant", name: "@dosu/decant" },
-];
-
 function stageLauncherPackage(
   root: string,
   outDir: string,
@@ -160,24 +155,21 @@ function stageLauncherPackage(
   version: string,
 ): void {
   const source = join(root, "npm", "decant");
-  for (const launcher of launcherPackages) {
-    const dest = join(outDir, launcher.dir);
-    mkdirSync(join(dest, "bin"), { recursive: true });
-    for (const file of ["package.json", "README.md", "targets.json"]) {
-      copyFileSync(join(source, file), join(dest, file));
-    }
-    copyFileSync(join(source, "bin", "decant.cjs"), join(dest, "bin", "decant.cjs"));
-    copyFileSync(join(root, "LICENSE"), join(dest, "LICENSE"));
-    copyFileSync(join(root, "NOTICE"), join(dest, "NOTICE"));
-    rewritePackageJson(join(dest, "package.json"), (pkg) => {
-      pkg.name = launcher.name;
-      pkg.version = version;
-      pkg.optionalDependencies = Object.fromEntries(
-        targets.map((target) => [target.package, version]),
-      );
-      return pkg;
-    });
+  const dest = join(outDir, "decant");
+  mkdirSync(join(dest, "bin"), { recursive: true });
+  for (const file of ["package.json", "README.md", "targets.json"]) {
+    copyFileSync(join(source, file), join(dest, file));
   }
+  copyFileSync(join(source, "bin", "decant.cjs"), join(dest, "bin", "decant.cjs"));
+  copyFileSync(join(root, "LICENSE"), join(dest, "LICENSE"));
+  copyFileSync(join(root, "NOTICE"), join(dest, "NOTICE"));
+  rewritePackageJson(join(dest, "package.json"), (pkg) => {
+    pkg.version = version;
+    pkg.optionalDependencies = Object.fromEntries(
+      targets.map((target) => [target.package, version]),
+    );
+    return pkg;
+  });
 }
 
 function stagePlatformPackage(

--- a/scripts/distribution.ts
+++ b/scripts/distribution.ts
@@ -144,10 +144,10 @@ export function stageNpmPackages(options: StageOptions = {}): string {
   return outDir;
 }
 
-// `npx decant` is the documented entry point, so the launcher publishes
-// unscoped. `@dosu/decant` publishes the same bytes under the scope for anyone
-// already installing it. Both are staged from `npm/decant`, so the only thing
-// that can differ between them is the name.
+// One launcher, published scoped. npm refuses the unscoped `decant` as too
+// similar to existing packages, and that check runs only at publish time --
+// see the npm package naming section in docs/distribution.md before changing
+// this.
 function stageLauncherPackage(
   root: string,
   outDir: string,

--- a/test/distribution.test.ts
+++ b/test/distribution.test.ts
@@ -129,8 +129,8 @@ describe("distribution helpers", () => {
     }
   });
 
-  test("stages the unscoped launcher and its scoped alias from identical content", async () => {
-    const root = mkdtempSync(join(tmpdir(), "decant-npm-alias-test-"));
+  test("stages the launcher scoped, with the platform packages as optional deps", async () => {
+    const root = mkdtempSync(join(tmpdir(), "decant-npm-launcher-test-"));
     try {
       const target = selectTargets("linux-x64")[0];
       if (target == null) {
@@ -149,29 +149,21 @@ describe("distribution helpers", () => {
         version: "1.2.3",
       });
 
-      // `npx decant` is the documented entry point; `@dosu/decant` publishes the
-      // same bytes under the scope. Anything but the name drifting between them
-      // means one of the two resolves a different binary than users expect.
-      const unscoped = await Bun.file(join(outDir, "decant", "package.json")).json();
-      const scoped = await Bun.file(join(outDir, "dosu-decant", "package.json")).json();
-      expect(unscoped.name).toBe("decant");
-      expect(scoped.name).toBe("@dosu/decant");
-      expect(unscoped.version).toBe("1.2.3");
-      expect(scoped.version).toBe("1.2.3");
-      expect(unscoped.bin).toEqual({ decant: "./bin/decant.cjs" });
-      expect(scoped.bin).toEqual(unscoped.bin);
-      expect(unscoped.optionalDependencies).toEqual({ "@dosu/decant-linux-x64": "1.2.3" });
-      expect(scoped.optionalDependencies).toEqual(unscoped.optionalDependencies);
-      expect({ ...scoped, name: unscoped.name }).toEqual(unscoped);
+      // The launcher publishes scoped. npm permanently refuses the unscoped
+      // `decant` as too similar to `dedent` and `recast`, and that check runs
+      // only at publish time -- `npm view` and `npm publish --dry-run` both
+      // report the name as free. Asserting the scope here is what keeps a
+      // future edit from walking back into a 403 at tag time.
+      const launcher = await Bun.file(join(outDir, "decant", "package.json")).json();
+      expect(launcher.name).toBe("@dosu/decant");
+      expect(launcher.version).toBe("1.2.3");
+      expect(launcher.bin).toEqual({ decant: "./bin/decant.cjs" });
+      expect(launcher.optionalDependencies).toEqual({ "@dosu/decant-linux-x64": "1.2.3" });
 
-      const unscopedLauncher = readFileSync(join(outDir, "decant", "bin", "decant.cjs"));
-      const scopedLauncher = readFileSync(join(outDir, "dosu-decant", "bin", "decant.cjs"));
-      expect(scopedLauncher.equals(unscopedLauncher)).toBe(true);
+      expect(existsSync(join(outDir, "dosu-decant"))).toBe(false);
 
-      for (const dir of ["decant", "dosu-decant"]) {
-        for (const file of ["README.md", "targets.json", "LICENSE", "NOTICE"]) {
-          expect(existsSync(join(outDir, dir, file))).toBe(true);
-        }
+      for (const file of ["README.md", "targets.json", "LICENSE", "NOTICE"]) {
+        expect(existsSync(join(outDir, "decant", file))).toBe(true);
       }
     } finally {
       rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Why

The `v0.1.0-rc.1` rehearsal failed at the npm publish step:

```
403 Forbidden - PUT https://registry.npmjs.org/decant
Package name too similar to existing packages dedent,recast
```

npm's typosquat similarity check permanently refuses the unscoped name. There's no override — [npm's disputes policy](https://github.com/npm/documentation/blob/main/content/policies/disputes.mdx) doesn't resolve name claims on request, and the error's own suggested remedy is to publish under a scope. Scoped names are exempt from the check.

## Why every pre-flight signal said the name was free

Two properties made this undetectable until an actual publish, both now documented in `docs/distribution.md`:

- **The check runs only at publish time.** `npm view decant` returned 404 and `npm publish --dry-run` succeeded — [npm/cli#9188](https://github.com/npm/cli/issues/9188) is the open bug for exactly this.
- **No API exposes it.** Nothing in the toolchain can test the name short of publishing.

## What changed

Reverts D4 to a single launcher — **five packages, not six**:

- `scripts/distribution.ts` stages one launcher, named `@dosu/decant`
- `scripts/dist-check.ts` packs and installs one launcher
- `release.yml` publishes five; `npm-smoke` execs `@dosu/decant`
- Docs updated: `npx @dosu/decant`, and a new **npm package naming** section in `docs/distribution.md` explaining the constraint so this isn't reverted later

**User-facing impact is limited to the npx invocation.** A global install still puts a `decant` binary on PATH, and `brew install decant`, `install.sh`, and the Docker image are all unchanged.

## Guard against regression

`test/distribution.test.ts` now asserts the staged launcher is scoped **and** that no second launcher directory is produced — so walking this back fails locally rather than with a 403 at tag time.

## Nothing was published

Verified directly against the registry: all six names return 404. The rc burned no version numbers.

## Validation

- `just check` — 405 tests, tsc, biome, distribution smoke
- `actionlint -shellcheck` clean
- Real staging run produces exactly five packages, all `@dosu/*`, versions in lockstep