### PR TITLE
fix(cli): honor --no-sync in serve instead of ingesting anyway

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,11 @@ Run from the repo root.
   `cd`s into (macOS only, the only platform `canLaunch` accepts); defaults to
   `$HOME`.
 - `DECANT_NO_SYNC` (any value) or `--no-sync`: skip the sync-on-read that read
-  commands otherwise perform.
+  commands otherwise perform, and run `serve` without its source watcher, so it
+  serves the archive as-is and ingests nothing. `POST /api/sync` still works:
+  this suppresses syncs decant starts on its own, not one an operator asks for.
+  Use it whenever pointing a command at a scratch archive, or the watcher will
+  fill that archive from the real `~/.claude` and `~/.codex`.
 - Global flags on every command: `--db`, `--json`, `--format table|json|md`,
   `-q/--quiet`, `--no-color`, `--no-sync`.
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ Claude `stream-json` logs; pass `--path` more than once to ingest multiple paths
 - `DECANT_LOG_LEVEL`: minimum structured operational log level written as JSON
   Lines to stderr. Defaults to `info`; accepts `trace`, `debug`, `info`, `warn`
   (or `warning`), `error`, `fatal`, and `off` (or `silent`).
+- `DECANT_NO_SYNC`: set to any value to skip the sync-on-read that read commands
+  perform, and to run `decant serve` without its source watcher so it serves the
+  archive as-is and ingests nothing. The `--no-sync` flag does the same. The
+  "Sync now" button and `POST /api/sync` still work; this only suppresses the
+  syncing decant starts on its own.
 - `DECANT_TRUSTED_PEERS`: comma-separated peer IPs or IPv4 CIDRs allowed through
   the local API guard when `serve` is bound to a non-loopback host. Unset by
   default. Keep it as narrow as the deployment allows: every listed address, and

--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -51,7 +51,7 @@ guard reads or writes the whole archive.
 - `POST /api/settings`
 - `GET /api/sync-status`
 - `GET /api/metadata/sync-status`
-- `POST /api/sync`
+- `POST /api/sync` (works even under `--no-sync`, which only stops the watcher)
 - `GET /api/sessions?from=YYYY-MM-DD&to=YYYY-MM-DD`
 - `GET /api/sessions/:id`
 - `GET /api/sessions/:id/outline`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -163,7 +163,7 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
     .option("--format <format>", "output format (table | json | md)", parseOutputFormat)
     .option("-q, --quiet", "suppress non-essential output")
     .option("--no-color", "disable ANSI color")
-    .option("--no-sync", "skip sync-on-read for read commands");
+    .option("--no-sync", "skip sync-on-read, and serve without the source watcher");
 
   const globals = (): GlobalOptions => program.opts<GlobalOptions>();
   const resolve = (overrides: Partial<ConfigOverrides> = {}): Config =>
@@ -332,6 +332,14 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
             claudeDir: commandOptions.claudeDir,
             codexDir: commandOptions.codexDir,
           });
+          // Without this, --no-sync (and DECANT_NO_SYNC) were accepted here and
+          // silently ignored: serve's watcher kept ingesting the source
+          // directories, so pointing serve at a scratch archive filled it with
+          // whatever was in the real ~/.claude and ~/.codex. Omitting `watch`
+          // entirely is what serve() checks to decide whether to run a watcher
+          // at all. POST /api/sync is deliberately untouched -- this turns off
+          // syncing decant starts on its own, not a sync the operator asks for.
+          const syncEnabled = shouldSync(globals(), options.env);
           const server = serveApp({
             config,
             hostname: commandOptions.host ?? DEFAULT_SERVE_HOST,
@@ -345,19 +353,21 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
                 ? trustedPeers(commandOptions.trustedPeer)
                 : undefined,
             logger: globals().quiet ? undefined : serverLogger,
-            watch: {
-              intervalMs: commandOptions.intervalMs,
-              debounceMs: commandOptions.debounceMs,
-              enableWatch: commandOptions.fsWatch !== false,
-              onEvent: emitWatchEvent,
-            },
+            watch: syncEnabled
+              ? {
+                  intervalMs: commandOptions.intervalMs,
+                  debounceMs: commandOptions.debounceMs,
+                  enableWatch: commandOptions.fsWatch !== false,
+                  onEvent: emitWatchEvent,
+                }
+              : undefined,
           });
           if (!globals().quiet) {
             serverLogger.info("Server started.", {
               "event.name": "decant.server.started",
               "server.address": commandOptions.host ?? DEFAULT_SERVE_HOST,
               "server.port": server.port,
-              "watch.enabled": true,
+              "watch.enabled": syncEnabled,
             });
           }
           try {

--- a/test/serve-wiring.test.ts
+++ b/test/serve-wiring.test.ts
@@ -49,6 +49,40 @@ function httpStatus(ip: string, port: number, path: string): Promise<number> {
   });
 }
 
