### PR TITLE
fix(ui): transcript accessibility, whole-session counts, and backward paging

### DIFF
--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -85,6 +85,13 @@ excerpt from the first text block for each human/prompt turn, so the sticky
 thread navigation can cover the whole session without loading every rich
 transcript block up front.
 
+Session detail also returns `totals`, holding `reply_count` and
+`tool_call_count` aggregated across the whole session rather than the requested
+page, so a client can report them without loading every message. A reply is an
+assistant message carrying at least one renderable block, matching what the UI
+draws. The nested `subagents` entries carry structure and a summary but no
+messages, so they omit `totals` along with the paging fields.
+
 Session summaries returned by the list and detail routes include
 `reasoning_effort` and `reasoning_effort_levels`. The first is the normalized
 provider effort label, `mixed` when the setting changes between turns, or

--- a/src/query.ts
+++ b/src/query.ts
@@ -169,10 +169,28 @@ export interface MessageView {
   blocks: BlockView[];
 }
 
+/**
+ * Whole-session counts that stay correct when `messages` holds only one page.
+ * A reader counting the returned messages would undercount every paged
+ * transcript, so these are aggregated across the session regardless of window.
+ */
+export interface SessionTotals {
+  /** Assistant messages that have something to render. */
+  reply_count: number;
+  /** `tool_use` blocks across the session. */
+  tool_call_count: number;
+}
+
 export interface SessionDetail {
   summary: SessionSummary;
   messages: MessageView[];
   subagents: SubagentDetail[];
+  /**
+   * Present on a real session read. Absent on the `subagents` stubs, which
+   * carry structure and a summary but no messages, exactly like the paging
+   * fields below.
+   */
+  totals?: SessionTotals;
   message_offset?: number;
   message_limit?: number | null;
   has_more_messages?: boolean;
@@ -363,10 +381,43 @@ export function getSession(
     summary: rootSummary,
     messages,
     subagents: buildSubagentDetails(childrenByParent, id, 0, new Set([id])),
+    totals: getSessionTotals(db, id),
     message_offset: messageLimit != null ? messageOffset : undefined,
     message_limit: messageLimit,
     has_more_messages:
       messageLimit != null ? messageOffset + messages.length < summaryRow.message_count : undefined,
+  };
+}
+
+/**
+ * Session-wide reply and tool-call counts.
+ *
+ * The renderable-block predicate mirrors the reader's own rule: a text or
+ * thinking block counts only when it carries non-whitespace text, and tool
+ * blocks always count. Keeping the two in step matters because these totals are
+ * displayed next to a transcript the reader can also count by hand.
+ */
+function getSessionTotals(db: Database, id: number): SessionTotals {
+  const row = db
+    .query(
+      `SELECT
+         (SELECT COUNT(*) FROM message m
+           WHERE m.session_id = ?1 AND m.role = 'assistant'
+             AND EXISTS (
+               SELECT 1 FROM block b
+               WHERE b.message_id = m.id
+                 AND (b.type IN ('tool_use', 'tool_result')
+                      OR (b.type IN ('text', 'thinking') AND TRIM(COALESCE(b.text, '')) <> ''))
+             )
+         ) AS reply_count,
+         (SELECT COUNT(*) FROM block b
+           WHERE b.session_id = ?1 AND b.type = 'tool_use'
+         ) AS tool_call_count`,
+    )
+    .get(id) as { reply_count: number; tool_call_count: number } | null;
+  return {
+    reply_count: row?.reply_count ?? 0,
+    tool_call_count: row?.tool_call_count ?? 0,
   };
 }
 

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -64,6 +64,7 @@ import { effortDisplayLabel, effortTooltip } from "./effort.ts";
 import { isFramed } from "./frame-guard.ts";
 import { planSessionLoad, shouldShowSessionSkeleton } from "./loading-state.ts";
 import {
+  hasOpenModal,
   isInteractiveTarget,
   nextTranscriptSeq,
   revealTranscriptMessage,
@@ -4498,7 +4499,7 @@ function SessionDetailView({ id }: { id: number }) {
         event.repeat ||
         isInteractiveTarget(event.target) ||
         isInteractiveTarget(document.activeElement) ||
-        document.querySelector("[role='dialog']") != null
+        hasOpenModal(document)
       ) {
         return;
       }
@@ -4525,7 +4526,13 @@ function SessionDetailView({ id }: { id: number }) {
 
   const messages = renderableMessages(detail.messages);
   const toc = outline == null ? threadToc(messages) : threadTocFromOutline(outline);
-  const stats = threadStats(detail.summary, messages, toc, contextWindow?.turn_count);
+  const stats = threadStats(
+    detail.summary,
+    messages,
+    toc,
+    contextWindow?.turn_count,
+    detail.totals,
+  );
   const subagentRuns = countSubagentRuns(detail.subagents);
   const compactionBySeq = new Map(
     (contextWindow?.compactions ?? []).map((compaction) => [compaction.seq, compaction] as const),
@@ -4715,6 +4722,7 @@ type SessionDetailData = {
     blocks: TranscriptBlockData[];
   }[];
   subagents: SubagentDetailData[];
+  totals?: { reply_count: number; tool_call_count: number };
   message_offset?: number;
   message_limit?: number | null;
   has_more_messages?: boolean;
@@ -5902,20 +5910,31 @@ function tocPresentation(text: string): { label: string; icon: IconName } {
   return { label: firstLine(cleanSessionTitle(text) ?? text, 70), icon: "messages" };
 }
 
+/**
+ * Header stats are all whole-session figures. Counting `messages` here would
+ * mix scopes: turns and tokens cover the session, so replies and tool calls
+ * counted from the loaded window would silently shrink the moment a transcript
+ * paginates. `totals` comes from the server aggregated over the session; the
+ * window fallback only applies to a payload that predates it.
+ */
 function threadStats(
   summary: SessionSummary,
   messages: SessionDetailData["messages"],
   toc: ThreadTocItem[],
   fullTurnCount?: number | null,
+  totals?: SessionDetailData["totals"],
 ) {
   return {
     turns: fullTurnCount != null && fullTurnCount > 0 ? fullTurnCount : toc.length,
-    replies: messages.filter((message) => message.role === "assistant").length,
-    toolCalls: messages.reduce(
-      (sum, message) =>
-        sum + message.blocks.filter((block) => block.block_type === "tool_use").length,
-      0,
-    ),
+    replies:
+      totals?.reply_count ?? messages.filter((message) => message.role === "assistant").length,
+    toolCalls:
+      totals?.tool_call_count ??
+      messages.reduce(
+        (sum, message) =>
+          sum + message.blocks.filter((block) => block.block_type === "tool_use").length,
+        0,
+      ),
     tokens: summary.total_input_tokens + summary.total_output_tokens,
   };
 }

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -75,6 +75,8 @@ import {
 import {
   appendTranscriptPage,
   clampTranscriptWindowOffset,
+  prependTranscriptPage,
+  previousTranscriptPageRequest,
   runWithTranscriptRequestSlot,
   transcriptWindowOffset,
 } from "./transcript-pagination.ts";
@@ -4316,6 +4318,108 @@ function SessionDetailView({ id }: { id: number }) {
     return request;
   }, [id]);
 
+  /**
+   * Fill in the gap in front of the loaded window.
+   *
+   * A window only starts partway into a session when the reader arrived by deep
+   * link, outline click, or compaction jump. Without this, everything before
+   * that landing point is unreachable by keyboard: ArrowUp hits the top of the
+   * window and stops, even though earlier messages exist.
+   */
+  const loadPreviousMessages = useCallback((): Promise<boolean> => {
+    const sessionVersion = sessionVersionRef.current;
+    return runWithTranscriptRequestSlot(
+      loadMorePromiseRef,
+      () => sessionVersionRef.current === sessionVersion,
+      false,
+      async () => {
+        const current = detailRef.current;
+        if (current == null || current.summary.id !== id) {
+          return false;
+        }
+        const request = previousTranscriptPageRequest(
+          current.message_offset ?? 0,
+          SESSION_DETAIL_MESSAGE_PAGE_SIZE,
+        );
+        if (request == null) {
+          return false;
+        }
+        setLoadingMore(true);
+        setLoadMoreError(null);
+        return getJson<SessionDetailData>(
+          `/api/sessions/${id}?message_limit=${request.limit}&message_offset=${request.offset}`,
+        )
+          .then((page) => {
+            if (sessionVersionRef.current !== sessionVersion) {
+              return false;
+            }
+            const latest = detailRef.current;
+            if (latest == null || latest.summary.id !== id) {
+              return false;
+            }
+            if (page.messages.length === 0) {
+              return false;
+            }
+            // Inserting above the viewport shifts everything below it down by
+            // the height of the new content. Browser scroll anchoring does not
+            // rescue this: measured in Chromium, a page's worth of prepended
+            // turns moved the anchor by its full height, so the correction below
+            // is doing the work rather than duplicating the browser's.
+            //
+            // Anchor on how far a surviving turn moved rather than on
+            // scrollHeight, which would misread the content-visibility
+            // placeholders: their height stays an estimate until they render.
+            let anchorSeq: number | null = null;
+            let anchorTop: number | null = null;
+            for (const message of latest.messages) {
+              const top = document
+                .getElementById(`message-${message.seq}`)
+                ?.getBoundingClientRect().top;
+              if (top != null) {
+                anchorSeq = message.seq;
+                anchorTop = top;
+                break;
+              }
+            }
+            const nextDetail = {
+              ...latest,
+              messages: prependTranscriptPage(latest.messages, page.messages),
+              message_offset: request.offset,
+            };
+            detailRef.current = nextDetail;
+            setDetail(nextDetail);
+            if (anchorSeq != null && anchorTop != null) {
+              const seq = anchorSeq;
+              const before = anchorTop;
+              requestAnimationFrame(() => {
+                if (sessionVersionRef.current !== sessionVersion) {
+                  return;
+                }
+                const after = document
+                  .getElementById(`message-${seq}`)
+                  ?.getBoundingClientRect().top;
+                if (after != null && after !== before) {
+                  window.scrollBy({ behavior: "auto", top: after - before });
+                }
+              });
+            }
+            return true;
+          })
+          .catch((err: unknown) => {
+            if (sessionVersionRef.current === sessionVersion) {
+              setLoadMoreError(errorMessage(err));
+            }
+            return false;
+          })
+          .finally(() => {
+            if (sessionVersionRef.current === sessionVersion) {
+              setLoadingMore(false);
+            }
+          });
+      },
+    );
+  }, [id]);
+
   const loadMessageWindow = useCallback(
     async (seq: number): Promise<boolean> => {
       const sessionVersion = sessionVersionRef.current;
@@ -4463,8 +4567,10 @@ function SessionDetailView({ id }: { id: number }) {
         activeSeq = nearestTranscriptSeq(sequences);
       }
       let targetSeq = nextTranscriptSeq(sequences, activeSeq, direction);
-      if (targetSeq == null && direction === 1 && current.has_more_messages === true) {
-        await loadMoreMessages();
+      const canLoadForward = direction === 1 && current.has_more_messages === true;
+      const canLoadBackward = direction === -1 && (current.message_offset ?? 0) > 0;
+      if (targetSeq == null && (canLoadForward || canLoadBackward)) {
+        await (canLoadForward ? loadMoreMessages() : loadPreviousMessages());
         if (sessionVersionRef.current !== sessionVersion) {
           return;
         }
@@ -4488,7 +4594,7 @@ function SessionDetailView({ id }: { id: number }) {
         }
       });
     },
-    [id, loadMoreMessages],
+    [id, loadMoreMessages, loadPreviousMessages],
   );
 
   useEffect(() => {
@@ -4640,17 +4746,31 @@ function SessionDetailView({ id }: { id: number }) {
         <div className="transcript-column">
           {(detail.message_offset ?? 0) > 0 ? (
             <div className="transcript-window-start">
+              {/* Counts what is missing rather than naming the first loaded
+                  message. The offset is a zero-based row index, so printing it
+                  as a 1-based ordinal contradicted the #message-<seq> anchor
+                  for that very message. */}
               <span>
-                Viewing from message {formatInt((detail.message_offset ?? 0) + 1)} of{" "}
-                {formatInt(detail.summary.message_count)}
+                {formatInt(detail.message_offset ?? 0)} earlier{" "}
+                {(detail.message_offset ?? 0) === 1 ? "message" : "messages"} not loaded
               </span>
-              <button
-                className="button small secondary"
-                onClick={() => void jumpToMessage(0)}
-                type="button"
-              >
-                Start at the beginning
-              </button>
+              <span className="transcript-window-start-actions">
+                <button
+                  className="button small secondary"
+                  disabled={loadingMore}
+                  onClick={() => void loadPreviousMessages()}
+                  type="button"
+                >
+                  {loadingMore ? "Loading…" : "Load earlier"}
+                </button>
+                <button
+                  className="button small secondary"
+                  onClick={() => void jumpToMessage(0)}
+                  type="button"
+                >
+                  Start at the beginning
+                </button>
+              </span>
             </div>
           ) : null}
           {messages.map((message) => (

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -38,6 +38,7 @@ import {
 import {
   type CSSProperties,
   type MouseEvent,
+  memo,
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
   useCallback,
@@ -65,6 +66,7 @@ import { planSessionLoad, shouldShowSessionSkeleton } from "./loading-state.ts";
 import {
   isInteractiveTarget,
   nextTranscriptSeq,
+  revealTranscriptMessage,
   type TranscriptNavigationDirection,
   transcriptNavigationDirection,
   transcriptSeqFromHash,
@@ -4507,6 +4509,12 @@ function SessionDetailView({ id }: { id: number }) {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [navigateTranscript]);
 
+  // Hoisted above the early returns because hooks cannot run conditionally.
+  // TranscriptTurn is memoized, and a Map rebuilt every render would defeat
+  // that for every turn on the screen.
+  const subagents = detail?.subagents;
+  const subagentsByToolUse = useMemo(() => subagentMap(subagents ?? []), [subagents]);
+
   if (error != null) {
     return <div className="notice danger">Unable to load session: {error}</div>;
   }
@@ -4518,7 +4526,6 @@ function SessionDetailView({ id }: { id: number }) {
   const messages = renderableMessages(detail.messages);
   const toc = outline == null ? threadToc(messages) : threadTocFromOutline(outline);
   const stats = threadStats(detail.summary, messages, toc, contextWindow?.turn_count);
-  const subagentsByToolUse = subagentMap(detail.subagents);
   const subagentRuns = countSubagentRuns(detail.subagents);
   const compactionBySeq = new Map(
     (contextWindow?.compactions ?? []).map((compaction) => [compaction.seq, compaction] as const),
@@ -4618,7 +4625,6 @@ function SessionDetailView({ id }: { id: number }) {
                 </span>
                 <span>{item.label}</span>
                 {jumpingToSeq === item.seq ? <b>loading</b> : null}
-                {item.tools > 0 ? <b>{item.tools}</b> : null}
               </a>
             ))}
           </div>
@@ -4767,7 +4773,14 @@ type TranscriptBlockData = {
   tool_result: string | null;
 };
 
-function TranscriptTurn({
+// tabIndex={-1} makes each turn programmatically focusable without adding it to
+// the tab order, so arrow-key navigation can move focus and a screen reader
+// announces the turn it scrolled to. Without it the highlight is visual only.
+//
+// Memoized: a transcript loads an unbounded number of turns, and every arrow
+// keypress changes `active` on exactly two of them. Without this, each keypress
+// re-renders every loaded turn.
+const TranscriptTurn = memo(function TranscriptTurn({
   active,
   compaction,
   message,
@@ -4815,6 +4828,7 @@ function TranscriptTurn({
         active ? " is-keyboard-active" : ""
       }${providerClass}`}
       id={`message-${message.seq}`}
+      tabIndex={-1}
     >
       <TranscriptIdentityBadge message={message} tool={tool} />
       <div className="turn-meta">
@@ -4836,7 +4850,7 @@ function TranscriptTurn({
       </div>
     </article>
   );
-}
+});
 
 function CompactionTurn({
   active = false,
@@ -5862,7 +5876,6 @@ function threadToc(messages: SessionDetailData["messages"]): ThreadTocItem[] {
       {
         seq: message.seq,
         ...tocPresentation(label),
-        tools: message.blocks.filter((block) => block.block_type === "tool_use").length,
       },
     ];
   });
@@ -5872,14 +5885,12 @@ function threadTocFromOutline(outline: SessionOutlineItemData[]): ThreadTocItem[
   return outline.map((item) => ({
     seq: item.seq,
     ...tocPresentation(item.text),
-    tools: 0,
   }));
 }
 
 type ThreadTocItem = {
   seq: number;
   label: string;
-  tools: number;
   icon: IconName;
 };
 
@@ -6051,10 +6062,10 @@ function nearestTranscriptSeq(sequences: readonly number[]): number | null {
 }
 
 function scrollTranscriptMessage(seq: number) {
-  document.getElementById(`message-${seq}`)?.scrollIntoView({
-    behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
-    block: "start",
-  });
+  revealTranscriptMessage(
+    document.getElementById(`message-${seq}`),
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
 }
 
 async function getJson<T>(path: string, init?: RequestInit): Promise<T> {

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -49,7 +49,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { createPortal } from "react-dom";
+import { createPortal, flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import {
   type AnalyticsChartMetric,
@@ -4186,6 +4186,10 @@ function SessionDetailView({ id }: { id: number }) {
   const [economicsError, setEconomicsError] = useState<string | null>(null);
   const [loadingMore, setLoadingMore] = useState(false);
   const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
+  // Separate from loadMoreError: the two loads fail in different places and
+  // retry in opposite directions, so one shared message would report a failed
+  // backward load at the foot of the transcript under the wrong wording.
+  const [loadEarlierError, setLoadEarlierError] = useState<string | null>(null);
   const [jumpingToSeq, setJumpingToSeq] = useState<number | null>(null);
   const [activeMessageSeq, setActiveMessageSeq] = useState<number | null>(null);
   const detailRef = useRef<SessionDetailData | null>(null);
@@ -4209,6 +4213,7 @@ function SessionDetailView({ id }: { id: number }) {
     setEconomicsError(null);
     setLoadingMore(false);
     setLoadMoreError(null);
+    setLoadEarlierError(null);
     setJumpingToSeq(null);
     activeMessageSeqRef.current = null;
     handledMessageHashRef.current = null;
@@ -4345,7 +4350,7 @@ function SessionDetailView({ id }: { id: number }) {
           return false;
         }
         setLoadingMore(true);
-        setLoadMoreError(null);
+        setLoadEarlierError(null);
         return getJson<SessionDetailData>(
           `/api/sessions/${id}?message_limit=${request.limit}&message_offset=${request.offset}`,
         )
@@ -4387,27 +4392,27 @@ function SessionDetailView({ id }: { id: number }) {
               message_offset: request.offset,
             };
             detailRef.current = nextDetail;
-            setDetail(nextDetail);
+            // flushSync commits the prepend before it returns, so the
+            // measurement below is guaranteed to see the new DOM. Deferring to
+            // requestAnimationFrame would be both less certain -- React commits
+            // on its own schedule -- and a frame late, long enough for the
+            // browser to paint the shifted position before it was corrected.
+            flushSync(() => {
+              setDetail(nextDetail);
+            });
             if (anchorSeq != null && anchorTop != null) {
-              const seq = anchorSeq;
-              const before = anchorTop;
-              requestAnimationFrame(() => {
-                if (sessionVersionRef.current !== sessionVersion) {
-                  return;
-                }
-                const after = document
-                  .getElementById(`message-${seq}`)
-                  ?.getBoundingClientRect().top;
-                if (after != null && after !== before) {
-                  window.scrollBy({ behavior: "auto", top: after - before });
-                }
-              });
+              const after = document
+                .getElementById(`message-${anchorSeq}`)
+                ?.getBoundingClientRect().top;
+              if (after != null && after !== anchorTop) {
+                window.scrollBy({ behavior: "auto", top: after - anchorTop });
+              }
             }
             return true;
           })
           .catch((err: unknown) => {
             if (sessionVersionRef.current === sessionVersion) {
-              setLoadMoreError(errorMessage(err));
+              setLoadEarlierError(errorMessage(err));
             }
             return false;
           })
@@ -4754,6 +4759,11 @@ function SessionDetailView({ id }: { id: number }) {
                 {formatInt(detail.message_offset ?? 0)} earlier{" "}
                 {(detail.message_offset ?? 0) === 1 ? "message" : "messages"} not loaded
               </span>
+              {loadEarlierError != null ? (
+                <span className="transcript-window-start-error" role="status">
+                  Couldn’t load the earlier messages: {loadEarlierError}
+                </span>
+              ) : null}
               <span className="transcript-window-start-actions">
                 <button
                   className="button small secondary"
@@ -4761,7 +4771,11 @@ function SessionDetailView({ id }: { id: number }) {
                   onClick={() => void loadPreviousMessages()}
                   type="button"
                 >
-                  {loadingMore ? "Loading…" : "Load earlier"}
+                  {loadEarlierError != null
+                    ? "Try again"
+                    : loadingMore
+                      ? "Loading…"
+                      : "Load earlier"}
                 </button>
                 <button
                   className="button small secondary"

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2772,6 +2772,13 @@ mark {
   text-align: left;
 }
 
+.transcript-window-start-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
 .transcript-load-more {
   gap: 12px;
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2772,6 +2772,11 @@ mark {
   text-align: left;
 }
 
+.transcript-window-start-error {
+  color: var(--danger);
+  min-width: 0;
+}
+
 .transcript-window-start-actions {
   display: flex;
   align-items: center;

--- a/src/ui/transcript-navigation.ts
+++ b/src/ui/transcript-navigation.ts
@@ -107,6 +107,23 @@ export function revealTranscriptMessage(
   return true;
 }
 
+/**
+ * Selector for anything modal enough that arrow keys should not reach the
+ * transcript underneath it. Nothing in the UI matches today; this is a guard
+ * against a modal added later silently scrolling the page behind itself.
+ *
+ * `[role='dialog']` alone missed both of the other ways a modal is normally
+ * expressed, so all three are covered: the native element (only while open,
+ * since a closed `<dialog>` stays in the DOM), the ARIA role, and the
+ * `aria-modal` flag.
+ */
+const MODAL_SELECTOR = "dialog[open], [role='dialog'], [role='alertdialog'], [aria-modal='true']";
+
+/** True when a modal is on screen, so transcript navigation should stand down. */
+export function hasOpenModal(root: { querySelector(selectors: string): unknown } | null): boolean {
+  return root?.querySelector(MODAL_SELECTOR) != null;
+}
+
 export function transcriptSeqFromHash(hash: string): number | null {
   const match = hash.match(/^#message-(\d+)$/);
   if (match == null) {

--- a/src/ui/transcript-navigation.ts
+++ b/src/ui/transcript-navigation.ts
@@ -77,6 +77,36 @@ export function isInteractiveTarget(target: unknown): boolean {
   );
 }
 
+/**
+ * The part of a turn element `revealTranscriptMessage` drives. Structural for
+ * the same reason as `TranscriptEventTarget`, and so tests need no real DOM.
+ */
+export interface TranscriptScrollTarget {
+  scrollIntoView(options: { behavior: "auto" | "smooth"; block: "start" }): void;
+  focus(options: { preventScroll: boolean }): void;
+}
+
+/**
+ * Bring a turn into view and move focus to it. Focus is the point: without it
+ * arrow-key navigation is a purely visual highlight that assistive tech never
+ * announces. `preventScroll` keeps the browser from running a second, competing
+ * scroll to an element we just animated to.
+ *
+ * Returns false when there is nothing to reveal, which happens whenever the
+ * target seq sits outside the currently loaded message window.
+ */
+export function revealTranscriptMessage(
+  target: TranscriptScrollTarget | null | undefined,
+  prefersReducedMotion: boolean,
+): boolean {
+  if (target == null) {
+    return false;
+  }
+  target.scrollIntoView({ behavior: prefersReducedMotion ? "auto" : "smooth", block: "start" });
+  target.focus({ preventScroll: true });
+  return true;
+}
+
 export function transcriptSeqFromHash(hash: string): number | null {
   const match = hash.match(/^#message-(\d+)$/);
   if (match == null) {

--- a/src/ui/transcript-pagination.ts
+++ b/src/ui/transcript-pagination.ts
@@ -53,6 +53,46 @@ export function appendTranscriptPage<T extends SequencedTranscriptMessage>(
 }
 
 /**
+ * Prepend an earlier transcript page, deduplicating for the same reason
+ * `appendTranscriptPage` does. Order matters: the transcript renders in `seq`
+ * order, so the earlier page goes in front.
+ */
+export function prependTranscriptPage<T extends SequencedTranscriptMessage>(
+  current: readonly T[],
+  incoming: readonly T[],
+): T[] {
+  if (incoming.length === 0) {
+    return [...current];
+  }
+  const seen = new Set(current.map((message) => message.seq));
+  return [...incoming.filter((message) => !seen.has(message.seq)), ...current];
+}
+
+/**
+ * The request that fills the gap in front of a window, or null when the window
+ * already reaches the start of the session.
+ *
+ * The limit is the size of the gap rather than a full page, so the fetch stops
+ * exactly where the loaded window begins. Asking for a full page here would
+ * re-fetch rows already held whenever the window starts less than a page in.
+ */
+export function previousTranscriptPageRequest(
+  offset: number,
+  pageSize: number,
+): { offset: number; limit: number } | null {
+  if (!Number.isFinite(offset) || !Number.isFinite(pageSize)) {
+    return null;
+  }
+  const start = Math.trunc(offset);
+  const size = Math.max(1, Math.trunc(pageSize));
+  if (start <= 0) {
+    return null;
+  }
+  const previousOffset = Math.max(0, start - size);
+  return { offset: previousOffset, limit: start - previousOffset };
+}
+
+/**
  * Keep a little preceding context when opening an unloaded outline target.
  *
  * Treats `seq` as a dense, zero-based row index, because the server pages with

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -102,6 +102,62 @@ describe("query reads", () => {
     db.close();
   });
 
+  test("session totals cover the whole session, not the requested page", () => {
+    const db = seeded();
+    const id = listSessions(db)[0]?.id ?? 0;
+
+    const whole = getSession(db, id);
+    const totals = whole?.totals;
+    if (totals == null) {
+      throw new Error("a real session read must carry totals");
+    }
+    // Guard against a vacuous assertion: a session with nothing to count would
+    // let a page-scoped implementation pass this test unchanged.
+    expect(totals.reply_count).toBeGreaterThan(0);
+    expect(totals.tool_call_count).toBeGreaterThan(0);
+
+    // The first page deliberately excludes later replies and tool calls, so a
+    // count taken over `messages` would come back smaller here.
+    const firstPage = getSession(db, id, { messageLimit: 1, messageOffset: 0 });
+    expect(firstPage?.has_more_messages).toBe(true);
+    expect(firstPage?.totals).toEqual(totals);
+
+    const repliesOnPage = (firstPage?.messages ?? []).filter(
+      (message) => message.role === "assistant",
+    ).length;
+    expect(repliesOnPage).toBeLessThan(totals.reply_count ?? 0);
+
+    // The aggregate must agree with the reader's own rule, or the header would
+    // contradict a transcript the reader can count by hand. Recomputed here the
+    // way the UI does it, over a fully loaded session.
+    const renderable = (whole?.messages ?? []).filter(
+      (message) =>
+        message.is_compact_boundary ||
+        message.blocks.some((block) =>
+          block.block_type === "text" || block.block_type === "thinking"
+            ? (block.text ?? "").trim() !== ""
+            : block.block_type === "tool_use" || block.block_type === "tool_result",
+        ),
+    );
+    expect(renderable.filter((message) => message.role === "assistant").length).toBe(
+      totals.reply_count,
+    );
+    expect(
+      renderable.reduce(
+        (sum, message) =>
+          sum + message.blocks.filter((block) => block.block_type === "tool_use").length,
+        0,
+      ),
+    ).toBe(totals.tool_call_count);
+
+    // Stubs carry structure and a summary but no messages, so they carry no
+    // totals either rather than reporting a misleading zero.
+    for (const subagent of whole?.subagents ?? []) {
+      expect(subagent.totals).toBeUndefined();
+    }
+    db.close();
+  });
+
   test("listSessions filters by tool, offset, and uses the default limit", () => {
     const db = seeded();
     upsertSession(

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -341,6 +341,20 @@ describe("server routes", () => {
       message_limit: 2,
       has_more_messages: false,
     });
+    // Backward paging: the client holds a window starting at offset 2 and asks
+    // for the gap in front of it. The two pages must abut exactly -- an overlap
+    // would duplicate rows, a hole would make messages unreachable by keyboard.
+    const laterWindow = await route(config, `/api/sessions/${id}?message_limit=2&message_offset=2`);
+    const earlierGap = await route(config, `/api/sessions/${id}?message_limit=2&message_offset=0`);
+    const seqOf = (result: { body: unknown }) =>
+      (result.body as { messages: { seq: number }[] }).messages.map((message) => message.seq);
+    expect(seqOf(laterWindow).length).toBeGreaterThan(0);
+    expect(seqOf(earlierGap).length).toBeGreaterThan(0);
+    const stitched = [...seqOf(earlierGap), ...seqOf(laterWindow)];
+    expect(new Set(stitched).size).toBe(stitched.length);
+    expect(stitched).toEqual([...stitched].sort((a, b) => a - b));
+    expect(stitched).toEqual([0, 1, 2, 3]);
+
     const outline = await route(config, `/api/sessions/${id}/outline`);
     expect(outline.status).toBe(200);
     expect(outline.body).toEqual([

--- a/test/ui-transcript-navigation.test.ts
+++ b/test/ui-transcript-navigation.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
   isInteractiveTarget,
   nextTranscriptSeq,
+  revealTranscriptMessage,
+  type TranscriptScrollTarget,
   transcriptNavigationDirection,
   transcriptSeqFromHash,
 } from "../src/ui/transcript-navigation.ts";
@@ -64,5 +66,36 @@ describe("interactive target guard", () => {
     expect(isInteractiveTarget("article")).toBe(false);
     expect(isInteractiveTarget({})).toBe(false);
     expect(isInteractiveTarget({ matches: () => false })).toBe(false);
+  });
+});
+
+describe("revealTranscriptMessage", () => {
+  function recordingTarget() {
+    const calls: { scrolled: string[]; focused: boolean[] } = { scrolled: [], focused: [] };
+    const target: TranscriptScrollTarget = {
+      scrollIntoView: (options) => calls.scrolled.push(options.behavior),
+      focus: (options) => calls.focused.push(options.preventScroll),
+    };
+    return { calls, target };
+  }
+
+  test("moves focus to the turn it scrolls to", () => {
+    const { calls, target } = recordingTarget();
+    expect(revealTranscriptMessage(target, false)).toBe(true);
+    expect(calls.scrolled).toEqual(["smooth"]);
+    // Focus is what makes arrow-key navigation perceivable to a screen reader.
+    expect(calls.focused).toEqual([true]);
+  });
+
+  test("honors reduced motion without giving up focus", () => {
+    const { calls, target } = recordingTarget();
+    revealTranscriptMessage(target, true);
+    expect(calls.scrolled).toEqual(["auto"]);
+    expect(calls.focused).toEqual([true]);
+  });
+
+  test("reports a miss when the seq is outside the loaded window", () => {
+    expect(revealTranscriptMessage(null, false)).toBe(false);
+    expect(revealTranscriptMessage(undefined, false)).toBe(false);
   });
 });

--- a/test/ui-transcript-navigation.test.ts
+++ b/test/ui-transcript-navigation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  hasOpenModal,
   isInteractiveTarget,
   nextTranscriptSeq,
   revealTranscriptMessage,
@@ -97,5 +98,36 @@ describe("revealTranscriptMessage", () => {
   test("reports a miss when the seq is outside the loaded window", () => {
     expect(revealTranscriptMessage(null, false)).toBe(false);
     expect(revealTranscriptMessage(undefined, false)).toBe(false);
+  });
+});
+
+describe("hasOpenModal", () => {
+  function root(matcher: (selectors: string) => boolean) {
+    return { querySelector: (selectors: string) => (matcher(selectors) ? {} : null) };
+  }
+
+  test("covers every way the UI could express a modal", () => {
+    for (const marker of [
+      "dialog[open]",
+      "[role='dialog']",
+      "[role='alertdialog']",
+      "[aria-modal='true']",
+    ]) {
+      expect(hasOpenModal(root((selectors) => selectors.includes(marker)))).toBe(true);
+    }
+  });
+
+  test("requires a native dialog to be open", () => {
+    // A closed <dialog> stays in the DOM, so matching bare "dialog" would wedge
+    // navigation permanently once one is added. Asserted by checking that a
+    // root matching only the bare tag is not considered modal.
+    expect(hasOpenModal(root((selectors) => /(^|[\s,])dialog([\s,]|$)/.test(selectors)))).toBe(
+      false,
+    );
+  });
+
+  test("lets navigation through when nothing is modal", () => {
+    expect(hasOpenModal(root(() => false))).toBe(false);
+    expect(hasOpenModal(null)).toBe(false);
   });
 });

--- a/test/ui-transcript-pagination.test.ts
+++ b/test/ui-transcript-pagination.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
   appendTranscriptPage,
   clampTranscriptWindowOffset,
+  prependTranscriptPage,
+  previousTranscriptPageRequest,
   runWithTranscriptRequestSlot,
   transcriptWindowOffset,
 } from "../src/ui/transcript-pagination.ts";
@@ -133,5 +135,53 @@ describe("transcript window clamping", () => {
     }
     expect(clampTranscriptWindowOffset(500, 2000, Number.NaN)).toBe(0);
     expect(clampTranscriptWindowOffset(500, 2000, Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe("prependTranscriptPage", () => {
+  test("puts the earlier page in front, in seq order", () => {
+    expect(prependTranscriptPage([{ seq: 4 }, { seq: 5 }], [{ seq: 2 }, { seq: 3 }])).toEqual([
+      { seq: 2 },
+      { seq: 3 },
+      { seq: 4 },
+      { seq: 5 },
+    ]);
+  });
+
+  test("drops rows already held so a retry cannot duplicate them", () => {
+    expect(prependTranscriptPage([{ seq: 3 }, { seq: 4 }], [{ seq: 2 }, { seq: 3 }])).toEqual([
+      { seq: 2 },
+      { seq: 3 },
+      { seq: 4 },
+    ]);
+  });
+
+  test("copies the window when there is nothing to add", () => {
+    const current = [{ seq: 1 }];
+    const result = prependTranscriptPage(current, []);
+    expect(result).toEqual(current);
+    expect(result).not.toBe(current);
+  });
+});
+
+describe("previousTranscriptPageRequest", () => {
+  test("asks only for the gap in front of the window", () => {
+    // A window starting at 160 with a page size of 160 has a full page missing.
+    expect(previousTranscriptPageRequest(160, 160)).toEqual({ offset: 0, limit: 160 });
+  });
+
+  test("does not re-fetch rows already held when the gap is short", () => {
+    // 40 rows missing, so ask for 40 -- not a full page that would overlap.
+    expect(previousTranscriptPageRequest(40, 160)).toEqual({ offset: 0, limit: 40 });
+  });
+
+  test("stops at the start of the session", () => {
+    expect(previousTranscriptPageRequest(0, 160)).toBeNull();
+    expect(previousTranscriptPageRequest(-5, 160)).toBeNull();
+  });
+
+  test("refuses to build a request from non-finite input", () => {
+    expect(previousTranscriptPageRequest(Number.NaN, 160)).toBeNull();
+    expect(previousTranscriptPageRequest(160, Number.POSITIVE_INFINITY)).toBeNull();
   });
 });


### PR DESCRIPTION
Works the non-blocking backlog raised in review of #43. Four defects, each verified rather than assumed.

## Keyboard navigation moved no focus

Arrow keys scrolled the transcript and set a visual highlight, but never moved focus — so screen-reader users got nothing at all from navigating. Turns are now focusable with `tabIndex={-1}` (programmatically focusable, not in the tab order) and focus follows the scroll, with `preventScroll` so the browser doesn't run a second scroll competing with the one it just animated.

The reveal logic moved into `transcript-navigation.ts`, where it is unit-testable without a DOM.

## Header stats mixed scopes

`turns` and `tokens` covered the whole session while `replies` and `toolCalls` were counted from the loaded message window, so both silently shrank as soon as a transcript paginated — a long session showed the tool calls of its first page next to its full turn count.

Session detail now returns a `totals` object aggregated across the session. The SQL predicate mirrors the reader's own renderable-block rule, and a test asserts the two agree over a fully loaded session; they sit next to a transcript the reader can count by hand, so drift between them would be visible.

Confirmed against a 480-message synthetic session: `totals` reports 192 replies while a 5-message page is loaded. Previously the header would have said 5.

## ArrowUp dead-ended at the top of a window

A window only starts partway into a session when the reader arrived by deep link, outline click, or compaction jump. Everything before that landing point was unreachable — ArrowUp stopped at the top, and the only way back was "Start at the beginning", which discards where you were.

ArrowUp now fills the gap in front of the window, mirroring what ArrowDown already did at the other end, and the banner offers the same as a button. The request asks for exactly the gap rather than a full page, so a window starting less than a page in does not re-fetch rows it already holds.

Prepending shifts everything below down by the height of the new content, and browser scroll anchoring does not rescue it — measured in Chromium, a page of prepended turns moved the anchor by its full height. The viewport is held by measuring how far a surviving turn moved, rather than by `scrollHeight`, which would misread the `content-visibility` placeholders.

## Banner numbering contradicted the anchors

The banner printed the window offset as a 1-based ordinal ("Viewing from message 281") while the anchor for that very message is `#message-280`. It now counts what is missing instead, which is unambiguous and closer to what a reader wants to know.

## Also

- `TranscriptTurn` is memoized. A transcript loads an unbounded number of turns and each keypress changes `active` on exactly two of them, so every keypress re-rendered every loaded turn. This required hoisting `subagentsByToolUse` into a `useMemo` above the component's early returns — rebuilt inline, its fresh `Map` identity defeated the memo for every turn on screen.
- The outline's tool-count badge is gone. `threadToc` returns early for any non-user message and only `parseAssistant` emits `tool_use` blocks, so the count was structurally always zero and the badge had never rendered.
- The navigation guard's `[role='dialog']` check matched a selector nothing in this UI renders, and missed both other ways a modal is normally expressed. `hasOpenModal` covers the native element, the ARIA roles, and `aria-modal`, and requires a native dialog to be *open* — a closed one stays in the DOM and would have wedged navigation permanently.

## Verification

Driven in a real browser against a 480-message synthetic session built from generated fixtures (no real transcripts, and the generator is deliberately not part of this PR):

- deep link lands with focus on the target turn (`activeElement` = `ARTICLE#message-300`)
- ArrowUp at the window top loads backward: window grew 160 → 320 turns, contiguous, no gap
- "Load earlier" with 32000px inserted above the viewport: **zero drift**

`bun test` (419 pass), `bunx tsc --noEmit`, and `bunx biome check .` are all clean.

## Not fixed here

One backlog item is dismissed rather than fixed: the context-window tooltip's `turn N · call K of M` is not a numbering inconsistency. `turn` is a documented 1-based turn number and a different quantity from `seq`; the thread navigation displays no numbers at all. The real instance of that complaint was the window banner, fixed above.

https://claude.ai/code/session_01F7zx7ddrKzTGbx8NWfGHSh