### PR TITLE
fix(release): detect GHCR visibility instead of pretending to fix it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -812,26 +812,24 @@ jobs:
           push-to-registry: true
 
       # A GHCR package created under an org is PRIVATE on first push, even when
-      # the repository is public — the push succeeds and an anonymous
-      # `docker pull` then 401s. Confirmed on v0.1.0-rc.2. Flipping it here
-      # rather than in a runbook means nobody has to remember it on the release
-      # that first creates the package. Idempotent, and non-blocking: the image
-      # is already pushed by this point, so a failure here should not fail the
-      # release.
-      - name: Ensure the GHCR package is public
+      # the repository is public: the push succeeds and an anonymous
+      # `docker pull` then 401s. There is NO API to change package visibility --
+      # it is web UI only (cli/cli#6820, open since 2023). So this step cannot
+      # fix it; it detects it and says so loudly, rather than leaving a release
+      # that looks green while `docker pull` fails for everyone.
+      - name: Check the image is anonymously pullable
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.meta.outputs.version }}
         run: |
           set -euo pipefail
-          current="$(gh api orgs/dosu-ai/packages/container/decant --jq .visibility 2>/dev/null || echo unknown)"
-          if [ "$current" = "public" ]; then
-            echo "GHCR package already public"
+          code="$(curl -s -o /dev/null -w '%{http_code}' \
+            "https://ghcr.io/v2/dosu-ai/decant/manifests/${VERSION}")"
+          if [ "$code" = "200" ]; then
+            echo "anonymous pull works (HTTP 200) — package is public"
             exit 0
           fi
-          echo "GHCR package visibility is '${current}' — setting public"
-          gh api -X PATCH orgs/dosu-ai/packages/container/decant -f visibility=public
-          gh api orgs/dosu-ai/packages/container/decant --jq '"now: " + .visibility'
+          echo "::warning::ghcr.io/dosu-ai/decant:${VERSION} is not anonymously pullable (HTTP ${code}). A GHCR package is private on first push and there is no API to change it. Set it to public once, by hand: https://github.com/orgs/dosu-ai/packages/container/decant/settings -> Danger Zone -> Change visibility. This is a one-time action; later releases inherit it."
 
   # Render the exact formula that will be tested and pushed. Stable AND is_latest
   # only: a prerelease must not seed the tap and a backport must not downgrade it.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -36,6 +36,18 @@ What is safe to state here, because `release.yml` already shows it:
 - The repository must be public before the first publish; npm provenance
   hard-fails from a private repository.
 
+One manual step has no automated equivalent: a GHCR package created under an
+organization is **private on first push**, even from a public repository. The
+push succeeds and an anonymous `docker pull` then fails with 401. There is no
+API to change package visibility — it is web UI only, and has been since 2023
+(cli/cli#6820). Set it once at
+`https://github.com/orgs/dosu-ai/packages/container/decant/settings` under
+"Change visibility"; later releases inherit it. Note that public is one-way.
+
+The `docker` job checks anonymous pullability after pushing and warns if it
+fails, so a release never looks green while `docker pull` is broken for
+everyone else.
+
 Before the first tag, also confirm:
 
 - A full-ref secret scan (gitleaks or similar) across every ref and tag.


### PR DESCRIPTION
## The step I added in #58 does not work

It called `PATCH /orgs/{org}/packages/container/{name}` with a `visibility` field. **That endpoint does not exist.** Verified against the live package with a `write:packages` token: `GET` on the same path succeeds and returns `visibility: private`, `PATCH` returns Not Found.

There is no API for package visibility at all:

- [cli/cli#6820](https://github.com/cli/cli/issues/6820) — open since 2023: *"Given that there is no API for this we unfortunately cannot do anything about this"*
- [OpenCTI#5985](https://github.com/OpenCTI-Platform/connectors/issues/5985), March 2026 — *"it can only be done manually through the GitHub web UI"*
- GitHub's docs describe only the UI path

The `visibility` field in the packages REST API is a **filter** on list endpoints, not a setter.

I based that step on a PR found in a search without checking the endpoint existed. Because it was `continue-on-error`, it would have failed silently on every release while appearing to handle the problem — worse than not having it at all.

## What it does now

Checks whether the pushed tag is anonymously pullable and warns with the exact settings URL when it isn't. That can't fix it, but it stops a release looking green while `docker pull` is broken for anyone without a token.

Verified the logic against the real package, which is still private:

```
$ curl -so /dev/null -w '%{http_code}' https://ghcr.io/v2/dosu-ai/decant/manifests/0.1.0-rc.2
401   -> emits the warning
```

`docs/releasing.md` now records this as the one genuinely manual step, including that public visibility is one-way.

## Validation

- `just check` — 405 tests, tsc, biome, distribution smoke
- `actionlint -shellcheck` clean