+/**
+ * Read serve's JSON Lines startup log until it reports its port.
+ *
+ * The kill timer matters: without it a `read()` that never resolves -- a child
+ * that hangs before writing anything -- blocks until the per-test timeout
+ * instead of failing here with the output collected so far. Killing the process
+ * makes the stream end, so the loop exits and reports what it saw.
+ */
+async function readServePort(
+  proc: Bun.Subprocess<"ignore", "ignore", "pipe">,
+): Promise<{ port: number; log: string }> {
+  const kill = setTimeout(() => proc.kill(), 15_000);
+  try {
+    const reader = proc.stderr.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      // serve reports startup as JSON Lines on stderr (PR #41). The older
+      // "serving http://host:port" line no longer exists, and scraping for it
+      // drains the deadline and fails as if the server never started.
+      const match = buffer.match(/"server\.port":\s*(\d+)/);
+      if (match) {
+        return { port: Number(match[1]), log: buffer };
+      }
+    }
+    throw new Error(`serve never reported its port; stderr so far: ${buffer.slice(0, 300)}`);
+  } finally {
+    clearTimeout(kill);
+  }
+}
+
 interface ServeCase {
   env?: Record<string, string>;
   flags?: string[];
@@ -85,27 +119,7 @@ async function withServe<T>(c: ServeCase, run: (port: number) => Promise<T>): Pr
   );
 
   try {
-    const reader = proc.stderr.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-    const deadline = Date.now() + 15_000;
-    let port: number | null = null;
-    while (Date.now() < deadline) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      // serve reports startup as JSON Lines on stderr (PR #41). The older
-      // "serving http://host:port" line no longer exists, and scraping for it
-      // drains the deadline and fails as if the server never started.
-      const match = buffer.match(/"server\.port":\s*(\d+)/);
-      if (match) {
-        port = Number(match[1]);
-        break;
-      }
-    }
-    if (port == null) {
-      throw new Error(`serve never reported its port; stderr so far: ${buffer.slice(0, 300)}`);
-    }
+    const { port } = await readServePort(proc);
     return await run(port);
   } finally {
     proc.kill();
@@ -212,25 +226,8 @@ async function withSeededServe<T>(
   );
 
   try {
-    const reader = proc.stderr.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-    const deadline = Date.now() + 15_000;
-    let port: number | null = null;
-    while (Date.now() < deadline) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const match = buffer.match(/"server\.port":\s*(\d+)/);
-      if (match) {
-        port = Number(match[1]);
-        break;
-      }
-    }
-    if (port == null) {
-      throw new Error(`serve never reported its port; stderr so far: ${buffer.slice(0, 300)}`);
-    }
-    return await run(port, buffer);
+    const { port, log } = await readServePort(proc);
+    return await run(port, log);
   } finally {
     proc.kill();
     await proc.exited;
@@ -244,9 +241,34 @@ async function sessionCount(port: number): Promise<number> {
   return body.sessions ?? 0;
 }
 
-/** Give a watcher that IS running long enough to have ingested. */
-async function settle(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 2500));
+/** Poll until the startup sync lands, rather than sleeping a fixed guess. */
+async function waitForIngest(port: number): Promise<number> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const count = await sessionCount(port);
+    if (count > 0) {
+      return count;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error("watcher never ingested the fixture");
+}
+
+/**
+ * How long to give a watcher that should NOT be running.
+ *
+ * Proving a negative needs a real wait; there is no event to poll for when the
+ * intended behaviour is that nothing happens. This cannot be shortened to a
+ * token delay: against the unfixed CLI the ingest lands around the 2.5s mark,
+ * so a 100ms wait would let these tests pass on the very bug they exist to
+ * catch. It is deliberately longer than `waitForIngest` needs when the watcher
+ * IS running, which the baseline test measures.
+ */
+const NO_INGEST_GRACE_MS = 4000;
+
+async function expectNoIngest(port: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, NO_INGEST_GRACE_MS));
+  expect(await sessionCount(port)).toBe(0);
 }
 
 describe("serve sync opt-out (real CLI process)", () => {
@@ -255,24 +277,24 @@ describe("serve sync opt-out (real CLI process)", () => {
   test("baseline: the watcher ingests the source tree by default", async () => {
     await withSeededServe({}, async (port, startupLog) => {
       expect(startupLog).toContain('"watch.enabled":true');
-      await settle();
-      expect(await sessionCount(port)).toBeGreaterThan(0);
+      // Also establishes that the grace period below outlasts a real ingest.
+      const started = Date.now();
+      expect(await waitForIngest(port)).toBeGreaterThan(0);
+      expect(Date.now() - started).toBeLessThan(NO_INGEST_GRACE_MS);
     });
   }, 40_000);
 
   test("--no-sync leaves the archive untouched", async () => {
     await withSeededServe({ flags: ["--no-sync"] }, async (port, startupLog) => {
       expect(startupLog).toContain('"watch.enabled":false');
-      await settle();
-      expect(await sessionCount(port)).toBe(0);
+      await expectNoIngest(port);
     });
   }, 40_000);
 
   test("DECANT_NO_SYNC does the same, matching read commands", async () => {
     await withSeededServe({ env: { DECANT_NO_SYNC: "1" } }, async (port, startupLog) => {
       expect(startupLog).toContain('"watch.enabled":false');
-      await settle();
-      expect(await sessionCount(port)).toBe(0);
+      await expectNoIngest(port);
     });
   }, 40_000);
 

--- a/test/serve-wiring.test.ts
+++ b/test/serve-wiring.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import net from "node:net";
 import { networkInterfaces, tmpdir } from "node:os";
 import { join } from "node:path";
@@ -156,4 +156,132 @@ describe.skipIf(lanIP == null)("serve trusted-peer wiring (real CLI process)", (
       },
     );
   }, 30_000);
+});
+
+/**
+ * `--no-sync` is a global flag, and `serve` used to accept it while its watcher
+ * kept ingesting anyway. That is worse than rejecting it: pointing `serve` at a
+ * scratch archive to inspect it, or to take a screenshot, silently filled that
+ * archive with whatever the real `~/.claude` and `~/.codex` held.
+ *
+ * These spawn the real CLI against a synthetic source tree, because the bug was
+ * entirely in the argv-to-serve() wiring -- every layer below it was correct.
+ */
+interface SyncCase {
+  env?: Record<string, string>;
+  flags?: string[];
+}
+
+async function withSeededServe<T>(
+  c: SyncCase,
+  run: (port: number, startupLog: string) => Promise<T>,
+): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), "decant-serve-sync-"));
+  const claudeDir = join(dir, "claude");
+  const codexDir = join(dir, "codex");
+  const projectDir = join(claudeDir, "-Users-dev-proj");
+  mkdirSync(projectDir, { recursive: true });
+  mkdirSync(codexDir, { recursive: true });
+  // A real, ingestible session. If the watcher runs, this lands in the archive.
+  copyFileSync(join(repoRoot, "fixtures", "claude", "sample.jsonl"), join(projectDir, "s1.jsonl"));
+
+  const env = { ...process.env, ...(c.env ?? {}) };
+  delete env.DECANT_TRUSTED_PEERS;
+  if (!(c.env && "DECANT_NO_SYNC" in c.env)) {
+    delete env.DECANT_NO_SYNC;
+  }
+
+  const proc = Bun.spawn(
+    [
+      "bun",
+      "src/cli.ts",
+      "--db",
+      join(dir, "archive.db"),
+      ...(c.flags ?? []),
+      "serve",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      "0",
+      "--claude-dir",
+      claudeDir,
+      "--codex-dir",
+      codexDir,
+    ],
+    { cwd: repoRoot, env, stdout: "ignore", stderr: "pipe" },
+  );
+
+  try {
+    const reader = proc.stderr.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    const deadline = Date.now() + 15_000;
+    let port: number | null = null;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const match = buffer.match(/"server\.port":\s*(\d+)/);
+      if (match) {
+        port = Number(match[1]);
+        break;
+      }
+    }
+    if (port == null) {
+      throw new Error(`serve never reported its port; stderr so far: ${buffer.slice(0, 300)}`);
+    }
+    return await run(port, buffer);
+  } finally {
+    proc.kill();
+    await proc.exited;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function sessionCount(port: number): Promise<number> {
+  const response = await fetch(`http://127.0.0.1:${port}/api/stats/summary`);
+  const body = (await response.json()) as { sessions?: number };
+  return body.sessions ?? 0;
+}
+
+/** Give a watcher that IS running long enough to have ingested. */
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 2500));
+}
+
+describe("serve sync opt-out (real CLI process)", () => {
+  // Without this the suite would pass vacuously: an unloadable fixture, or a
+  // watcher that never starts, makes every "stayed empty" assertion trivial.
+  test("baseline: the watcher ingests the source tree by default", async () => {
+    await withSeededServe({}, async (port, startupLog) => {
+      expect(startupLog).toContain('"watch.enabled":true');
+      await settle();
+      expect(await sessionCount(port)).toBeGreaterThan(0);
+    });
+  }, 40_000);
+
+  test("--no-sync leaves the archive untouched", async () => {
+    await withSeededServe({ flags: ["--no-sync"] }, async (port, startupLog) => {
+      expect(startupLog).toContain('"watch.enabled":false');
+      await settle();
+      expect(await sessionCount(port)).toBe(0);
+    });
+  }, 40_000);
+
+  test("DECANT_NO_SYNC does the same, matching read commands", async () => {
+    await withSeededServe({ env: { DECANT_NO_SYNC: "1" } }, async (port, startupLog) => {
+      expect(startupLog).toContain('"watch.enabled":false');
+      await settle();
+      expect(await sessionCount(port)).toBe(0);
+    });
+  }, 40_000);
+
+  test("the UI still serves the archive it was pointed at", async () => {
+    // Opting out of ingestion must not degrade reads; that is the whole point
+    // of the mode.
+    await withSeededServe({ flags: ["--no-sync"] }, async (port) => {
+      expect((await fetch(`http://127.0.0.1:${port}/api/health`)).status).toBe(200);
+      expect((await fetch(`http://127.0.0.1:${port}/api/sessions`)).status).toBe(200);
+    });
+  }, 40_000);
 });


### PR DESCRIPTION
Fixes the trap I hit while verifying #61.

## What happened

`--no-sync` is a **global** flag, documented as "skip sync-on-read for read commands". `serve` therefore accepted it without complaint — it is a valid global option, so there is no unknown-option error — and then ignored it completely. The watcher kept ingesting the source directories regardless.

That is worse than rejecting the flag would have been. Pointing `serve` at a scratch archive to inspect a copy, or to stage a screenshot, silently filled that archive from the real `~/.claude` and `~/.codex`. In my case a supposedly empty scratch database reached **309 MB of private transcripts within seconds**, and the startup log cheerfully reported `"watch.enabled": true` — because that field was a hardcoded literal, not the actual state.

For a tool whose whole posture is local-first and privacy-preserving, a flag that reads as "don't sync" quietly not applying to the one command that continuously ingests your private directories is the wrong default to ship at v0.1.0.

## The fix

`serve` now omits its `watch` options when sync is off. That is already what `serve()` checks (`options.watch != null`) to decide whether to run a watcher at all, so no new plumbing was needed — the bug was entirely in the argv-to-`serve()` wiring. The log field now reports the real value.

`DECANT_NO_SYNC` goes through the same `shouldSync` helper the read commands use, so the flag and the environment variable agree rather than diverging.

`POST /api/sync` is **deliberately untouched**. This suppresses syncing decant starts on its own, not a sync an operator explicitly asks for, and reads must keep working — serving an archive as-is is the entire point of the mode.

## Verification

Tested through the real CLI process against a synthetic source tree, since every layer below the wiring was already correct.

- **Baseline:** the watcher *does* ingest by default. Without this, an unloadable fixture or a watcher that never starts would make every "stayed empty" assertion pass for the wrong reason.
- `--no-sync` → archive stays empty
- `DECANT_NO_SYNC=1` → same
- `--no-sync` still serves `/api/health` and `/api/sessions`

Both new cases **fail on the unfixed CLI on the archive contents alone** — `Expected: 0, Received: 1` — verified by temporarily removing the log assertions so the data assertion was what ran. The log-field check is not carrying the test.

Reproduced the original scenario end to end with the fix in place: the exact invocation that grew a 309 MB archive now reports `"watch.enabled":false`, holds 0 sessions, and stays at 4 KB.

`bun test` (409 pass), `bunx tsc --noEmit`, `bunx biome check .` clean.

## Docs

`--no-sync` was undocumented in the README. It is now covered there and in AGENTS.md, both stating that it turns off `serve`'s watcher and that an explicit sync still works, plus a note in the route reference.

https://claude.ai/code/session_01F7zx7ddrKzTGbx8NWfGHSh