### PR TITLE
feat: ingest trust (journal hygiene, typed diagnostics) and trajectory-v1 export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,10 +99,10 @@ A change is ready when:
 4. **Costs are computed at ingest** with `cost::estimateCost` and stored on the
    session row. Editing pricing does not rewrite historical rows; rebuild the
    archive to recompute.
-5. **The schema baseline is v15.** Pre-v8 archives are intentionally rebuild-only:
+5. **The schema baseline is v17.** Pre-v8 archives are intentionally rebuild-only:
    delete the archive and re-ingest from the source directories. Do not add
    broad forward migrations unless that product decision changes; the narrow
-   v8-to-v15 migrations preserve existing TypeScript-cutover archives.
+   v8-to-v17 migrations preserve existing TypeScript-cutover archives.
 6. **Parsers are the extension point.** A new source tool means
    `src/sources/<tool>.ts`, synthetic fixtures, parser tests, ingest/query tests,
    and golden updates.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,9 @@ Adding model pricing? Update `src/cost.ts`, include string normalization, and ad
 tests.
 
 Adding a source tool? Add `src/sources/<tool>.ts`, synthetic fixtures, parser
-tests, ingest/query coverage, and golden updates. Adding support for a new agent CLI? Follow the agent-executable prompt in docs/prompts/add-source.md.
+tests, ingest/query coverage, and golden updates.
+
+Adding support for a new agent CLI? Follow the agent-executable prompt in docs/prompts/add-source.md.
 
 ## How we work
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Adding model pricing? Update `src/cost.ts`, include string normalization, and ad
 tests.
 
 Adding a source tool? Add `src/sources/<tool>.ts`, synthetic fixtures, parser
-tests, ingest/query coverage, and golden updates.
+tests, ingest/query coverage, and golden updates. Adding support for a new agent CLI? Follow the agent-executable prompt in docs/prompts/add-source.md.
 
 ## How we work
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ decant distill replay 1
 decant distill skill --kind agents
 decant recommendations ls
 decant export 1 > session.md
+decant export 1 --format trajectory > session.trajectory.json
 decant completion zsh
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ decant distill replay 1
 decant distill skill --kind agents
 decant recommendations ls
 decant export 1 > session.md
-decant export 1 --format trajectory > session.trajectory.json
+decant export 1 --as trajectory > session.trajectory.json
 decant completion zsh
 ```
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,9 +14,11 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.2",
+        "@letta-ai/trajectory": "^0.2.0",
         "@types/bun": "^1.3.14",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "ajv": "^8.20.0",
         "typescript": "^7.0.2",
       },
     },
@@ -39,6 +41,8 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A=="],
+
+    "@letta-ai/trajectory": ["@letta-ai/trajectory@0.2.0", "", {}, "sha512-biCyT0z8nh4Q8kIqBrPgmzoalacPmosmCpvEjdN9ILpL85+T75b8ahcN9MHPHQUVRj/J7UyQuRahJ4/JdrpCcA=="],
 
     "@logtape/logtape": ["@logtape/logtape@2.2.4", "", {}, "sha512-2rALzv9m4ibE5FyB8/FMm5MPMMlK7ujgy3ufricVKIxj6e7SZbw4w6J16/fRAsXgdDlOXPUA0aa6XoEQvdlKxw=="],
 
@@ -90,6 +94,8 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
@@ -98,11 +104,19 @@
 
     "echarts": ["echarts@6.1.0", "", { "dependencies": { "tslib": "2.3.0", "zrender": "6.1.0" } }, "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA=="],
 
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
     "lucide-react": ["lucide-react@1.23.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw=="],
 
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 

--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -55,6 +55,8 @@ guard reads or writes the whole archive.
 - `GET /api/sessions?from=YYYY-MM-DD&to=YYYY-MM-DD`
 - `GET /api/sessions/:id`
 - `GET /api/sessions/:id/outline`
+- `GET /api/sessions/:id/issues` — ingest diagnostics recorded for the session's
+  source file
 - `GET /api/sessions/:id/token-economics`
 - `GET /api/sessions/:id/context-window`
 - `GET /api/projects`

--- a/docs/prompts/add-source.md
+++ b/docs/prompts/add-source.md
@@ -1,0 +1,85 @@
+# Add a source: parser for a new coding-agent CLI
+
+You are adding support for a new session-transcript source to decant. Work
+through this document top to bottom. The privacy rules are hard requirements,
+not suggestions.
+
+## Privacy rules (read first)
+
+- Real transcripts are private. When you inspect the tool's native session
+  store, extract **aggregate shapes only**: record-type names, key sets, value
+  types, counts. Never print, quote, or commit transcript prose, file paths
+  from another person's machine, tokens, or environment values.
+- Fixtures are **synthetic**: write them by hand from the shapes you observed,
+  with invented content ("hello", "/tmp/example", "example-model"). A fixture
+  that started life as a real transcript is a rejected PR, even if edited.
+- Parity checks against your own real store report **counts and shape
+  mismatches only** (see step 6), never content.
+
+## What decant needs from a source
+
+1. **Discovery** — where session files live and which filenames are sessions
+   (`src/ingest.ts: discover()`); non-session sidecars are excluded by name,
+   like Codex's `session_index.jsonl` and Claude's `journal.jsonl`.
+2. **A parser** — `src/sources/<tool>.ts` exporting
+   `parse<Tool>Session(sourceSessionId: string, content: string, ...): ParsedSession`.
+   Pure and print-free: return data and issues; never throw on malformed
+   input; never write to stdout/stderr (invariant 1).
+3. **A tool id** — add the wire string to `TOOLS` in `src/model.ts`
+   (lowercase snake_case; it is stored in SQLite and never reworded).
+4. **A watch root** — extend `watchDirs()` in `src/watch.ts` so `serve`
+   notices new sessions.
+5. **A capability report** — fill in the table below in your PR description.
+
+## Capability report (required in the PR)
+
+| capability | value for this source |
+|---|---|
+| per-message token usage | reported exactly / partially / absent |
+| cache token split | reported / absent |
+| model id per session | reported / inferred / absent |
+| reasoning tokens | reported / inferred / absent (`REASONING_SOURCES`) |
+| timestamps | per record / per session / absent |
+| tool call/result linkage | by id / by adjacency / absent |
+
+Decant promises economics only where usage data exists. If this source
+reports no usage, cost must surface as unavailable, not zero — say so in the
+PR so the maintainers wire the presentation tier deliberately.
+
+## Parser rules
+
+- Malformed line → push `{code: "unparsed_line", lineNo, error, rawLine}`
+  onto issues and continue. Never fail the file.
+- Record types you do not recognize → count them and emit one
+  `unknown_record_type` issue per distinct type (see
+  `src/sources/claude.ts` for the pattern). This is decant's format-drift
+  sensor; do not silently swallow unknowns.
+- Call `linkageIssues(session)` from `src/diagnostics.ts` before returning.
+- Normalize into `NormalizedSession` (`src/model.ts`): roles map onto
+  `user | assistant | system | tool | other`; blocks onto
+  `text | thinking | tool_use | tool_result | web_search | image | other`.
+  Keep the raw record on `message.raw` (canonical JSON) — the archive is
+  full-fidelity even where the normalized model is lossy.
+- MCP tool names follow `mcp__<server>__<base>`; if the source spells them
+  differently, normalize in the parser so `classifyTool` (`src/tools.ts`)
+  classifies them — see the Codex handling for the precedent.
+- Emit exactly one session per source file. Per-session diagnostics join on the session's source path, so a parser that yields multiple sessions from one file would mis-attribute every issue count for that file.
+
+## Tests (all required)
+
+1. Parser tests: `test/<tool>.test.ts` — happy path, malformed line,
+   unknown record type, tool call/result linkage, usage totals.
+2. Fixtures: `fixtures/<tool>/sample.jsonl` (+ variants your parser branches
+   on), synthetic per the privacy rules.
+3. Ingest tests: extend `test/ingest.test.ts` discovery coverage.
+4. Goldens: new fixtures must appear in `test/golden/rows/*.json` and
+   `test/golden/meta.json`'s fixture list. Goldens are hand-maintained —
+   mirror the existing rows' field layout exactly; there is no regeneration
+   script.
+
+## Definition of done
+
+`bun test && bunx tsc --noEmit && bunx biome check .` green, plus a parity
+run over your own real store: parse every session, then report — in
+aggregate only — sessions parsed, sessions with issues, issue counts by
+code, and any record type your parser had to mark unknown.

--- a/package.json
+++ b/package.json
@@ -28,9 +28,11 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.2",
+    "@letta-ai/trajectory": "^0.2.0",
     "@types/bun": "^1.3.14",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "ajv": "^8.20.0",
     "typescript": "^7.0.2"
   },
   "dependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -999,10 +999,16 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
                 if (!globals().quiet) {
                   const repairs = Object.entries(out.report)
                     .filter(([key, value]) => key !== "dropped_blocks" && (value as number) > 0)
-                    .map(([key, value]) => `${key}=${value}`)
+                    .map(([key, value]) => `${key}=${value}`);
+                  const dropped = Object.entries(out.report.dropped_blocks)
+                    .map(([kind, count]) => `${kind}=${count}`)
                     .join(" ");
-                  if (repairs !== "") {
-                    io.writeErr(`session ${sessionId}: ${repairs}\n`);
+                  if (dropped !== "") {
+                    repairs.push(`dropped[${dropped}]`);
+                  }
+                  const line = repairs.join(" ");
+                  if (line !== "") {
+                    io.writeErr(`session ${sessionId}: ${line}\n`);
                   }
                 }
                 return { content: JSON.stringify(out.records, null, 2) };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,7 @@ import {
   timeline,
 } from "./distill.ts";
 import type { Operation } from "./enrich.ts";
-import { toMarkdown } from "./export.ts";
+import { exportTrajectory, toMarkdown } from "./export.ts";
 import { sync as ingestSync } from "./ingest.ts";
 import { configureLogging, getDecantLogger, logWatchEvent } from "./logging.ts";
 import { getSession, listProjects, listSessions, search } from "./query.ts";
@@ -163,7 +163,13 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
     .option("--format <format>", "output format (table | json | md)", parseOutputFormat)
     .option("-q, --quiet", "suppress non-essential output")
     .option("--no-color", "disable ANSI color")
-    .option("--no-sync", "skip sync-on-read, and serve without the source watcher");
+    .option("--no-sync", "skip sync-on-read, and serve without the source watcher")
+    // export's own --format (md | json | trajectory) reuses this flag name for a
+    // command-specific purpose. Without positional options, Commander resolves
+    // --format anywhere in argv against this global first, regardless of where
+    // it appears — this scopes it to "before the subcommand name" so a
+    // subcommand's own same-named option governs anything typed after it.
+    .enablePositionalOptions();
 
   const globals = (): GlobalOptions => program.opts<GlobalOptions>();
   const resolve = (overrides: Partial<ConfigOverrides> = {}): Config =>
@@ -954,63 +960,114 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
 
   program
     .command("export")
-    .description("export a session to Markdown or JSON")
+    .description("export a session to Markdown, JSON, or a trajectory-v1 record file")
     .argument("[id]", "session id", optionalInteger)
     .option("--all", "export every session")
+    .option("--include-subagents", "with --all, also export subagent sessions")
+    .option("--format <format>", "md | json | trajectory (default: md, or json with --json)")
     .option("--out <dir>", "output directory")
-    .action((id: number | undefined, commandOptions: { all?: boolean; out?: string }) =>
-      run(() => {
-        const archive = readArchive();
-        try {
-          const ext = isJson(globals()) ? "json" : "md";
-          const render = (sessionId: number): string | null => {
-            const detail = getSession(archive.db, sessionId);
-            if (detail == null) {
-              return null;
-            }
-            return isJson(globals()) ? JSON.stringify(detail, null, 2) : toMarkdown(detail);
-          };
-
-          if (commandOptions.all === true) {
-            if (commandOptions.out == null) {
-              io.writeErr("error: --all requires --out <dir>\n");
-              return 2;
-            }
-            mkdirSync(commandOptions.out, { recursive: true });
-            let count = 0;
-            for (const session of listSessions(archive.db, { limit: Number.MAX_SAFE_INTEGER })) {
-              const content = render(session.id);
-              if (content != null) {
-                writeFileSync(join(commandOptions.out, `${session.id}.${ext}`), content);
-                count += 1;
-              }
-            }
-            io.writeErr(`exported ${count} sessions to ${commandOptions.out}\n`);
-            return 0;
-          }
-
-          if (id == null) {
-            io.writeErr("error: provide a session id, or --all --out <dir>\n");
+    .action(
+      (
+        id: number | undefined,
+        commandOptions: {
+          all?: boolean;
+          includeSubagents?: boolean;
+          format?: string;
+          out?: string;
+        },
+      ) =>
+        run(() => {
+          const format = commandOptions.format ?? (isJson(globals()) ? "json" : "md");
+          if (format !== "md" && format !== "json" && format !== "trajectory") {
+            io.writeErr(`error: unknown export format: ${format}\n`);
             return 2;
           }
-          const content = render(id);
-          if (content == null) {
-            io.writeErr(`error: no session with id ${id}\n`);
-            return 1;
+          const archive = readArchive();
+          try {
+            const ext = format === "md" ? "md" : format === "json" ? "json" : "trajectory.json";
+            const render = (sessionId: number): { content: string } | { error: string } => {
+              if (format === "trajectory") {
+                const out = exportTrajectory(archive.db, sessionId);
+                if (!out.ok) {
+                  return out.reason === "not_found"
+                    ? { error: `no session with id ${sessionId}` }
+                    : {
+                        error:
+                          `session ${sessionId} has no ` +
+                          `${out.reason === "missing_user_records" ? "user" : "assistant"} ` +
+                          "records; not exportable as a trajectory",
+                      };
+                }
+                if (!globals().quiet) {
+                  const repairs = Object.entries(out.report)
+                    .filter(([key, value]) => key !== "dropped_blocks" && (value as number) > 0)
+                    .map(([key, value]) => `${key}=${value}`)
+                    .join(" ");
+                  if (repairs !== "") {
+                    io.writeErr(`session ${sessionId}: ${repairs}\n`);
+                  }
+                }
+                return { content: JSON.stringify(out.records, null, 2) };
+              }
+              const detail = getSession(archive.db, sessionId);
+              if (detail == null) {
+                return { error: `no session with id ${sessionId}` };
+              }
+              return {
+                content: format === "json" ? JSON.stringify(detail, null, 2) : toMarkdown(detail),
+              };
+            };
+
+            if (commandOptions.all === true) {
+              if (commandOptions.out == null) {
+                io.writeErr("error: --all requires --out <dir>\n");
+                return 2;
+              }
+              mkdirSync(commandOptions.out, { recursive: true });
+              let count = 0;
+              let skipped = 0;
+              const sessions = listSessions(archive.db, {
+                limit: Number.MAX_SAFE_INTEGER,
+                includeSubagents: commandOptions.includeSubagents === true,
+              });
+              for (const session of sessions) {
+                const rendered = render(session.id);
+                if ("error" in rendered) {
+                  skipped += 1;
+                  continue;
+                }
+                writeFileSync(join(commandOptions.out, `${session.id}.${ext}`), rendered.content);
+                count += 1;
+              }
+              io.writeErr(
+                `exported ${count} sessions to ${commandOptions.out}` +
+                  `${skipped > 0 ? ` (${skipped} skipped)` : ""}\n`,
+              );
+              return 0;
+            }
+
+            if (id == null) {
+              io.writeErr("error: provide a session id, or --all --out <dir>\n");
+              return 2;
+            }
+            const rendered = render(id);
+            if ("error" in rendered) {
+              io.writeErr(`error: ${rendered.error}\n`);
+              return 1;
+            }
+            if (commandOptions.out != null) {
+              mkdirSync(commandOptions.out, { recursive: true });
+              const path = join(commandOptions.out, `${id}.${ext}`);
+              writeFileSync(path, rendered.content);
+              io.writeErr(`wrote ${path}\n`);
+            } else {
+              io.writeOut(`${rendered.content}\n`);
+            }
+            return 0;
+          } finally {
+            archive.db.close();
           }
-          if (commandOptions.out != null) {
-            mkdirSync(commandOptions.out, { recursive: true });
-            const path = join(commandOptions.out, `${id}.${ext}`);
-            writeFileSync(path, content);
-            io.writeErr(`wrote ${path}\n`);
-          } else {
-            io.writeOut(`${content}\n`);
-          }
-          return 0;
-        } finally {
-          archive.db.close();
-        }
-      }),
+        }),
     );
 
   try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -212,6 +212,7 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
         ingested: report.ingested,
         skipped: report.skipped,
         issues: report.issues,
+        issues_by_code: report.issuesByCode,
         failed: report.failed,
       };
       if (isJson(globals())) {
@@ -222,7 +223,10 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
             `${report.skipped} skipped, ${report.issues} issues, ${report.failed} failed\n`,
         );
       }
-      return report.issues > 0 ? 3 : 0;
+      // Exit 3 means decant dropped source content, which is what an unparsed
+      // line is. The other codes are sensors over content that did land, so
+      // they are reported without failing the command.
+      return (report.issuesByCode.unparsed_line ?? 0) > 0 ? 3 : 0;
     } finally {
       archive.db.close();
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -163,13 +163,7 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
     .option("--format <format>", "output format (table | json | md)", parseOutputFormat)
     .option("-q, --quiet", "suppress non-essential output")
     .option("--no-color", "disable ANSI color")
-    .option("--no-sync", "skip sync-on-read, and serve without the source watcher")
-    // export's own --format (md | json | trajectory) reuses this flag name for a
-    // command-specific purpose. Without positional options, Commander resolves
-    // --format anywhere in argv against this global first, regardless of where
-    // it appears — this scopes it to "before the subcommand name" so a
-    // subcommand's own same-named option governs anything typed after it.
-    .enablePositionalOptions();
+    .option("--no-sync", "skip sync-on-read, and serve without the source watcher");
 
   const globals = (): GlobalOptions => program.opts<GlobalOptions>();
   const resolve = (overrides: Partial<ConfigOverrides> = {}): Config =>
@@ -964,7 +958,11 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
     .argument("[id]", "session id", optionalInteger)
     .option("--all", "export every session")
     .option("--include-subagents", "with --all, also export subagent sessions")
-    .option("--format <format>", "md | json | trajectory (default: md, or json with --json)")
+    // Named --as, not --format, to match `distill script --as` rather than
+    // collide with the global --format table|json|md: Commander resolves a
+    // global option's flag anywhere in argv (before or after a subcommand),
+    // so a same-named local option on export would be shadowed by the root's.
+    .option("--as <format>", "md | json | trajectory (default: md, or json with --json)")
     .option("--out <dir>", "output directory")
     .action(
       (
@@ -972,12 +970,12 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
         commandOptions: {
           all?: boolean;
           includeSubagents?: boolean;
-          format?: string;
+          as?: string;
           out?: string;
         },
       ) =>
         run(() => {
-          const format = commandOptions.format ?? (isJson(globals()) ? "json" : "md");
+          const format = commandOptions.as ?? (isJson(globals()) ? "json" : "md");
           if (format !== "md" && format !== "json" && format !== "trajectory") {
             io.writeErr(`error: unknown export format: ${format}\n`);
             return 2;

--- a/src/db.ts
+++ b/src/db.ts
@@ -14,7 +14,7 @@ import schemaSql from "./schema.sql" with { type: "text" };
 /// effective DDL with migrations 1..LATEST_SCHEMA_VERSION already applied
 /// and is now the frozen baseline, so a fresh archive is created in one step
 /// and stamped with the full migration history.
-export const LATEST_SCHEMA_VERSION = 15;
+export const LATEST_SCHEMA_VERSION = 16;
 
 /// Owner-only mode for the archive and its SQLite sidecars. The transcripts
 /// decant ingests sit in 0600 files under 0700 directories; the aggregate of
@@ -307,6 +307,29 @@ function migrate(db: Database, current: number): void {
       }
       db.query(
         "INSERT INTO schema_migrations (version, applied_at) VALUES (15, datetime('now'))",
+      ).run();
+    }
+    if (current < 16) {
+      // Claude Code's dynamic-workflow runs write orchestration journals
+      // (subagents/workflows/<runId>/journal.jsonl). Builds before v16 swept
+      // them up as sessions with role-"other" messages; discovery now skips
+      // them, and this drops the rows those builds created. Detach children
+      // first: session.parent_session_id has no ON DELETE clause.
+      db.exec(`
+        UPDATE session SET parent_session_id = NULL
+        WHERE parent_session_id IN (
+          SELECT id FROM session
+          WHERE source_path LIKE '%/journal.jsonl' OR source_path LIKE '%\\journal.jsonl'
+        );
+        DELETE FROM session
+        WHERE source_path LIKE '%/journal.jsonl' OR source_path LIKE '%\\journal.jsonl';
+        DELETE FROM ingest_issue
+        WHERE source_path LIKE '%/journal.jsonl' OR source_path LIKE '%\\journal.jsonl';
+        DELETE FROM ingest_source
+        WHERE path LIKE '%/journal.jsonl' OR path LIKE '%\\journal.jsonl';
+      `);
+      db.query(
+        "INSERT INTO schema_migrations (version, applied_at) VALUES (16, datetime('now'))",
       ).run();
     }
     db.exec("COMMIT;");

--- a/src/db.ts
+++ b/src/db.ts
@@ -14,7 +14,7 @@ import schemaSql from "./schema.sql" with { type: "text" };
 /// effective DDL with migrations 1..LATEST_SCHEMA_VERSION already applied
 /// and is now the frozen baseline, so a fresh archive is created in one step
 /// and stamped with the full migration history.
-export const LATEST_SCHEMA_VERSION = 16;
+export const LATEST_SCHEMA_VERSION = 17;
 
 /// Owner-only mode for the archive and its SQLite sidecars. The transcripts
 /// decant ingests sit in 0600 files under 0700 directories; the aggregate of
@@ -330,6 +330,17 @@ function migrate(db: Database, current: number): void {
       `);
       db.query(
         "INSERT INTO schema_migrations (version, applied_at) VALUES (16, datetime('now'))",
+      ).run();
+    }
+    if (current < 17) {
+      if (!hasColumn(db, "ingest_issue", "code")) {
+        // Every pre-v17 issue row was a parse failure by construction —
+        // parsers emitted issues only from JSON.parse catch blocks.
+        db.exec("ALTER TABLE ingest_issue ADD COLUMN code TEXT NOT NULL DEFAULT 'unparsed_line'");
+      }
+      db.exec("CREATE INDEX IF NOT EXISTS idx_ingest_issue_source ON ingest_issue(source_path)");
+      db.query(
+        "INSERT INTO schema_migrations (version, applied_at) VALUES (17, datetime('now'))",
       ).run();
     }
     db.exec("COMMIT;");

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,51 @@
+// Cross-message linkage diagnostics over a parsed session. Pure and
+// print-free: parsers append the result to ParsedSession.issues so ingest
+// stores one complete diagnostic set per source file.
+import type { Issue, NormalizedSession } from "./model.ts";
+
+export function linkageIssues(session: NormalizedSession): Issue[] {
+  const issues: Issue[] = [];
+  const useIds = new Map<string, string | null>();
+  for (const message of session.messages) {
+    for (const block of message.blocks) {
+      if (block.blockType !== "tool_use" || block.toolUseId == null) {
+        continue;
+      }
+      if (useIds.has(block.toolUseId)) {
+        issues.push({
+          code: "duplicate_tool_use_id",
+          lineNo: null,
+          error: `tool_use id "${block.toolUseId}" appears more than once (${block.toolName ?? "unknown tool"})`,
+          rawLine: null,
+        });
+      }
+      useIds.set(block.toolUseId, block.toolName);
+    }
+  }
+  const answered = new Set<string>();
+  for (const message of session.messages) {
+    for (const block of message.blocks) {
+      if (block.blockType !== "tool_result" || block.toolUseId == null) {
+        continue;
+      }
+      if (!useIds.has(block.toolUseId)) {
+        issues.push({
+          code: "orphan_tool_result",
+          lineNo: null,
+          error: `tool_result references tool_use id "${block.toolUseId}" absent from the session`,
+          rawLine: null,
+        });
+      }
+      if (answered.has(block.toolUseId)) {
+        issues.push({
+          code: "duplicate_tool_result",
+          lineNo: null,
+          error: `tool_use id "${block.toolUseId}" received more than one result`,
+          rawLine: null,
+        });
+      }
+      answered.add(block.toolUseId);
+    }
+  }
+  return issues;
+}

--- a/src/export.ts
+++ b/src/export.ts
@@ -116,9 +116,116 @@ function trajectoryTruncate(text: string, max: number): { text: string; truncate
   return { text: `${head}${marker}${tail}`, truncated: true };
 }
 
+interface TrajectoryLeaf {
+  original: string;
+  current: string;
+  set: (value: string) => void;
+}
+
+/** Every string leaf reachable in the args object, arrays included, each with a
+ * setter that writes back into its own container. */
+function trajectoryCollectLeaves(value: unknown, leaves: TrajectoryLeaf[]): void {
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const child = value[index];
+      if (typeof child === "string") {
+        leaves.push({
+          original: child,
+          current: child,
+          set: (next) => {
+            value[index] = next;
+          },
+        });
+      } else if (child !== null && typeof child === "object") {
+        trajectoryCollectLeaves(child, leaves);
+      }
+    }
+    return;
+  }
+  if (value === null || typeof value !== "object") {
+    return;
+  }
+  const record = value as Record<string, unknown>;
+  for (const [key, child] of Object.entries(record)) {
+    if (typeof child === "string") {
+      leaves.push({
+        original: child,
+        current: child,
+        set: (next) => {
+          record[key] = next;
+        },
+      });
+    } else if (child !== null && typeof child === "object") {
+      trajectoryCollectLeaves(child, leaves);
+    }
+  }
+}
+
+/** Shrink an over-cap args object into the cap while keeping its field
+ * structure, by truncating string leaves largest-first in place. Returns the
+ * serialization once it fits, or null when the overage does not live in the
+ * string leaves (many small fields, or bulk in the keys) and only a `_raw` wrap
+ * can help. `parsed` is mutated either way.
+ *
+ * Their core.ts has two of these; this follows the strictly decreasing one
+ * (`shrinkObjectArgsSafely`), not the legacy loop whose hard 2 000-character
+ * per-leaf floor can spin forever or return an over-cap object — the bug their
+ * PARITY.md records as a 21,560-character object escaping a 20,000 cap. Two
+ * things make termination unconditional here: a leaf no longer than the marker
+ * cannot shrink usefully, so shrinking stops rather than retrying it, and an
+ * iteration that shortens nothing gives up instead of looping. */
+function trajectoryShrinkLeaves(parsed: object, limit: number): string | null {
+  const leaves: TrajectoryLeaf[] = [];
+  trajectoryCollectLeaves(parsed, leaves);
+  const markerFloor = [...trajectoryMarker(0)].length;
+  let serialized = JSON.stringify(parsed);
+  while ([...serialized].length > limit) {
+    let largest: TrajectoryLeaf | undefined;
+    let largestLen = 0;
+    for (const leaf of leaves) {
+      const length = [...leaf.current].length;
+      if (length > largestLen) {
+        largest = leaf;
+        largestLen = length;
+      }
+    }
+    if (largest == null || largestLen <= markerFloor) {
+      return null;
+    }
+    // Cut only as much of the biggest leaf as the overage needs, so an object
+    // barely over the cap keeps nearly all of its content. The overage is
+    // measured on the serialized form and the leaf in code points, and escaping
+    // makes those differ, so a gentle cut can fail to shrink the serialization
+    // at all; halving always shrinks it for a leaf longer than the marker, and
+    // is the fallback whenever the gentle cut does not land. Truncating from the
+    // leaf's original text keeps the marker's dropped-count honest across
+    // repeated passes over the same leaf.
+    const before = [...serialized].length;
+    const halved = Math.floor(largestLen / 2);
+    const gentle = Math.max(halved, Math.min(largestLen - 1, largestLen - (before - limit) - 1));
+    let shrank = false;
+    for (const target of gentle > halved ? [gentle, halved] : [halved]) {
+      const { text } = trajectoryTruncate(largest.original, target);
+      largest.set(text);
+      largest.current = text;
+      serialized = JSON.stringify(parsed);
+      if ([...serialized].length < before) {
+        shrank = true;
+        break;
+      }
+    }
+    if (!shrank) {
+      return null;
+    }
+  }
+  return serialized;
+}
+
 /** Serialize tool args as a JSON object string within the cap. Non-object args
- * are reshaped to {"_raw": <string>} (their tool_arguments_reshaped move); an
- * over-cap object degrades to a truncated {"_raw": ...} wrap. */
+ * are reshaped to {"_raw": <string>} (their tool_arguments_reshaped move). An
+ * over-cap object keeps its field structure by shrinking its string leaves, and
+ * degrades to a truncated {"_raw": ...} wrap only if that cannot reach the
+ * cap. */
 function trajectoryArgs(toolInput: string | null, report: TrajectoryReport): string {
   let parsed: unknown;
   try {
@@ -131,7 +238,15 @@ function trajectoryArgs(toolInput: string | null, report: TrajectoryReport): str
   if (serialized != null && [...serialized].length <= TRAJECTORY_ARGS_MAX) {
     return serialized;
   }
+  if (serialized != null) {
+    const shrunk = trajectoryShrinkLeaves(parsed as object, TRAJECTORY_ARGS_MAX);
+    if (shrunk != null) {
+      report.tool_args_wrapped += 1;
+      return shrunk;
+    }
+  }
   report.tool_args_wrapped += 1;
+  // `serialized` predates any leaf shrinking, so the wrap carries the original.
   const raw = serialized ?? toolInput ?? "";
   // Budget for {"_raw":""} scaffolding + escaping: truncate the payload, then
   // shrink until the serialized wrapper fits (escaping can expand length).

--- a/src/export.ts
+++ b/src/export.ts
@@ -190,11 +190,14 @@ export function exportTrajectory(db: Database, sessionId: number): TrajectoryExp
     report.dropped_blocks[kind] = (report.dropped_blocks[kind] ?? 0) + 1;
   };
 
-  // Pass 1: assign globally unique call ids in appearance order; queue renames
-  // so results pair with their call temporally (first result -> original id,
-  // second result for a duplicated id -> the renamed second call).
-  const idUses = new Map<string, number>();
-  const callIdBySite = new Map<string, string[]>(); // original id -> assigned ids in order
+  // Pass 1: assign globally unique call ids in appearance order. A name already
+  // taken is renamed by probing `__dup<n>` upward until the candidate is unused
+  // (their core.ts move): a fixed `__dup2` would collide when the source itself
+  // contains an id that already looks like one of our renames. Each original id
+  // keeps a queue of the names it was assigned, so pass 2 reads the strings back
+  // instead of recomputing a suffix it can no longer predict.
+  const assignedByOriginal = new Map<string, string[]>();
+  const usedIds = new Set<string>();
   let callSites = 0;
   for (const message of detail.messages) {
     if (!isTrajectoryWireRole(message.role)) {
@@ -209,20 +212,25 @@ export function exportTrajectory(db: Database, sessionId: number): TrajectoryExp
       if (block.tool_use_id == null) {
         report.tool_call_ids_synthesized += 1;
       }
-      const seen = idUses.get(original) ?? 0;
-      idUses.set(original, seen + 1);
-      const assigned = seen === 0 ? original : `${original}__dup${seen + 1}`;
-      if (seen > 0) {
+      let assigned = original;
+      if (usedIds.has(assigned)) {
+        let suffix = 2;
+        while (usedIds.has(`${original}__dup${suffix}`)) {
+          suffix += 1;
+        }
+        assigned = `${original}__dup${suffix}`;
         report.tool_call_ids_renamed += 1;
       }
-      const queue = callIdBySite.get(original) ?? [];
+      usedIds.add(assigned);
+      const queue = assignedByOriginal.get(original) ?? [];
       queue.push(assigned);
-      callIdBySite.set(original, queue);
+      assignedByOriginal.set(original, queue);
     }
   }
 
   // Pass 2: emit records.
   const records: unknown[] = [];
+  const callTaken = new Map<string, number>(); // original id -> calls emitted
   const resultTaken = new Map<string, number>(); // original id -> results consumed
   const answered = new Set<string>(); // assigned ids with a result already
   let lastTimestamp: string | null = null;
@@ -296,7 +304,9 @@ export function exportTrajectory(db: Database, sessionId: number): TrajectoryExp
       } else if (block.block_type === "tool_use") {
         callEmit += 1;
         const original = block.tool_use_id ?? `decant-${sessionId}-${callEmit}`;
-        const assigned = callIdBySite.get(original)?.shift() ?? original;
+        const emitted = callTaken.get(original) ?? 0;
+        callTaken.set(original, emitted + 1);
+        const assigned = assignedByOriginal.get(original)?.[emitted] ?? original;
         const name =
           block.tool_name != null && block.tool_name !== "" ? block.tool_name : "unknown_tool";
         records.push({
@@ -308,15 +318,16 @@ export function exportTrajectory(db: Database, sessionId: number): TrajectoryExp
         assistantCount += 1;
       } else if (block.block_type === "tool_result") {
         const original = block.tool_use_id;
-        const totalCalls = original == null ? undefined : idUses.get(original);
-        if (original == null || totalCalls == null) {
+        const queue = original == null ? undefined : assignedByOriginal.get(original);
+        if (original == null || queue == null) {
           report.orphan_tool_results_dropped += 1;
           continue;
         }
         const taken = resultTaken.get(original) ?? 0;
-        const targetIndex = Math.min(taken, totalCalls - 1);
-        const assigned = targetIndex === 0 ? original : `${original}__dup${targetIndex + 1}`;
-        if (answered.has(assigned) && taken >= totalCalls) {
+        // Pair with the call this result answers by position, reading back the
+        // name pass 1 assigned it. Queues are never empty, so the index holds.
+        const assigned = queue[Math.min(taken, queue.length - 1)] ?? original;
+        if (answered.has(assigned) && taken >= queue.length) {
           report.duplicate_tool_results_dropped += 1;
           continue;
         }

--- a/src/export.ts
+++ b/src/export.ts
@@ -357,7 +357,10 @@ export function exportTrajectory(db: Database, sessionId: number): TrajectoryExp
     if (raw == null) {
       return null;
     }
-    const withZone = /(Z|[+-]\d{2}:?\d{2})$/.test(raw) ? raw : `${raw}Z`;
+    // Bare ±hh is a valid ISO-8601 offset: recognize it so we never corrupt
+    // it with an appended Z. (Bun's Date cannot parse bare ±hh either way, so
+    // such stamps still fall through to the fill ladder — but as themselves.)
+    const withZone = /(Z|[+-]\d{2}(?::?\d{2})?)$/.test(raw) ? raw : `${raw}Z`;
     const date = new Date(withZone);
     return Number.isNaN(date.getTime()) ? null : date.toISOString();
   };

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,4 +1,5 @@
-import type { SessionDetail } from "./query.ts";
+import type { Database } from "bun:sqlite";
+import { getSession, type SessionDetail } from "./query.ts";
 
 export function toMarkdown(detail: SessionDetail): string {
   const summary = detail.summary;
@@ -34,4 +35,328 @@ export function toMarkdown(detail: SessionDetail): string {
     }
   }
   return out;
+}
+
+// trajectory-v1 emission (letta-ai/trajectory schema/trajectory-v1.schema.json).
+// One JSON array per session: meta first, then per-block records. Their runtime
+// validator is stricter than the schema; the rules enforced here are: meta at
+// index 0 exactly once, args always a serialized JSON object, globally unique
+// tool-call ids, results only for calls that exist, >=1 user and >=1 assistant.
+
+const TRAJECTORY_SOURCES: Record<string, string> = {
+  claude_code: "claude-code",
+  codex: "codex",
+};
+
+/** Their core.ts NOISE_PREFIXES, applied to user text so downstream consumers
+ * see the cleaning trajectory-native pipelines expect. The last entry has no
+ * closing ">" by design — it matches attribute forms. */
+const TRAJECTORY_NOISE_PREFIXES = [
+  "<local-command-caveat>",
+  "<command-name>",
+  "<command-message>",
+  "<local-command-stdout>",
+  "<local-command-stderr>",
+  "<task-notification",
+];
+
+const TRAJECTORY_ARGS_MAX = 20_000;
+const TRAJECTORY_RESULT_MAX = 2_500;
+const TRAJECTORY_SYNTH_BASE_MS = Date.UTC(2026, 0, 1);
+const TRAJECTORY_SYNTH_STEP_SECONDS = 15;
+
+/** decant roles with a trajectory wire equivalent. `system`/`other` messages
+ * have none and are dropped whole. `tool` is in: decant files a result-only
+ * message under role `tool` and a text+result message under `user`, so tool
+ * results reach the wire only if both roles are walked. Both emission passes
+ * filter on this so the calls registered in pass 1 are exactly what pass 2
+ * emits. */
+function isTrajectoryWireRole(role: string): boolean {
+  return role === "user" || role === "assistant" || role === "tool";
+}
+
+function trajectoryMarker(remaining: number): string {
+  return `\n… [truncated, ${remaining} more chars]`;
+}
+
+/** Marker-inclusive head-tail truncation in Unicode code points, ported from
+ * trajectory's truncateText: the marker sits mid-string and counts against the
+ * limit, and head takes the odd code point (head = ceil half). The marker
+ * announces how many code points were dropped, so its own length depends on the
+ * budget — hence the binary search for the largest budget that still fits. */
+function trajectoryTruncate(text: string, max: number): { text: string; truncated: boolean } {
+  const chars = [...text];
+  if (chars.length <= max) {
+    return { text, truncated: false };
+  }
+  let low = 0;
+  let high = Math.min(chars.length - 1, max);
+  let keep = -1;
+  let marker = "";
+  while (low <= high) {
+    const candidate = Math.floor((low + high) / 2);
+    const candidateMarker = trajectoryMarker(chars.length - candidate);
+    if (candidate + [...candidateMarker].length <= max) {
+      keep = candidate;
+      marker = candidateMarker;
+      low = candidate + 1;
+    } else {
+      high = candidate - 1;
+    }
+  }
+  if (keep < 0) {
+    // Budgets too small for the descriptive marker degrade to a bare ellipsis.
+    marker = [..."…"].slice(0, max).join("");
+    keep = max - [...marker].length;
+  }
+  const headLen = Math.ceil(keep / 2);
+  const tailLen = keep - headLen;
+  const head = chars.slice(0, headLen).join("");
+  const tail = tailLen > 0 ? chars.slice(chars.length - tailLen).join("") : "";
+  return { text: `${head}${marker}${tail}`, truncated: true };
+}
+
+/** Serialize tool args as a JSON object string within the cap. Non-object args
+ * are reshaped to {"_raw": <string>} (their tool_arguments_reshaped move); an
+ * over-cap object degrades to a truncated {"_raw": ...} wrap. */
+function trajectoryArgs(toolInput: string | null, report: TrajectoryReport): string {
+  let parsed: unknown;
+  try {
+    parsed = toolInput == null ? {} : JSON.parse(toolInput);
+  } catch {
+    parsed = undefined;
+  }
+  const isPlainObject = typeof parsed === "object" && parsed !== null && !Array.isArray(parsed);
+  const serialized = isPlainObject ? JSON.stringify(parsed) : null;
+  if (serialized != null && [...serialized].length <= TRAJECTORY_ARGS_MAX) {
+    return serialized;
+  }
+  report.tool_args_wrapped += 1;
+  const raw = serialized ?? toolInput ?? "";
+  // Budget for {"_raw":""} scaffolding + escaping: truncate the payload, then
+  // shrink until the serialized wrapper fits (escaping can expand length).
+  let budget = TRAJECTORY_ARGS_MAX - 12;
+  let wrapped: string;
+  do {
+    const { text } = trajectoryTruncate(raw, Math.max(2, budget));
+    wrapped = JSON.stringify({ _raw: text });
+    budget = Math.floor(budget / 2);
+  } while ([...wrapped].length > TRAJECTORY_ARGS_MAX && budget > 2);
+  return wrapped;
+}
+
+interface TrajectorySessionRow {
+  cwd: string | null;
+  git_branch: string | null;
+}
+
+export interface TrajectoryReport {
+  dropped_blocks: Record<string, number>;
+  noise_user_records_dropped: number;
+  orphan_tool_results_dropped: number;
+  duplicate_tool_results_dropped: number;
+  tool_call_ids_synthesized: number;
+  tool_call_ids_renamed: number;
+  tool_args_wrapped: number;
+  tool_results_truncated: number;
+  timestamps_filled: number;
+}
+
+export type TrajectoryExport =
+  | { ok: true; records: unknown[]; report: TrajectoryReport }
+  | { ok: false; reason: "not_found" | "missing_user_records" | "missing_assistant_records" };
+
+export function exportTrajectory(db: Database, sessionId: number): TrajectoryExport {
+  const detail = getSession(db, sessionId);
+  if (detail == null) {
+    return { ok: false, reason: "not_found" };
+  }
+  const row = db
+    .query("SELECT cwd, git_branch FROM session WHERE id = ?1")
+    .get(sessionId) as TrajectorySessionRow | null;
+
+  const report: TrajectoryReport = {
+    dropped_blocks: {},
+    noise_user_records_dropped: 0,
+    orphan_tool_results_dropped: 0,
+    duplicate_tool_results_dropped: 0,
+    tool_call_ids_synthesized: 0,
+    tool_call_ids_renamed: 0,
+    tool_args_wrapped: 0,
+    tool_results_truncated: 0,
+    timestamps_filled: 0,
+  };
+  const drop = (kind: string): void => {
+    report.dropped_blocks[kind] = (report.dropped_blocks[kind] ?? 0) + 1;
+  };
+
+  // Pass 1: assign globally unique call ids in appearance order; queue renames
+  // so results pair with their call temporally (first result -> original id,
+  // second result for a duplicated id -> the renamed second call).
+  const idUses = new Map<string, number>();
+  const callIdBySite = new Map<string, string[]>(); // original id -> assigned ids in order
+  let callSites = 0;
+  for (const message of detail.messages) {
+    if (!isTrajectoryWireRole(message.role)) {
+      continue;
+    }
+    for (const block of message.blocks) {
+      if (block.block_type !== "tool_use") {
+        continue;
+      }
+      callSites += 1;
+      const original = block.tool_use_id ?? `decant-${sessionId}-${callSites}`;
+      if (block.tool_use_id == null) {
+        report.tool_call_ids_synthesized += 1;
+      }
+      const seen = idUses.get(original) ?? 0;
+      idUses.set(original, seen + 1);
+      const assigned = seen === 0 ? original : `${original}__dup${seen + 1}`;
+      if (seen > 0) {
+        report.tool_call_ids_renamed += 1;
+      }
+      const queue = callIdBySite.get(original) ?? [];
+      queue.push(assigned);
+      callIdBySite.set(original, queue);
+    }
+  }
+
+  // Pass 2: emit records.
+  const records: unknown[] = [];
+  const resultTaken = new Map<string, number>(); // original id -> results consumed
+  const answered = new Set<string>(); // assigned ids with a result already
+  let lastTimestamp: string | null = null;
+  let synthIndex = 0;
+  // Their library always emits Date#toISOString() output; normalize source
+  // timestamps the same way. Unparseable values count as missing and are
+  // filled (last-seen, then session start, then their synthetic-base ladder).
+  const toIsoZ = (raw: string | null): string | null => {
+    if (raw == null) {
+      return null;
+    }
+    const withZone = /(Z|[+-]\d{2}:?\d{2})$/.test(raw) ? raw : `${raw}Z`;
+    const date = new Date(withZone);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  };
+  // Counts filled timestamps per emitted record: dropped blocks never ask.
+  const timestampFor = (raw: string | null): string => {
+    const normalized = toIsoZ(raw);
+    if (normalized != null) {
+      lastTimestamp = normalized;
+      return normalized;
+    }
+    report.timestamps_filled += 1;
+    if (lastTimestamp != null) {
+      return lastTimestamp;
+    }
+    const started = toIsoZ(detail.summary.started_at);
+    if (started != null) {
+      lastTimestamp = started;
+      return started;
+    }
+    synthIndex += 1;
+    return new Date(
+      TRAJECTORY_SYNTH_BASE_MS + synthIndex * TRAJECTORY_SYNTH_STEP_SECONDS * 1000,
+    ).toISOString();
+  };
+
+  let userCount = 0;
+  let assistantCount = 0;
+  let callEmit = 0;
+  for (const message of detail.messages) {
+    if (!isTrajectoryWireRole(message.role)) {
+      if (message.blocks.length > 0) {
+        drop(`${message.role}_message`);
+      }
+      continue;
+    }
+    const timestamp = (): string => timestampFor(message.timestamp);
+    for (const block of message.blocks) {
+      const text = block.text ?? "";
+      const hasText = text.trim() !== "";
+      if (block.block_type === "text" && hasText) {
+        if (message.role === "user") {
+          const trimmed = text.trimStart();
+          if (TRAJECTORY_NOISE_PREFIXES.some((prefix) => trimmed.startsWith(prefix))) {
+            report.noise_user_records_dropped += 1;
+            continue;
+          }
+          records.push({ role: "user", content: text, timestamp: timestamp() });
+          userCount += 1;
+        } else if (message.role === "assistant") {
+          records.push({ role: "assistant", content: text, timestamp: timestamp() });
+          assistantCount += 1;
+        } else {
+          // Prose on a `tool`-role message has no wire equivalent: speaking it
+          // as either party would misattribute it.
+          drop(`${message.role}_text`);
+        }
+      } else if (block.block_type === "thinking" && hasText) {
+        records.push({ role: "reasoning", content: text, timestamp: timestamp() });
+      } else if (block.block_type === "tool_use") {
+        callEmit += 1;
+        const original = block.tool_use_id ?? `decant-${sessionId}-${callEmit}`;
+        const assigned = callIdBySite.get(original)?.shift() ?? original;
+        const name =
+          block.tool_name != null && block.tool_name !== "" ? block.tool_name : "unknown_tool";
+        records.push({
+          role: "assistant",
+          content: null,
+          tool_calls: [{ id: assigned, name, args: trajectoryArgs(block.tool_input, report) }],
+          timestamp: timestamp(),
+        });
+        assistantCount += 1;
+      } else if (block.block_type === "tool_result") {
+        const original = block.tool_use_id;
+        const totalCalls = original == null ? undefined : idUses.get(original);
+        if (original == null || totalCalls == null) {
+          report.orphan_tool_results_dropped += 1;
+          continue;
+        }
+        const taken = resultTaken.get(original) ?? 0;
+        const targetIndex = Math.min(taken, totalCalls - 1);
+        const assigned = targetIndex === 0 ? original : `${original}__dup${targetIndex + 1}`;
+        if (answered.has(assigned) && taken >= totalCalls) {
+          report.duplicate_tool_results_dropped += 1;
+          continue;
+        }
+        resultTaken.set(original, taken + 1);
+        answered.add(assigned);
+        const { text: content, truncated } = trajectoryTruncate(
+          block.tool_result ?? "",
+          TRAJECTORY_RESULT_MAX,
+        );
+        if (truncated) {
+          report.tool_results_truncated += 1;
+        }
+        records.push({ role: "tool", tool_call_id: assigned, content, timestamp: timestamp() });
+      } else {
+        // Empty text/thinking land here too: no wire content, so they are
+        // dropped and counted under their own block type.
+        drop(block.block_type);
+      }
+    }
+  }
+
+  if (userCount === 0) {
+    return { ok: false, reason: "missing_user_records" };
+  }
+  if (assistantCount === 0) {
+    return { ok: false, reason: "missing_assistant_records" };
+  }
+
+  const meta: Record<string, string> = {
+    role: "meta",
+    source: TRAJECTORY_SOURCES[detail.summary.tool] ?? detail.summary.tool,
+  };
+  if (row?.cwd != null && row.cwd !== "") {
+    meta.cwd = row.cwd;
+  }
+  if (row?.git_branch != null && row.git_branch !== "") {
+    meta.git_branch = row.git_branch;
+  }
+  if (detail.summary.model != null && detail.summary.model !== "") {
+    meta.model = detail.summary.model;
+  }
+  return { ok: true, records: [meta, ...records], report };
 }

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -48,6 +48,9 @@ export interface SyncReport {
   ingested: number;
   skipped: number;
   issues: number;
+  /** `issues` split by IngestIssueCode; only codes actually seen appear. Lets
+   * callers separate data loss (`unparsed_line`) from informational sensors. */
+  issuesByCode: Record<string, number>;
   failed: number;
   cancelled: boolean;
 }
@@ -106,6 +109,7 @@ export function sync(
     ingested: 0,
     skipped: 0,
     issues: 0,
+    issuesByCode: {},
     failed: 0,
     cancelled: false,
   };
@@ -162,6 +166,9 @@ export function sync(
     writeIngestedFile(db, prepared, parsed);
     report.ingested += 1;
     report.issues += parsed.issues.length;
+    for (const issue of parsed.issues) {
+      report.issuesByCode[issue.code] = (report.issuesByCode[issue.code] ?? 0) + 1;
+    }
   }
 
   resolveSubagentParents(db);
@@ -544,11 +551,11 @@ function writeIngestedFile(db: Database, prepared: Prepared, parsed: ParsedSessi
     );
     db.query("DELETE FROM ingest_issue WHERE source_path = ?1").run(prepared.file.path);
     const insertIssue = db.prepare(
-      `INSERT INTO ingest_issue(source_path, line_no, error, raw_line, created_at)
-       VALUES (?1, ?2, ?3, ?4, datetime('now'))`,
+      `INSERT INTO ingest_issue(source_path, line_no, error, raw_line, code, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'))`,
     );
     for (const issue of parsed.issues) {
-      insertIssue.run(prepared.file.path, issue.lineNo, issue.error, issue.rawLine);
+      insertIssue.run(prepared.file.path, issue.lineNo, issue.error, issue.rawLine, issue.code);
     }
     const status = parsed.issues.length === 0 ? "ok" : "ok_with_issues";
     db.query(

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -79,7 +79,7 @@ export function discover(config: IngestConfig): SourceFile[] {
   }
 
   const out: SourceFile[] = [];
-  collect(config.claudeDir, "claude_code", false, (name) => name.endsWith(".jsonl"), out);
+  collect(config.claudeDir, "claude_code", false, isClaudeSessionFile, out);
   collect(join(config.codexDir, "sessions"), "codex", false, isCodexRollout, out);
   collect(join(config.codexDir, "archived_sessions"), "codex", true, isCodexRollout, out);
   return out;
@@ -861,7 +861,7 @@ function collectSourcePath(path: string, out: SourceFile[]): void {
 
 function sourceFileForPath(path: string): SourceFile | null {
   const name = pathBasename(path);
-  if (!name.endsWith(".jsonl") || name === "session_index.jsonl") {
+  if (!name.endsWith(".jsonl") || name === "session_index.jsonl" || name === "journal.jsonl") {
     return null;
   }
   if (isCodexRollout(name)) {
@@ -881,6 +881,14 @@ function dedupeSourceFiles(files: SourceFile[]): SourceFile[] {
     unique.push(file);
   }
   return unique;
+}
+
+/** Claude Code also writes non-session JSONL into the projects tree; the only
+ * one today is the dynamic-workflow orchestration journal
+ * (subagents/workflows/<runId>/journal.jsonl). Session transcripts are
+ * <uuid>.jsonl mains and agent-*.jsonl subagents, which must keep flowing. */
+function isClaudeSessionFile(name: string): boolean {
+  return name.endsWith(".jsonl") && name !== "journal.jsonl";
 }
 
 function isCodexRollout(name: string): boolean {

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -34,7 +34,7 @@ import {
   materializeMissingSessionEconomics,
   materializeSessionEconomics,
 } from "./token-economics.ts";
-import { classifyTool, preview } from "./tools.ts";
+import { classifyTool, previewHeadTail } from "./tools.ts";
 import { resolveWorktreeRoots } from "./worktree.ts";
 
 export interface IngestConfig {
@@ -784,7 +784,7 @@ function writeSession(
       call.block.toolUseId,
       call.block.toolInput === undefined ? null : canonicalJson(call.block.toolInput),
       isError == null ? null : Number(isError),
-      output == null ? null : preview(output, 500),
+      output == null ? null : previewHeadTail(output, 500),
       output == null ? null : byteLength(output),
       call.block.ordinal,
       call.timestamp,

--- a/src/model.ts
+++ b/src/model.ts
@@ -170,10 +170,26 @@ export interface NormalizedSession {
   messages: NormalizedMessage[];
 }
 
+/** Wire strings stored in ingest_issue.code — never reworded (same contract
+ * as the const tuples above). `unparsed_line` is the only data-loss code;
+ * the rest are informational sensors. */
+export const INGEST_ISSUE_CODES = [
+  "unparsed_line",
+  "unknown_record_type",
+  "orphan_tool_result",
+  "duplicate_tool_use_id",
+  "duplicate_tool_result",
+] as const;
+export type IngestIssueCode = (typeof INGEST_ISSUE_CODES)[number];
+
 export interface Issue {
-  lineNo: number;
+  code: IngestIssueCode;
+  /** 1-based source line, when the issue is tied to a specific line. */
+  lineNo: number | null;
   error: string;
-  rawLine: string;
+  /** Verbatim source line for unparsed_line only. May contain transcript
+   * content: display-local, never logged (docs/logging.md). */
+  rawLine: string | null;
 }
 
 export interface ParsedSession {

--- a/src/query.ts
+++ b/src/query.ts
@@ -36,6 +36,8 @@ export interface SessionSummary {
   compaction_count: number;
   subagent_count: number;
   subagent_estimated_cost_usd: number;
+  /** Ingest diagnostics recorded against this session's source file. */
+  ingest_issue_count: number;
   subagents?: SessionSummary[];
 }
 
@@ -71,7 +73,9 @@ const SESSION_SUMMARY_SELECT = `
          s.agent_id, s.agent_type, s.spawn_depth,
          s.context_window_tokens, s.peak_context_tokens, s.compaction_count,
          COALESCE(sa.subagent_count, 0) AS subagent_count,
-         COALESCE(sa.subagent_estimated_cost_usd, 0.0) AS subagent_estimated_cost_usd
+         COALESCE(sa.subagent_estimated_cost_usd, 0.0) AS subagent_estimated_cost_usd,
+         (SELECT COUNT(*) FROM ingest_issue ii WHERE ii.source_path = s.source_path)
+           AS ingest_issue_count
   FROM session s
   LEFT JOIN project p ON p.id = s.project_id
   LEFT JOIN (
@@ -253,7 +257,9 @@ export function getSession(
               s.agent_id, s.agent_type, s.spawn_depth,
               s.context_window_tokens, s.peak_context_tokens, s.compaction_count,
               COALESCE(sa.subagent_count, 0) AS subagent_count,
-              COALESCE(sa.subagent_estimated_cost_usd, 0.0) AS subagent_estimated_cost_usd
+              COALESCE(sa.subagent_estimated_cost_usd, 0.0) AS subagent_estimated_cost_usd,
+              (SELECT COUNT(*) FROM ingest_issue ii WHERE ii.source_path = s.source_path)
+                AS ingest_issue_count
        FROM session s
        LEFT JOIN project p ON p.id = s.project_id
        LEFT JOIN (
@@ -457,6 +463,38 @@ export function getSessionOutline(db: Database, id: number): SessionOutlineItem[
   return rows
     .filter((row) => !parseMessageRawMeta(row.raw_meta).isCompactSummary)
     .map(({ seq, text }) => ({ seq, text }));
+}
+
+export interface SessionIngestIssue {
+  code: string;
+  line_no: number | null;
+  error: string;
+  raw_line: string | null;
+  created_at: string | null;
+}
+
+/**
+ * Issues recorded when this session's source file was last ingested. Null means
+ * no such session; an empty array means the file ingested cleanly.
+ *
+ * raw_line can contain transcript content: display-local, never logged.
+ */
+export function sessionIngestIssues(db: Database, sessionId: number): SessionIngestIssue[] | null {
+  const session = db.query("SELECT source_path FROM session WHERE id = ?1").get(sessionId) as {
+    source_path: string | null;
+  } | null;
+  if (session == null) {
+    return null;
+  }
+  if (session.source_path == null) {
+    return [];
+  }
+  return db
+    .query(
+      `SELECT code, line_no, error, raw_line, created_at
+       FROM ingest_issue WHERE source_path = ?1 ORDER BY id`,
+    )
+    .all(session.source_path) as SessionIngestIssue[];
 }
 
 function buildSubagentDetails(

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -801,7 +801,7 @@ function promotionCard(rec: StoredRecommendation): PromotionCard {
       "Format, lint, and tests run earlier with fewer end-of-task surprises.",
     ],
     "catalog:trajectory-export": [
-      "Connect and automate",
+      "Cold",
       "Export integration",
       "When building memory or evaluation pipelines with session data.",
       "Sessions flow into external memory and evaluation tools without manual export overhead.",

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -52,6 +52,8 @@ const SEARCH_HEAVY_RATIO = 5.0;
 const SEARCH_HEAVY_MIN_SESSIONS = 20;
 const ABANDONED_RATE = 0.25;
 const ABANDONED_MIN_CLASSIFIED = 10;
+const INGEST_HEALTH_MIN_SESSIONS = 15;
+const INGEST_HEALTH_MIN_SHARE = 0.1;
 const WINDOW = "s.started_at >= date('now','-30 days')";
 
 export function parseStatusFilter(value: string): StatusFilter | null {
@@ -73,6 +75,7 @@ export function signals(db: Database): Recommendation[] {
     ...churnFiles(db),
     ...searchHeavy(db),
     ...abandonedRate(db),
+    ...ingestHealth(db),
   ];
   out.sort((left, right) => right.score - left.score);
   return out.slice(0, 12);
@@ -594,6 +597,44 @@ function abandonedRate(db: Database): Recommendation[] {
       icon: "hero-hand-raised",
       tone: "danger",
       score: pct / 3,
+    },
+  ];
+}
+
+function ingestHealth(db: Database): Recommendation[] {
+  const counts = db
+    .query(
+      `SELECT COUNT(DISTINCT s.id) AS affected
+       FROM session s JOIN ingest_issue ii ON ii.source_path = s.source_path
+       WHERE ${WINDOW} AND ii.code != 'unparsed_line'`,
+    )
+    .get() as { affected: number };
+  const inWindow = (
+    db.query(`SELECT COUNT(*) AS n FROM session s WHERE ${WINDOW}`).get() as { n: number }
+  ).n;
+  if (inWindow < INGEST_HEALTH_MIN_SESSIONS || counts.affected === 0) {
+    return [];
+  }
+  const share = counts.affected / inWindow;
+  if (share < INGEST_HEALTH_MIN_SHARE) {
+    return [];
+  }
+  const pct = Math.round(share * 100);
+  return [
+    {
+      key: "signal:ingest-health",
+      kind: "signal",
+      category: null,
+      title: `${counts.affected} recent sessions ingested with diagnostics`,
+      detail: `${pct}% of the last 30 days' sessions carry ingest diagnostics (unknown record types or tool-linkage anomalies) — a source CLI likely changed its transcript format.`,
+      suggestion:
+        "Update decant to the latest release; if the diagnostics persist, file an issue with the output of `decant sync --json` (it includes per-code counts, no transcript content).",
+      prompt: null,
+      url: "https://github.com/dosu-ai/decant/issues",
+      link_label: "Report a format change",
+      icon: "hero-exclamation-triangle",
+      tone: "warning",
+      score: counts.affected * 2,
     },
   ];
 }

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -736,6 +736,16 @@ function promotionCard(rec: StoredRecommendation): PromotionCard {
       "Abandoned-session share drops below 25 percent.",
     );
   }
+  if (rec.key === "signal:ingest-health") {
+    return card(
+      "Governance",
+      "Release notes or upstream issue",
+      "When a source CLI's transcript format changes.",
+      evidence,
+      action,
+      "Diagnostic codes fall below the signal threshold.",
+    );
+  }
 
   const catalogCards: Record<string, [string, string, string, string]> = {
     "catalog:agents-md": [

--- a/src/recommendations.ts
+++ b/src/recommendations.ts
@@ -177,6 +177,16 @@ export function catalog(): Recommendation[] {
       "Hooks guide",
       "Set up Claude Code hooks for this repo to run format, lint, and tests automatically (for example on file edits and pre-commit), following the hooks guide.",
     ),
+    cat(
+      "trajectory-export",
+      "Connect and automate",
+      "hero-arrow-up-tray",
+      "Feed your sessions to memory tooling",
+      "Export archived sessions as trajectory-v1 records — the token-lean transcript format memory and evaluation pipelines consume. Your archive keeps sessions the CLIs have already pruned.",
+      "https://github.com/letta-ai/trajectory",
+      "trajectory format",
+      "Using `decant export --all --as trajectory --out <dir>` (add --project or date filters via ls to curate), export the sessions I care about and wire them into my memory/evaluation tooling of choice.",
+    ),
   ];
 }
 
@@ -789,6 +799,12 @@ function promotionCard(rec: StoredRecommendation): PromotionCard {
       "Hook or preflight gate",
       "Before changes drift away from the repo's validation contract.",
       "Format, lint, and tests run earlier with fewer end-of-task surprises.",
+    ],
+    "catalog:trajectory-export": [
+      "Connect and automate",
+      "Export integration",
+      "When building memory or evaluation pipelines with session data.",
+      "Sessions flow into external memory and evaluation tools without manual export overhead.",
     ],
   };
   const found = catalogCards[rec.key];

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1,6 +1,7 @@
--- decant:schema_version=15
+-- decant:schema_version=16
 -- Effective decant schema (migrations 1..15 applied), frozen as the current
--- baseline. Do not edit without updating schema tests.
+-- baseline. v16 is data-only (no DDL changes). Do not edit without updating
+-- schema tests.
 CREATE TABLE schema_migrations(
             version INTEGER PRIMARY KEY,
             applied_at TEXT NOT NULL

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1,7 +1,7 @@
--- decant:schema_version=16
--- Effective decant schema (migrations 1..15 applied), frozen as the current
--- baseline. v16 is data-only (no DDL changes). Do not edit without updating
--- schema tests.
+-- decant:schema_version=17
+-- Effective decant schema (migrations 1..17 applied), frozen as the current
+-- baseline. v16 is data-only (no DDL changes); v17 adds ingest_issue.code and
+-- idx_ingest_issue_source. Do not edit without updating schema tests.
 CREATE TABLE schema_migrations(
             version INTEGER PRIMARY KEY,
             applied_at TEXT NOT NULL
@@ -150,6 +150,7 @@ CREATE TABLE ingest_issue (
   source_path TEXT,
   line_no INTEGER,
   error TEXT,
+  code TEXT NOT NULL DEFAULT 'unparsed_line',
   raw_line TEXT,
   created_at TEXT
 );
@@ -213,6 +214,7 @@ CREATE INDEX idx_toolcall_call_block ON tool_call(call_block_id);
 CREATE INDEX idx_toolcall_result_block ON tool_call(result_block_id);
 CREATE INDEX idx_fileref_message ON file_ref(message_id);
 CREATE INDEX idx_ingest_source_session ON ingest_source(session_id);
+CREATE INDEX idx_ingest_issue_source ON ingest_issue(source_path);
 CREATE VIRTUAL TABLE block_fts USING fts5(
   text, tool_name, tool_input,
   content='block', content_rowid='id'

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,14 @@ import type { Operation } from "./enrich.ts";
 import type { sync as ingestSync } from "./ingest.ts";
 import { canLaunch, launchAgent, command as launchCommand, openIde } from "./launcher.ts";
 import { exceptionAttributes, logHttpRequest, type StructuredLogger } from "./logging.ts";
-import { getSession, getSessionOutline, listProjects, listSessions, search } from "./query.ts";
+import {
+  getSession,
+  getSessionOutline,
+  listProjects,
+  listSessions,
+  search,
+  sessionIngestIssues,
+} from "./query.ts";
 import {
   list as listRecommendations,
   markImplemented,
@@ -225,6 +232,13 @@ export async function handleRequest(
         return outline == null ? json({ error: "session not found" }, 404) : json(outline);
       });
     }
+    const sessionIssuesMatch = url.pathname.match(/^\/api\/sessions\/(\d+)\/issues$/);
+    if (request.method === "GET" && sessionIssuesMatch != null) {
+      return withDb(config, context, (db) => {
+        const issues = sessionIngestIssues(db, Number(sessionIssuesMatch[1]));
+        return issues == null ? json({ error: "session not found" }, 404) : json(issues);
+      });
+    }
     const sessionMatch = url.pathname.match(/^\/api\/sessions\/(\d+)$/);
     if (request.method === "GET" && sessionMatch != null) {
       return withDb(config, context, (db) => {
@@ -437,7 +451,15 @@ function runSyncWorker(
       cancelPoll = setInterval(() => {
         if (cancel.aborted) {
           settle();
-          resolve({ scanned: 0, ingested: 0, skipped: 0, issues: 0, failed: 0, cancelled: true });
+          resolve({
+            scanned: 0,
+            ingested: 0,
+            skipped: 0,
+            issues: 0,
+            issuesByCode: {},
+            failed: 0,
+            cancelled: true,
+          });
         }
       }, 150);
     }

--- a/src/sources/claude.ts
+++ b/src/sources/claude.ts
@@ -1,10 +1,12 @@
 import { isPriceable } from "../cost.ts";
+import { linkageIssues } from "../diagnostics.ts";
 import { canonicalJson } from "../json.ts";
 import {
   emptyUsage,
   type Json,
   type NormalizedBlock,
   type NormalizedMessage,
+  type NormalizedSession,
   type ParsedSession,
   type Role,
   reasoningEffortLevels,
@@ -204,35 +206,35 @@ export function parseClaudeSession(
   };
   const effortLevels = reasoningEffortLevels(reasoningEfforts);
 
-  return {
-    session: {
-      tool: "claude_code",
-      sourceSessionId,
-      projectPath: cwd,
-      title,
-      cwd,
-      gitBranch,
-      model,
-      reasoningEffort: summarizeReasoningEfforts(effortLevels),
-      reasoningEffortLevels: effortLevels,
-      cliVersion,
-      startedAt,
-      endedAt,
-      isArchived: false,
-      isSubagent,
-      rootSourceSessionId,
-      spawnToolUseId,
-      agentId,
-      agentType,
-      spawnDepth,
-      rawMeta,
-      totals,
-      estReasoningTokens,
-      reasoningSource: anyThinking ? "inferred" : "none",
-      messages,
-    },
-    issues,
+  const normalized: NormalizedSession = {
+    tool: "claude_code",
+    sourceSessionId,
+    projectPath: cwd,
+    title,
+    cwd,
+    gitBranch,
+    model,
+    reasoningEffort: summarizeReasoningEfforts(effortLevels),
+    reasoningEffortLevels: effortLevels,
+    cliVersion,
+    startedAt,
+    endedAt,
+    isArchived: false,
+    isSubagent,
+    rootSourceSessionId,
+    spawnToolUseId,
+    agentId,
+    agentType,
+    spawnDepth,
+    rawMeta,
+    totals,
+    estReasoningTokens,
+    reasoningSource: anyThinking ? "inferred" : "none",
+    messages,
   };
+  issues.push(...linkageIssues(normalized));
+
+  return { session: normalized, issues };
 }
 
 function lineReasoningInputs(message: NormalizedMessage): [number, number, boolean] {

--- a/src/sources/claude.ts
+++ b/src/sources/claude.ts
@@ -66,6 +66,7 @@ export function parseClaudeSession(
   let endedAt: string | null = null;
   let title: string | null = null;
   let seq = 0;
+  const unknownTypes = new Map<string, { count: number; firstLine: number }>();
 
   for (const [index, line] of content.split(/\n/).entries()) {
     if (line.trim() === "") {
@@ -77,6 +78,7 @@ export function parseClaudeSession(
       value = JSON.parse(line) as Json;
     } catch (error) {
       issues.push({
+        code: "unparsed_line",
         lineNo: index + 1,
         error: error instanceof Error ? error.message : String(error),
         rawLine: line,
@@ -141,9 +143,21 @@ export function parseClaudeSession(
         }
       }
     } else {
+      const seen = unknownTypes.get(typ) ?? { count: 0, firstLine: index + 1 };
+      seen.count += 1;
+      unknownTypes.set(typ, seen);
       messages.push(simpleMessage(value, "other", seq));
       seq += 1;
     }
+  }
+
+  for (const [typ, seen] of unknownTypes) {
+    issues.push({
+      code: "unknown_record_type",
+      lineNo: seen.firstLine,
+      error: `unknown record type "${typ}" on ${seen.count} line(s); kept as role "other"`,
+      rawLine: null,
+    });
   }
 
   const messageTotals = emptyUsage();

--- a/src/sources/codex.ts
+++ b/src/sources/codex.ts
@@ -40,6 +40,7 @@ export function parseCodexSession(
   let contextWindow: number | null = null;
   let rawMeta: Json = null;
   let seq = 0;
+  const unknownTypes = new Map<string, { count: number; firstLine: number }>();
 
   for (const [index, line] of content.split(/\n/).entries()) {
     if (line.trim() === "") {
@@ -51,6 +52,7 @@ export function parseCodexSession(
       value = JSON.parse(line) as Json;
     } catch (error) {
       issues.push({
+        code: "unparsed_line",
         lineNo: index + 1,
         error: error instanceof Error ? error.message : String(error),
         rawLine: line,
@@ -124,7 +126,23 @@ export function parseCodexSession(
         messages.push(message.message);
         seq += 1;
       }
+    } else if (typ !== "event_msg") {
+      // event_msg subtypes other than token_count are known stream noise
+      // (response_item carries the durable copy). Anything else is a
+      // top-level record type this parser has never seen — the drift sensor.
+      const seen = unknownTypes.get(typ) ?? { count: 0, firstLine: index + 1 };
+      seen.count += 1;
+      unknownTypes.set(typ, seen);
     }
+  }
+
+  for (const [typ, seen] of unknownTypes) {
+    issues.push({
+      code: "unknown_record_type",
+      lineNo: seen.firstLine,
+      error: `unknown record type "${typ}" on ${seen.count} line(s); ignored`,
+      rawLine: null,
+    });
   }
 
   title = titles.get(sourceSessionId) ?? title;

--- a/src/sources/codex.ts
+++ b/src/sources/codex.ts
@@ -1,9 +1,11 @@
+import { linkageIssues } from "../diagnostics.ts";
 import { canonicalJson } from "../json.ts";
 import {
   emptyUsage,
   type Json,
   type NormalizedBlock,
   type NormalizedMessage,
+  type NormalizedSession,
   type ParsedSession,
   type Role,
   reasoningEffortLevels,
@@ -151,35 +153,35 @@ export function parseCodexSession(
   }
   const effortLevels = reasoningEffortLevels(reasoningEfforts);
 
-  return {
-    session: {
-      tool: "codex",
-      sourceSessionId,
-      projectPath: cwd,
-      title,
-      cwd,
-      gitBranch: null,
-      model,
-      reasoningEffort: summarizeReasoningEfforts(effortLevels),
-      reasoningEffortLevels: effortLevels,
-      cliVersion,
-      startedAt,
-      endedAt,
-      isArchived: false,
-      isSubagent,
-      rootSourceSessionId: parentThreadId,
-      spawnToolUseId: null,
-      agentId: agentId ?? (isSubagent ? sourceSessionId : null),
-      agentType,
-      spawnDepth,
-      rawMeta,
-      totals,
-      estReasoningTokens: 0,
-      reasoningSource: sawTokenCount ? "reported" : "none",
-      messages,
-    },
-    issues,
+  const normalized: NormalizedSession = {
+    tool: "codex",
+    sourceSessionId,
+    projectPath: cwd,
+    title,
+    cwd,
+    gitBranch: null,
+    model,
+    reasoningEffort: summarizeReasoningEfforts(effortLevels),
+    reasoningEffortLevels: effortLevels,
+    cliVersion,
+    startedAt,
+    endedAt,
+    isArchived: false,
+    isSubagent,
+    rootSourceSessionId: parentThreadId,
+    spawnToolUseId: null,
+    agentId: agentId ?? (isSubagent ? sourceSessionId : null),
+    agentType,
+    spawnDepth,
+    rawMeta,
+    totals,
+    estReasoningTokens: 0,
+    reasoningSource: sawTokenCount ? "reported" : "none",
+    messages,
   };
+  issues.push(...linkageIssues(normalized));
+
+  return { session: normalized, issues };
 }
 
 function usageFrom(source: Json | undefined): TokenUsage {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -30,3 +30,20 @@ export function preview(s: string, max: number): string {
   }
   return `${chars.slice(0, max).join("")}…`;
 }
+
+/** Head and tail of a string with an elision marker between them, for text
+ * whose ending carries signal — tool errors report at the tail. Counts
+ * Unicode scalars, never splitting surrogate pairs. `max` bounds the kept
+ * scalars (60% head, 40% tail); the marker line is extra. */
+export function previewHeadTail(s: string, max: number): string {
+  const chars = [...s];
+  if (chars.length <= max) {
+    return s;
+  }
+  const tailLen = Math.floor((max * 2) / 5);
+  const headLen = max - tailLen;
+  const omitted = chars.length - headLen - tailLen;
+  const head = chars.slice(0, headLen).join("");
+  const tail = chars.slice(chars.length - tailLen).join("");
+  return `${head}\n[… ${omitted} chars omitted …]\n${tail}`;
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -34,16 +34,37 @@ export function preview(s: string, max: number): string {
 /** Head and tail of a string with an elision marker between them, for text
  * whose ending carries signal — tool errors report at the tail. Counts
  * Unicode scalars, never splitting surrogate pairs. `max` bounds the kept
- * scalars (60% head, 40% tail); the marker line is extra. */
+ * scalars (60% head, 40% tail); the marker line is extra.
+ *
+ * Runs at ingest on every tool result, so it never materializes the whole
+ * string as a scalar array — multi-megabyte outputs are common. */
 export function previewHeadTail(s: string, max: number): string {
-  const chars = [...s];
-  if (chars.length <= max) {
+  // UTF-16 length bounds the scalar count from above.
+  if (s.length <= max) {
+    return s;
+  }
+  let scalars = 0;
+  for (const _ of s) {
+    scalars += 1;
+  }
+  if (scalars <= max) {
     return s;
   }
   const tailLen = Math.floor((max * 2) / 5);
   const headLen = max - tailLen;
-  const omitted = chars.length - headLen - tailLen;
-  const head = chars.slice(0, headLen).join("");
-  const tail = chars.slice(chars.length - tailLen).join("");
+  const omitted = scalars - headLen - tailLen;
+  let head = "";
+  let taken = 0;
+  for (const ch of s) {
+    if (taken === headLen) {
+      break;
+    }
+    head += ch;
+    taken += 1;
+  }
+  // A scalar is at most two UTF-16 units, so the last 2*tailLen units hold at
+  // least tailLen scalars; a surrogate pair torn at the slice boundary can
+  // only sit before the final tailLen scalars, never inside them.
+  const tail = tailLen === 0 ? "" : [...s.slice(-tailLen * 2)].slice(-tailLen).join("");
   return `${head}\n[… ${omitted} chars omitted …]\n${tail}`;
 }

--- a/src/ui/ingest-issues.ts
+++ b/src/ui/ingest-issues.ts
@@ -1,0 +1,5 @@
+/** Label for the session-detail header badge that surfaces ingest diagnostics
+ * recorded against a session's source file. */
+export function formatIssueBadge(count: number): string {
+  return `${count} ingest issue${count === 1 ? "" : "s"}`;
+}

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -62,6 +62,7 @@ import { contextWindowDisplayMode } from "./context-window-state.ts";
 import { compactDateTime, fullDateTime } from "./date-time.ts";
 import { effortDisplayLabel, effortTooltip } from "./effort.ts";
 import { isFramed } from "./frame-guard.ts";
+import { formatIssueBadge } from "./ingest-issues.ts";
 import { planSessionLoad, shouldShowSessionSkeleton } from "./loading-state.ts";
 import {
   pathOnly,
@@ -127,6 +128,8 @@ type SessionSummary = {
   compaction_count: number;
   subagent_count: number;
   subagent_estimated_cost_usd: number;
+  /** Ingest diagnostics recorded against this session's source file. */
+  ingest_issue_count: number;
   subagents?: SessionSummary[];
 };
 
@@ -4272,6 +4275,9 @@ function SessionDetailView({ id }: { id: number }) {
   // retry in opposite directions, so one shared message would report a failed
   // backward load at the foot of the transcript under the wrong wording.
   const [loadEarlierError, setLoadEarlierError] = useState<string | null>(null);
+  const [showIssues, setShowIssues] = useState(false);
+  const [issues, setIssues] = useState<SessionIngestIssue[] | null>(null);
+  const [issuesError, setIssuesError] = useState<string | null>(null);
   const [jumpingToSeq, setJumpingToSeq] = useState<number | null>(null);
   const [activeMessageSeq, setActiveMessageSeq] = useState<number | null>(null);
   const detailRef = useRef<SessionDetailData | null>(null);
@@ -4296,6 +4302,9 @@ function SessionDetailView({ id }: { id: number }) {
     setLoadingMore(false);
     setLoadMoreError(null);
     setLoadEarlierError(null);
+    setShowIssues(false);
+    setIssues(null);
+    setIssuesError(null);
     setJumpingToSeq(null);
     activeMessageSeqRef.current = null;
     handledMessageHashRef.current = null;
@@ -4351,6 +4360,32 @@ function SessionDetailView({ id }: { id: number }) {
       cancelled = true;
     };
   }, [id]);
+
+  // Ingest issues are fetched lazily, on first expand, rather than eagerly
+  // alongside outline/economics/context-window above: most sessions have
+  // none, and the raw_line the row can join against is display-local by
+  // design (never logged), so there is no reason to pull it over the wire
+  // before the user asks to see it.
+  useEffect(() => {
+    if (!showIssues || issues != null || issuesError != null) {
+      return;
+    }
+    let cancelled = false;
+    void getJson<SessionIngestIssue[]>(`/api/sessions/${id}/issues`)
+      .then((nextIssues) => {
+        if (!cancelled) {
+          setIssues(nextIssues);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setIssuesError(errorMessage(err));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id, showIssues, issues, issuesError]);
 
   const loadMoreMessages = useCallback((): Promise<boolean> => {
     if (loadMorePromiseRef.current != null) {
@@ -4745,6 +4780,17 @@ function SessionDetailView({ id }: { id: number }) {
               labeled
               levels={detail.summary.reasoning_effort_levels}
             />
+            {detail.summary.ingest_issue_count > 0 ? (
+              <button
+                aria-expanded={showIssues}
+                aria-label={`${showIssues ? "Hide" : "Show"} ingest issues`}
+                className="badge-button"
+                onClick={() => setShowIssues((value) => !value)}
+                type="button"
+              >
+                <Badge tone="warning">{formatIssueBadge(detail.summary.ingest_issue_count)}</Badge>
+              </button>
+            ) : null}
             {detail.summary.project_path != null ? (
               <span className="project-chip" title={detail.summary.project_path}>
                 <Icon name="folder" />
@@ -4771,6 +4817,8 @@ function SessionDetailView({ id }: { id: number }) {
           </div>
         </div>
       </header>
+
+      {showIssues ? <IngestIssuesPanel error={issuesError} issues={issues} /> : null}
 
       <a className="back-link" href="/sessions" onClick={(event) => navigate(event, "/sessions")}>
         <Icon name="arrowLeft" />
@@ -4921,6 +4969,54 @@ function SessionDetailView({ id }: { id: number }) {
   );
 }
 
+function IngestIssuesPanel({
+  error,
+  issues,
+}: {
+  error: string | null;
+  issues: SessionIngestIssue[] | null;
+}) {
+  return (
+    <section className="panel ingest-issues-panel">
+      <div className="panel-heading">
+        <div>
+          <h2>Ingest issues</h2>
+          <p>Diagnostics recorded when this session's source file was last ingested.</p>
+        </div>
+      </div>
+      <div className="panel-body">
+        {error != null ? (
+          <div className="notice inline-notice">Unable to load ingest issues: {error}</div>
+        ) : issues == null ? (
+          <p className="faint">Loading issues…</p>
+        ) : issues.length === 0 ? (
+          <p className="faint">No issues recorded for this session.</p>
+        ) : (
+          <div className="signal-list">
+            {issues.map((issue) => (
+              // No stable id in the wire shape; composite of the fields shown
+              // is stable enough since this list is fetched once and never
+              // reorders.
+              <div className="signal-row" key={`${issue.code}-${issue.line_no}-${issue.error}`}>
+                <span className="signal-rail tone-warning" />
+                <div>
+                  <div>
+                    <code className="mono">{issue.code}</code>
+                    {issue.line_no != null ? (
+                      <span className="faint"> · line {issue.line_no}</span>
+                    ) : null}
+                  </div>
+                  <div className="muted">{issue.error}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
 type SessionDetailData = {
   summary: SessionSummary;
   messages: {
@@ -4947,6 +5043,14 @@ type SessionDetailData = {
 type SessionOutlineItemData = {
   seq: number;
   text: string;
+};
+
+/** Mirrors the server's SessionIngestIssue, minus raw_line and created_at:
+ * this panel never renders the raw transcript line (see docs/api/routes.md). */
+type SessionIngestIssue = {
+  code: string;
+  line_no: number | null;
+  error: string;
 };
 
 type ContextWindowPointData = {

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -4993,11 +4993,15 @@ function IngestIssuesPanel({
           <p className="faint">No issues recorded for this session.</p>
         ) : (
           <div className="signal-list">
-            {issues.map((issue) => (
+            {issues.map((issue, index) => (
               // No stable id in the wire shape; composite of the fields shown
-              // is stable enough since this list is fetched once and never
-              // reorders.
-              <div className="signal-row" key={`${issue.code}-${issue.line_no}-${issue.error}`}>
+              // plus the map index, since byte-identical rows (e.g. repeated
+              // duplicate_tool_result issues) would otherwise collide.
+              <div
+                className="signal-row"
+                // biome-ignore lint/suspicious/noArrayIndexKey: fetched once and never reorders; index only disambiguates byte-identical rows.
+                key={`${issue.code}-${issue.line_no}-${issue.error}-${index}`}
+              >
                 <span className="signal-rail tone-warning" />
                 <div>
                   <div>
@@ -5046,7 +5050,8 @@ type SessionOutlineItemData = {
 };
 
 /** Mirrors the server's SessionIngestIssue, minus raw_line and created_at:
- * this panel never renders the raw transcript line (see docs/api/routes.md). */
+ * this panel never renders the raw transcript line (see docs/logging.md and
+ * the sessionIngestIssues docstring in src/query.ts). */
 type SessionIngestIssue = {
   code: string;
   line_no: number | null;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1238,6 +1238,19 @@ select {
   flex: 0 0 auto;
 }
 
+.badge-button {
+  display: inline-flex;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+}
+
+.badge-button:hover .badge {
+  opacity: 0.85;
+}
+
 .brand-mark {
   fill: currentColor;
 }

--- a/test/claude.test.ts
+++ b/test/claude.test.ts
@@ -178,6 +178,32 @@ describe("parseClaudeSession", () => {
     expect(parsed.session.title).toBe("hello");
   });
 
+  test("flags unparsed lines with the unparsed_line code", () => {
+    const parsed = parseClaudeSession("s1", "not json\n");
+    expect(parsed.issues).toHaveLength(1);
+    expect(parsed.issues[0]?.code).toBe("unparsed_line");
+    expect(parsed.issues[0]?.lineNo).toBe(1);
+  });
+
+  test("flags unknown record types once per type with a count", () => {
+    const lines = [
+      JSON.stringify({ type: "wormhole", timestamp: "2026-07-01T00:00:00Z" }),
+      JSON.stringify({ type: "wormhole", timestamp: "2026-07-01T00:00:01Z" }),
+      JSON.stringify({
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text: "hi" }] },
+      }),
+    ].join("\n");
+    const parsed = parseClaudeSession("s1", lines);
+    const unknown = parsed.issues.filter((issue) => issue.code === "unknown_record_type");
+    expect(unknown).toHaveLength(1);
+    expect(unknown[0]?.error).toContain('"wormhole"');
+    expect(unknown[0]?.error).toContain("2 line");
+    expect(unknown[0]?.rawLine).toBeNull();
+    // the records themselves still land as role-"other" messages — behavior unchanged
+    expect(parsed.session.messages.filter((m) => m.role === "other")).toHaveLength(2);
+  });
+
   test("meta summary sets title and system and unknown types become messages", () => {
     const content = [
       '{"type":"summary","summary":"Synthesized Title"}',

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -213,7 +213,7 @@ describe("runCli", () => {
     );
   });
 
-  test("export --format trajectory writes a validating JSON array", async () => {
+  test("export --as trajectory writes a validating JSON array", async () => {
     const { dbPath } = await syncedCase();
     const list = await runCli(["--db", dbPath, "--json", "--no-sync", "ls"]);
     const sessions = JSON.parse(list.stdout) as { id: number; source_session_id: string }[];
@@ -222,21 +222,33 @@ describe("runCli", () => {
       throw new Error('expected the claude sample fixture session (source_session_id "sample")');
     }
 
+    // Globals after the subcommand: a regression guard for the exact shape
+    // AGENTS.md's "global flags on every command" contract, the justfile
+    // wrappers (`just ls {{ARGS}}`), and the bug-report template's repro
+    // commands all rely on — decant sync/ls --db ... --no-sync, not
+    // --db/--no-sync first.
     const result = await runCli([
+      "export",
+      String(sessionId),
+      "--as",
+      "trajectory",
       "--db",
       dbPath,
       "--no-sync",
-      "export",
-      String(sessionId),
-      "--format",
-      "trajectory",
     ]);
     expect(result).toMatchObject({ code: 0, stderr: "" });
     const records = JSON.parse(result.stdout) as { role: string; source?: string }[];
     expect(records[0]).toMatchObject({ role: "meta", source: "claude-code" });
   });
 
-  test("export --all --format trajectory names files <id>.trajectory.json", async () => {
+  test("global flags after the subcommand still parse (ls --db X --no-sync)", async () => {
+    const { dbPath } = await syncedCase();
+    const result = await runCli(["ls", "--json", "--db", dbPath, "--no-sync"]);
+    expect(result).toMatchObject({ code: 0, stderr: "" });
+    expect((JSON.parse(result.stdout) as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  test("export --all --as trajectory names files <id>.trajectory.json", async () => {
     const { dbPath } = await syncedCase();
     const list = await runCli(["--db", dbPath, "--json", "--no-sync", "ls"]);
     const sessions = JSON.parse(list.stdout) as { id: number; source_session_id: string }[];
@@ -252,7 +264,7 @@ describe("runCli", () => {
       "--no-sync",
       "export",
       "--all",
-      "--format",
+      "--as",
       "trajectory",
       "--out",
       outDir,
@@ -267,7 +279,7 @@ describe("runCli", () => {
     expect(result.stderr).not.toContain("skipped");
   });
 
-  test("export --format trajectory reports exit 1 for non-exportable or missing sessions, and tallies skips under --all", async () => {
+  test("export --as trajectory reports exit 1 for non-exportable or missing sessions, and tallies skips under --all", async () => {
     const dir = mkdtempSync(join(workDir, "traj-exit1-"));
     const dbPath = join(dir, "archive.db");
     const db = openDb(dbPath);
@@ -319,7 +331,7 @@ describe("runCli", () => {
       ...base,
       "export",
       String(assistantOnlyId),
-      "--format",
+      "--as",
       "trajectory",
     ]);
     expect(missingAssistant).toMatchObject({
@@ -327,31 +339,17 @@ describe("runCli", () => {
       stderr: `error: session ${assistantOnlyId} has no user records; not exportable as a trajectory\n`,
     });
 
-    const missingUser = await runCli([
-      ...base,
-      "export",
-      String(userOnlyId),
-      "--format",
-      "trajectory",
-    ]);
+    const missingUser = await runCli([...base, "export", String(userOnlyId), "--as", "trajectory"]);
     expect(missingUser).toMatchObject({
       code: 1,
       stderr: `error: session ${userOnlyId} has no assistant records; not exportable as a trajectory\n`,
     });
 
-    const notFound = await runCli([...base, "export", "999999", "--format", "trajectory"]);
+    const notFound = await runCli([...base, "export", "999999", "--as", "trajectory"]);
     expect(notFound).toMatchObject({ code: 1, stderr: "error: no session with id 999999\n" });
 
     const outDir = join(dir, "out");
-    const all = await runCli([
-      ...base,
-      "export",
-      "--all",
-      "--format",
-      "trajectory",
-      "--out",
-      outDir,
-    ]);
+    const all = await runCli([...base, "export", "--all", "--as", "trajectory", "--out", outDir]);
     expect(all.code).toBe(0);
     expect(existsSync(join(outDir, `${goodId}.trajectory.json`))).toBe(true);
     expect(existsSync(join(outDir, `${assistantOnlyId}.trajectory.json`))).toBe(false);
@@ -359,7 +357,7 @@ describe("runCli", () => {
     expect(all.stderr).toContain("(2 skipped)");
   });
 
-  test("export --all --format trajectory only visits subagents with --include-subagents, and --quiet suppresses the repairs line", async () => {
+  test("export --all --as trajectory only visits subagents with --include-subagents, and --quiet suppresses the repairs line", async () => {
     const dir = mkdtempSync(join(workDir, "traj-subagents-"));
     const dbPath = join(dir, "archive.db");
     const db = openDb(dbPath);
@@ -388,7 +386,7 @@ describe("runCli", () => {
       ...base,
       "export",
       "--all",
-      "--format",
+      "--as",
       "trajectory",
       "--out",
       withoutDir,
@@ -407,7 +405,7 @@ describe("runCli", () => {
       "export",
       "--all",
       "--include-subagents",
-      "--format",
+      "--as",
       "trajectory",
       "--out",
       withDir,
@@ -427,7 +425,7 @@ describe("runCli", () => {
       "export",
       "--all",
       "--include-subagents",
-      "--format",
+      "--as",
       "trajectory",
       "--out",
       quietDir,
@@ -439,7 +437,7 @@ describe("runCli", () => {
     expect(quiet.stderr).toBe(`exported 2 sessions to ${quietDir}\n`);
   });
 
-  test("export rejects unknown --format values and follows --json for the default", async () => {
+  test("export rejects unknown --as values and follows --json for the default", async () => {
     const { dbPath } = await syncedCase();
     const list = await runCli(["--db", dbPath, "--json", "--no-sync", "ls"]);
     const sessions = JSON.parse(list.stdout) as { id: number }[];
@@ -454,7 +452,7 @@ describe("runCli", () => {
       "--no-sync",
       "export",
       String(sessionId),
-      "--format",
+      "--as",
       "bogus",
     ]);
     expect(badFormat.code).toBe(2);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import {
   copyFileSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -12,6 +13,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { runCli } from "../src/cli.ts";
 import { LATEST_SCHEMA_VERSION, openDb } from "../src/db.ts";
+import { upsertSession } from "../src/ingest.ts";
+import { parseClaudeSession } from "../src/sources/claude.ts";
 
 const workDir = mkdtempSync(join(tmpdir(), "decant-cli-test-"));
 afterAll(() => rmSync(workDir, { recursive: true, force: true }));
@@ -208,6 +211,266 @@ describe("runCli", () => {
     expect((JSON.parse(implemented.stdout) as { key: string }[]).map((rec) => rec.key)).toContain(
       "catalog:agents-md",
     );
+  });
+
+  test("export --format trajectory writes a validating JSON array", async () => {
+    const { dbPath } = await syncedCase();
+    const list = await runCli(["--db", dbPath, "--json", "--no-sync", "ls"]);
+    const sessions = JSON.parse(list.stdout) as { id: number; source_session_id: string }[];
+    const sessionId = sessions.find((session) => session.source_session_id === "sample")?.id;
+    if (sessionId == null) {
+      throw new Error('expected the claude sample fixture session (source_session_id "sample")');
+    }
+
+    const result = await runCli([
+      "--db",
+      dbPath,
+      "--no-sync",
+      "export",
+      String(sessionId),
+      "--format",
+      "trajectory",
+    ]);
+    expect(result).toMatchObject({ code: 0, stderr: "" });
+    const records = JSON.parse(result.stdout) as { role: string; source?: string }[];
+    expect(records[0]).toMatchObject({ role: "meta", source: "claude-code" });
+  });
+
+  test("export --all --format trajectory names files <id>.trajectory.json", async () => {
+    const { dbPath } = await syncedCase();
+    const list = await runCli(["--db", dbPath, "--json", "--no-sync", "ls"]);
+    const sessions = JSON.parse(list.stdout) as { id: number; source_session_id: string }[];
+    const sessionId = sessions.find((session) => session.source_session_id === "sample")?.id;
+    if (sessionId == null) {
+      throw new Error('expected the claude sample fixture session (source_session_id "sample")');
+    }
+
+    const outDir = join(workDir, `traj-out-${caseCounter}`);
+    const result = await runCli([
+      "--db",
+      dbPath,
+      "--no-sync",
+      "export",
+      "--all",
+      "--format",
+      "trajectory",
+      "--out",
+      outDir,
+    ]);
+    expect(result.code).toBe(0);
+    expect(existsSync(join(outDir, `${sessionId}.trajectory.json`))).toBe(true);
+    // All 7 fixture sessions carry both roles, so none should be skipped here;
+    // the skip-tally path itself is covered separately below. Several fixtures
+    // do legitimately trigger repairs (wrapped args, dropped noise), so this
+    // only pins the final tally line, not the whole of stderr.
+    expect(result.stderr).toContain(`exported 7 sessions to ${outDir}\n`);
+    expect(result.stderr).not.toContain("skipped");
+  });
+
+  test("export --format trajectory reports exit 1 for non-exportable or missing sessions, and tallies skips under --all", async () => {
+    const dir = mkdtempSync(join(workDir, "traj-exit1-"));
+    const dbPath = join(dir, "archive.db");
+    const db = openDb(dbPath);
+    const goodId = upsertSession(
+      db,
+      parseClaudeSession(
+        "traj-good",
+        readFileSync(join(import.meta.dir, "..", "fixtures", "claude", "sample.jsonl"), "utf8"),
+      ),
+      "/good.jsonl",
+      1,
+      2,
+      "hash-good",
+    );
+    const assistantOnlyId = upsertSession(
+      db,
+      parseClaudeSession(
+        "traj-assistant-only",
+        JSON.stringify({
+          type: "assistant",
+          timestamp: "2026-07-01T00:00:00.000Z",
+          message: { role: "assistant", content: [{ type: "text", text: "hello" }] },
+        }),
+      ),
+      "/assistant-only.jsonl",
+      1,
+      2,
+      "hash-assistant-only",
+    );
+    const userOnlyId = upsertSession(
+      db,
+      parseClaudeSession(
+        "traj-user-only",
+        JSON.stringify({
+          type: "user",
+          timestamp: "2026-07-01T00:00:00.000Z",
+          message: { role: "user", content: [{ type: "text", text: "hello" }] },
+        }),
+      ),
+      "/user-only.jsonl",
+      1,
+      2,
+      "hash-user-only",
+    );
+    db.close();
+
+    const base = ["--db", dbPath, "--no-sync"];
+    const missingAssistant = await runCli([
+      ...base,
+      "export",
+      String(assistantOnlyId),
+      "--format",
+      "trajectory",
+    ]);
+    expect(missingAssistant).toMatchObject({
+      code: 1,
+      stderr: `error: session ${assistantOnlyId} has no user records; not exportable as a trajectory\n`,
+    });
+
+    const missingUser = await runCli([
+      ...base,
+      "export",
+      String(userOnlyId),
+      "--format",
+      "trajectory",
+    ]);
+    expect(missingUser).toMatchObject({
+      code: 1,
+      stderr: `error: session ${userOnlyId} has no assistant records; not exportable as a trajectory\n`,
+    });
+
+    const notFound = await runCli([...base, "export", "999999", "--format", "trajectory"]);
+    expect(notFound).toMatchObject({ code: 1, stderr: "error: no session with id 999999\n" });
+
+    const outDir = join(dir, "out");
+    const all = await runCli([
+      ...base,
+      "export",
+      "--all",
+      "--format",
+      "trajectory",
+      "--out",
+      outDir,
+    ]);
+    expect(all.code).toBe(0);
+    expect(existsSync(join(outDir, `${goodId}.trajectory.json`))).toBe(true);
+    expect(existsSync(join(outDir, `${assistantOnlyId}.trajectory.json`))).toBe(false);
+    expect(existsSync(join(outDir, `${userOnlyId}.trajectory.json`))).toBe(false);
+    expect(all.stderr).toContain("(2 skipped)");
+  });
+
+  test("export --all --format trajectory only visits subagents with --include-subagents, and --quiet suppresses the repairs line", async () => {
+    const dir = mkdtempSync(join(workDir, "traj-subagents-"));
+    const dbPath = join(dir, "archive.db");
+    const db = openDb(dbPath);
+    db.exec(`
+      INSERT INTO session(id, tool, source_session_id, started_at, is_subagent, parent_session_id)
+      VALUES
+        (1, 'claude_code', 'root', '2026-07-01T00:00:00Z', 0, NULL),
+        (2, 'claude_code', 'kid', '2026-07-01T00:01:00Z', 1, 1);
+      INSERT INTO message(id, session_id, seq, role, raw) VALUES
+        (1, 1, 0, 'user', '{}'),
+        (2, 1, 1, 'assistant', '{}'),
+        (3, 2, 0, 'user', '{}'),
+        (4, 2, 1, 'assistant', '{}');
+      INSERT INTO block(message_id, session_id, ordinal, type, text) VALUES
+        (1, 1, 0, 'text', 'Root prompt'),
+        (2, 1, 0, 'text', 'Root reply'),
+        (3, 2, 0, 'text', 'Kid prompt'),
+        (4, 2, 0, 'text', 'Kid reply');
+    `);
+    db.close();
+
+    const base = ["--db", dbPath, "--no-sync"];
+
+    const withoutDir = join(dir, "without");
+    const without = await runCli([
+      ...base,
+      "export",
+      "--all",
+      "--format",
+      "trajectory",
+      "--out",
+      withoutDir,
+    ]);
+    expect(without.code).toBe(0);
+    expect(existsSync(join(withoutDir, "1.trajectory.json"))).toBe(true);
+    expect(existsSync(join(withoutDir, "2.trajectory.json"))).toBe(false);
+    // Every block above is missing a timestamp, so each visited session fills
+    // two of them — a deterministic, non-empty repairs line to assert against.
+    expect(without.stderr).toContain("session 1: timestamps_filled=2");
+    expect(without.stderr).not.toContain("session 2:");
+
+    const withDir = join(dir, "with");
+    const withSubagents = await runCli([
+      ...base,
+      "export",
+      "--all",
+      "--include-subagents",
+      "--format",
+      "trajectory",
+      "--out",
+      withDir,
+    ]);
+    expect(withSubagents.code).toBe(0);
+    expect(existsSync(join(withDir, "1.trajectory.json"))).toBe(true);
+    expect(existsSync(join(withDir, "2.trajectory.json"))).toBe(true);
+    expect(withSubagents.stderr).toContain("session 1: timestamps_filled=2");
+    expect(withSubagents.stderr).toContain("session 2: timestamps_filled=2");
+
+    const quietDir = join(dir, "quiet");
+    const quiet = await runCli([
+      "--db",
+      dbPath,
+      "--no-sync",
+      "--quiet",
+      "export",
+      "--all",
+      "--include-subagents",
+      "--format",
+      "trajectory",
+      "--out",
+      quietDir,
+    ]);
+    expect(quiet.code).toBe(0);
+    expect(existsSync(join(quietDir, "1.trajectory.json"))).toBe(true);
+    expect(existsSync(join(quietDir, "2.trajectory.json"))).toBe(true);
+    expect(quiet.stderr).not.toContain("timestamps_filled");
+    expect(quiet.stderr).toBe(`exported 2 sessions to ${quietDir}\n`);
+  });
+
+  test("export rejects unknown --format values and follows --json for the default", async () => {
+    const { dbPath } = await syncedCase();
+    const list = await runCli(["--db", dbPath, "--json", "--no-sync", "ls"]);
+    const sessions = JSON.parse(list.stdout) as { id: number }[];
+    const sessionId = sessions[0]?.id;
+    if (sessionId == null) {
+      throw new Error("expected at least one synced session");
+    }
+
+    const badFormat = await runCli([
+      "--db",
+      dbPath,
+      "--no-sync",
+      "export",
+      String(sessionId),
+      "--format",
+      "bogus",
+    ]);
+    expect(badFormat.code).toBe(2);
+    expect(badFormat.stderr).toContain("error: unknown export format: bogus");
+
+    const jsonDefault = await runCli([
+      "--db",
+      dbPath,
+      "--json",
+      "--no-sync",
+      "export",
+      String(sessionId),
+    ]);
+    expect(jsonDefault.code).toBe(0);
+    expect(() => JSON.parse(jsonDefault.stdout)).not.toThrow();
+    expect(jsonDefault.stdout.startsWith("#")).toBe(false);
   });
 
   test("sync exits 3 only for data loss and reports every issue code", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,5 +1,13 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { copyFileSync, mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { runCli } from "../src/cli.ts";
@@ -200,6 +208,45 @@ describe("runCli", () => {
     expect((JSON.parse(implemented.stdout) as { key: string }[]).map((rec) => rec.key)).toContain(
       "catalog:agents-md",
     );
+  });
+
+  test("sync exits 3 only for data loss and reports every issue code", async () => {
+    const fixtureCase = freshCase();
+    const targetDir = join(workDir, `case-${caseCounter}-codes`);
+    mkdirSync(targetDir, { recursive: true });
+    const sample = readFileSync(
+      join(import.meta.dir, "..", "fixtures", "claude", "sample.jsonl"),
+      "utf8",
+    ).trimEnd();
+
+    // Informational only: an unknown record type keeps the line as role "other",
+    // so nothing is lost and the exit code must stay 0.
+    const informational = join(targetDir, "informational.jsonl");
+    writeFileSync(
+      informational,
+      `${sample}\n{"type":"mystery","uuid":"m1","timestamp":"2026-05-01T10:01:00.000Z"}\n`,
+    );
+    const soft = await runCli(
+      ["--db", fixtureCase.dbPath, "--json", "sync", "--path", informational],
+      { homeDir: targetDir },
+    );
+    expect(soft.code).toBe(0);
+    expect(JSON.parse(soft.stdout)).toMatchObject({
+      issues: 1,
+      issues_by_code: { unknown_record_type: 1 },
+    });
+
+    // A line that cannot be parsed is content decant dropped: exit 3.
+    const lossy = join(targetDir, "lossy.jsonl");
+    writeFileSync(lossy, `${sample}\n{not json\n`);
+    const hard = await runCli(["--db", fixtureCase.dbPath, "--json", "sync", "--path", lossy], {
+      homeDir: targetDir,
+    });
+    expect(hard.code).toBe(3);
+    expect(JSON.parse(hard.stdout)).toMatchObject({
+      issues: 1,
+      issues_by_code: { unparsed_line: 1 },
+    });
   });
 
   test("sync --path ingests only the requested source files", async () => {

--- a/test/codex.test.ts
+++ b/test/codex.test.ts
@@ -233,8 +233,12 @@ describe("parseCodexSession", () => {
       '{"type":"unknown-top","timestamp":"2026-05-01T10:00:02Z"}',
     ].join("\n");
     const parsed = parseCodexSession("fallback", `${content}\n`, new Map());
-    expect(parsed.issues).toHaveLength(1);
+    // the malformed line and the trailing unknown-top record each land an issue
+    expect(parsed.issues).toHaveLength(2);
+    expect(parsed.issues[0]?.code).toBe("unparsed_line");
     expect(parsed.issues[0]?.lineNo).toBe(2);
+    expect(parsed.issues[1]?.code).toBe("unknown_record_type");
+    expect(parsed.issues[1]?.error).toContain('"unknown-top"');
     const session = parsed.session;
     expect(session.sourceSessionId).toBe("sx");
     expect(session.cwd).toBe("/tmp/proj");
@@ -242,6 +246,26 @@ describe("parseCodexSession", () => {
     expect(session.cliVersion).toBe("1.2");
     expect(session.startedAt).toBe("2026-05-01T10:00:00Z");
     expect(session.endedAt).toBe("2026-05-01T10:00:02Z");
+  });
+
+  test("flags unknown top-level record types, ignoring event_msg subtypes", () => {
+    const lines = [
+      JSON.stringify({
+        type: "session_meta",
+        timestamp: "2026-07-01T00:00:00Z",
+        payload: { id: "c1" },
+      }),
+      JSON.stringify({
+        type: "event_msg",
+        timestamp: "2026-07-01T00:00:01Z",
+        payload: { type: "agent_message" },
+      }),
+      JSON.stringify({ type: "wormhole", timestamp: "2026-07-01T00:00:02Z", payload: {} }),
+    ].join("\n");
+    const parsed = parseCodexSession("c1", lines, new Map());
+    const unknown = parsed.issues.filter((issue) => issue.code === "unknown_record_type");
+    expect(unknown).toHaveLength(1);
+    expect(unknown[0]?.error).toContain('"wormhole"');
   });
 
   test("response item variants cover every block kind", () => {

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -164,7 +164,7 @@ describe("openDb", () => {
     const db = new Database(path, { create: true, strict: true });
     db.exec(`
       CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
-      CREATE TABLE session(id INTEGER PRIMARY KEY, tool TEXT NOT NULL, source_session_id TEXT NOT NULL);
+      CREATE TABLE session(id INTEGER PRIMARY KEY, tool TEXT NOT NULL, source_session_id TEXT NOT NULL, source_path TEXT);
       CREATE TABLE model_pricing(
         model TEXT PRIMARY KEY,
         input_per_mtok REAL,
@@ -173,6 +173,26 @@ describe("openDb", () => {
         cache_write_per_mtok REAL,
         source TEXT,
         updated_at TEXT
+      );
+      CREATE TABLE ingest_source (
+        path TEXT PRIMARY KEY,
+        tool TEXT,
+        size INTEGER,
+        mtime INTEGER,
+        hash TEXT,
+        session_id INTEGER REFERENCES session(id) ON DELETE SET NULL,
+        line_count INTEGER,
+        status TEXT,
+        error TEXT,
+        last_ingested_at TEXT
+      );
+      CREATE TABLE ingest_issue (
+        id INTEGER PRIMARY KEY,
+        source_path TEXT,
+        line_no INTEGER,
+        error TEXT,
+        raw_line TEXT,
+        created_at TEXT
       );
     `);
     const insert = db.prepare(
@@ -217,7 +237,13 @@ describe("openDb", () => {
     const db = new Database(path, { create: true, strict: true });
     db.exec(`
       CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
-      CREATE TABLE session(id INTEGER PRIMARY KEY, tool TEXT NOT NULL, source_session_id TEXT NOT NULL);
+      CREATE TABLE session(
+        id INTEGER PRIMARY KEY,
+        tool TEXT NOT NULL,
+        source_session_id TEXT NOT NULL,
+        source_path TEXT,
+        parent_session_id INTEGER REFERENCES session(id)
+      );
       CREATE TABLE model_pricing(
         model TEXT PRIMARY KEY,
         input_per_mtok REAL,
@@ -226,6 +252,26 @@ describe("openDb", () => {
         cache_write_per_mtok REAL,
         source TEXT,
         updated_at TEXT
+      );
+      CREATE TABLE ingest_source (
+        path TEXT PRIMARY KEY,
+        tool TEXT,
+        size INTEGER,
+        mtime INTEGER,
+        hash TEXT,
+        session_id INTEGER REFERENCES session(id) ON DELETE SET NULL,
+        line_count INTEGER,
+        status TEXT,
+        error TEXT,
+        last_ingested_at TEXT
+      );
+      CREATE TABLE ingest_issue (
+        id INTEGER PRIMARY KEY,
+        source_path TEXT,
+        line_no INTEGER,
+        error TEXT,
+        raw_line TEXT,
+        created_at TEXT
       );
     `);
     const insert = db.prepare(
@@ -257,6 +303,8 @@ describe("openDb", () => {
         id INTEGER PRIMARY KEY,
         tool TEXT NOT NULL,
         source_session_id TEXT NOT NULL,
+        source_path TEXT,
+        parent_session_id INTEGER REFERENCES session(id),
         context_window_tokens INTEGER,
         peak_context_tokens INTEGER,
         total_cache_creation_1h_tokens INTEGER NOT NULL DEFAULT 0
@@ -269,6 +317,26 @@ describe("openDb", () => {
         cache_write_per_mtok REAL,
         source TEXT,
         updated_at TEXT
+      );
+      CREATE TABLE ingest_source (
+        path TEXT PRIMARY KEY,
+        tool TEXT,
+        size INTEGER,
+        mtime INTEGER,
+        hash TEXT,
+        session_id INTEGER REFERENCES session(id) ON DELETE SET NULL,
+        line_count INTEGER,
+        status TEXT,
+        error TEXT,
+        last_ingested_at TEXT
+      );
+      CREATE TABLE ingest_issue (
+        id INTEGER PRIMARY KEY,
+        source_path TEXT,
+        line_no INTEGER,
+        error TEXT,
+        raw_line TEXT,
+        created_at TEXT
       );
       INSERT INTO session(
         id, tool, source_session_id, context_window_tokens, peak_context_tokens
@@ -308,8 +376,30 @@ describe("openDb", () => {
         id INTEGER PRIMARY KEY,
         tool TEXT NOT NULL,
         source_session_id TEXT NOT NULL,
+        source_path TEXT,
+        parent_session_id INTEGER REFERENCES session(id),
         reasoning_effort TEXT,
         reasoning_effort_checked INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE ingest_source (
+        path TEXT PRIMARY KEY,
+        tool TEXT,
+        size INTEGER,
+        mtime INTEGER,
+        hash TEXT,
+        session_id INTEGER REFERENCES session(id) ON DELETE SET NULL,
+        line_count INTEGER,
+        status TEXT,
+        error TEXT,
+        last_ingested_at TEXT
+      );
+      CREATE TABLE ingest_issue (
+        id INTEGER PRIMARY KEY,
+        source_path TEXT,
+        line_no INTEGER,
+        error TEXT,
+        raw_line TEXT,
+        created_at TEXT
       );
       INSERT INTO session(
         id, tool, source_session_id, reasoning_effort, reasoning_effort_checked
@@ -373,9 +463,31 @@ describe("openDb", () => {
         id INTEGER PRIMARY KEY,
         tool TEXT NOT NULL,
         source_session_id TEXT NOT NULL,
+        source_path TEXT,
+        parent_session_id INTEGER REFERENCES session(id),
         reasoning_effort TEXT,
         reasoning_effort_levels TEXT NOT NULL DEFAULT '[]',
         reasoning_effort_checked INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE ingest_source (
+        path TEXT PRIMARY KEY,
+        tool TEXT,
+        size INTEGER,
+        mtime INTEGER,
+        hash TEXT,
+        session_id INTEGER REFERENCES session(id) ON DELETE SET NULL,
+        line_count INTEGER,
+        status TEXT,
+        error TEXT,
+        last_ingested_at TEXT
+      );
+      CREATE TABLE ingest_issue (
+        id INTEGER PRIMARY KEY,
+        source_path TEXT,
+        line_no INTEGER,
+        error TEXT,
+        raw_line TEXT,
+        created_at TEXT
       );
       INSERT INTO session(
         id, tool, source_session_id, reasoning_effort,
@@ -429,6 +541,43 @@ describe("openDb", () => {
       },
     ]);
     migrated.close();
+  });
+
+  test("v16 purges journal-sourced phantom sessions", () => {
+    const path = join(workDir, "v16-journal.db");
+    let db = openDb(path);
+    db.exec(`
+      INSERT INTO session (tool, source_session_id, source_path)
+      VALUES ('claude_code', 'wf-journal', '/home/u/.claude/projects/p/s/subagents/workflows/wf_1/journal.jsonl');
+      INSERT INTO session (tool, source_session_id, source_path, parent_session_id)
+      VALUES ('claude_code', 'child-of-phantom', '/home/u/.claude/projects/p/s/subagents/agent-aa.jsonl',
+              (SELECT id FROM session WHERE source_session_id = 'wf-journal'));
+      INSERT INTO session (tool, source_session_id, source_path)
+      VALUES ('claude_code', 'real-session', '/home/u/.claude/projects/p/s.jsonl');
+      INSERT INTO message (session_id, seq, raw)
+      VALUES ((SELECT id FROM session WHERE source_session_id = 'wf-journal'), 0, '{}');
+      INSERT INTO ingest_source (path, tool) VALUES ('/home/u/.claude/projects/p/s/subagents/workflows/wf_1/journal.jsonl', 'claude_code');
+      INSERT INTO ingest_issue (source_path, line_no, error, raw_line, created_at)
+      VALUES ('/home/u/.claude/projects/p/s/subagents/workflows/wf_1/journal.jsonl', 1, 'x', '{}', datetime('now'));
+      DELETE FROM schema_migrations WHERE version >= 16;
+    `);
+    db.close();
+
+    db = openDb(path); // reopen: migrate() runs v16 again over the seeded rows
+    const ids = (
+      db.query("SELECT source_session_id FROM session ORDER BY source_session_id").all() as {
+        source_session_id: string;
+      }[]
+    ).map((row) => row.source_session_id);
+    expect(ids).toEqual(["child-of-phantom", "real-session"]);
+    const orphanParent = db
+      .query("SELECT parent_session_id FROM session WHERE source_session_id = 'child-of-phantom'")
+      .get() as { parent_session_id: number | null };
+    expect(orphanParent.parent_session_id).toBeNull();
+    expect((db.query("SELECT COUNT(*) AS n FROM message").get() as { n: number }).n).toBe(0);
+    expect((db.query("SELECT COUNT(*) AS n FROM ingest_source").get() as { n: number }).n).toBe(0);
+    expect((db.query("SELECT COUNT(*) AS n FROM ingest_issue").get() as { n: number }).n).toBe(0);
+    db.close();
   });
 
   test("rejects a pre-baseline archive and points at rebuilding it", () => {

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -24,7 +24,7 @@ function freshPath(): string {
   return join(workDir, `archive-${dbCounter}.db`);
 }
 
-// Inventory of the frozen v15 baseline. Shadow tables
+// Inventory of the frozen v17 baseline. Shadow tables
 // of block_fts are excluded; they are implementation details of FTS5.
 const BASELINE_TABLES = [
   "block",
@@ -42,7 +42,7 @@ const BASELINE_TABLES = [
   "tool_call",
 ];
 const BASELINE_TRIGGERS = ["block_ad", "block_ai", "block_au"];
-const BASELINE_INDEX_COUNT = 24;
+const BASELINE_INDEX_COUNT = 25;
 
 function inventory(db: Database, type: string): string[] {
   return (
@@ -577,6 +577,31 @@ describe("openDb", () => {
     expect((db.query("SELECT COUNT(*) AS n FROM message").get() as { n: number }).n).toBe(0);
     expect((db.query("SELECT COUNT(*) AS n FROM ingest_source").get() as { n: number }).n).toBe(0);
     expect((db.query("SELECT COUNT(*) AS n FROM ingest_issue").get() as { n: number }).n).toBe(0);
+    db.close();
+  });
+
+  test("v17 adds ingest_issue.code defaulting existing rows to unparsed_line", () => {
+    const path = join(workDir, "v17-code.db");
+    let db = openDb(path);
+    db.exec(`
+      INSERT INTO ingest_issue (source_path, line_no, error, raw_line, created_at)
+      VALUES ('/a.jsonl', 1, 'bad', '{', datetime('now'));
+      DELETE FROM schema_migrations WHERE version >= 17;
+    `);
+    // Simulate a pre-v17 table: drop the column the baseline now carries, and
+    // the index the migration creates alongside it.
+    db.exec("ALTER TABLE ingest_issue DROP COLUMN code;");
+    db.exec("DROP INDEX idx_ingest_issue_source;");
+    db.close();
+
+    db = openDb(path); // reopen: migrate() runs v17 over the pre-v17 table
+    const row = db.query("SELECT code FROM ingest_issue").get() as { code: string };
+    expect(row.code).toBe("unparsed_line");
+    expect(
+      db
+        .query("SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?1")
+        .get("idx_ingest_issue_source"),
+    ).not.toBeNull();
     db.close();
   });
 

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { linkageIssues } from "../src/diagnostics.ts";
+import type { NormalizedBlock, NormalizedMessage, NormalizedSession } from "../src/model.ts";
+import { emptyUsage } from "../src/model.ts";
+
+function block(partial: Partial<NormalizedBlock>): NormalizedBlock {
+  return {
+    ordinal: 0,
+    blockType: "text",
+    text: null,
+    toolName: null,
+    toolUseId: null,
+    toolInput: undefined,
+    toolResult: null,
+    isError: null,
+    ...partial,
+  };
+}
+
+function message(seq: number, blocks: NormalizedBlock[]): NormalizedMessage {
+  return {
+    seq,
+    sourceUuid: null,
+    parentSourceUuid: null,
+    role: "assistant",
+    model: null,
+    stopReason: null,
+    timestamp: null,
+    usage: null,
+    raw: null,
+    blocks,
+  };
+}
+
+function session(messages: NormalizedMessage[]): NormalizedSession {
+  return {
+    tool: "claude_code",
+    sourceSessionId: "s1",
+    projectPath: null,
+    title: null,
+    cwd: null,
+    gitBranch: null,
+    model: null,
+    reasoningEffort: null,
+    reasoningEffortLevels: [],
+    cliVersion: null,
+    startedAt: null,
+    endedAt: null,
+    isArchived: false,
+    isSubagent: false,
+    rootSourceSessionId: null,
+    spawnToolUseId: null,
+    agentId: null,
+    agentType: null,
+    spawnDepth: null,
+    rawMeta: null,
+    totals: emptyUsage(),
+    estReasoningTokens: 0,
+    reasoningSource: "none",
+    messages,
+  };
+}
+
+describe("linkageIssues", () => {
+  test("clean call/result pairs produce no issues", () => {
+    const s = session([
+      message(0, [block({ blockType: "tool_use", toolUseId: "t1", toolName: "Bash" })]),
+      message(1, [block({ blockType: "tool_result", toolUseId: "t1", toolResult: "ok" })]),
+    ]);
+    expect(linkageIssues(s)).toEqual([]);
+  });
+
+  test("flags orphan results, duplicate ids, and duplicate results", () => {
+    const s = session([
+      message(0, [
+        block({ blockType: "tool_use", toolUseId: "dup", toolName: "Bash" }),
+        block({ blockType: "tool_use", toolUseId: "dup", toolName: "Bash" }),
+      ]),
+      message(1, [
+        block({ blockType: "tool_result", toolUseId: "dup", toolResult: "a" }),
+        block({ blockType: "tool_result", toolUseId: "dup", toolResult: "b" }),
+        block({ blockType: "tool_result", toolUseId: "ghost", toolResult: "c" }),
+      ]),
+    ]);
+    const codes = linkageIssues(s)
+      .map((issue) => issue.code)
+      .sort();
+    expect(codes).toEqual(["duplicate_tool_result", "duplicate_tool_use_id", "orphan_tool_result"]);
+  });
+});

--- a/test/export-trajectory.test.ts
+++ b/test/export-trajectory.test.ts
@@ -506,4 +506,33 @@ describe("exportTrajectory", () => {
     expect(exportTrajectory(db, 999999)).toEqual({ ok: false, reason: "not_found" });
     db.close();
   });
+
+  test("normalizes offset timestamps and never corrupts bare ±hh offsets", () => {
+    const db = openDb(join(workDir, "offsets.db"));
+    const lines = [
+      // No-colon four-digit offset: parseable, must normalize to the UTC instant.
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-01T00:00:00+0530",
+        message: { role: "user", content: [{ type: "text", text: "offset question" }] },
+      }),
+      // Bare two-digit offset: Bun's Date cannot parse it, so it must fall
+      // through to the fill ladder as-is — not get a Z appended onto the
+      // offset. Either way it forward-fills from the previous record.
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-07-01T00:00:00+05",
+        message: { role: "assistant", content: [{ type: "text", text: "offset answer" }] },
+      }),
+    ].join("\n");
+    const sessionId = upsertSession(db, parseClaudeSession("traj-tz", lines), "/tz.jsonl", 1, 2, "h");
+    const out = exportTrajectory(db, sessionId);
+    if (!out.ok) throw new Error(`export failed: ${out.reason}`);
+    assertBothLayers(out.records);
+    const [, user, assistant] = out.records as { timestamp?: string }[];
+    expect(user?.timestamp).toBe("2026-06-30T18:30:00.000Z");
+    expect(assistant?.timestamp).toBe("2026-06-30T18:30:00.000Z");
+    expect(out.report.timestamps_filled).toBe(1);
+    db.close();
+  });
 });

--- a/test/export-trajectory.test.ts
+++ b/test/export-trajectory.test.ts
@@ -368,6 +368,124 @@ describe("exportTrajectory", () => {
     db.close();
   });
 
+  test("keeps field structure when shrinking over-cap object args", () => {
+    const db = openDb(join(workDir, "bigargs.db"));
+    const lines = [
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-01T00:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "go" }] },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-07-01T00:00:01.000Z",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "t1",
+              name: "Write",
+              input: { big: "z".repeat(40000), keep: "me" },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-01T00:00:02.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t1", content: "ok" }],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-07-01T00:00:03.000Z",
+        message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+      }),
+    ].join("\n");
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("traj-8", lines),
+      "/t8.jsonl",
+      1,
+      2,
+      "h",
+    );
+    const out = exportTrajectory(db, sessionId);
+    if (!out.ok) throw new Error(`export failed: ${out.reason}`);
+    assertBothLayers(out.records);
+
+    const args = (
+      out.records.find((r) => typeof r === "object" && r != null && "tool_calls" in r) as {
+        tool_calls: { args: string }[];
+      }
+    ).tool_calls[0]?.args;
+    expect(args).toBeDefined();
+    expect([...(args ?? "")].length).toBeLessThanOrEqual(20000);
+    const decoded = JSON.parse(args ?? "{}") as Record<string, string>;
+    expect(Object.keys(decoded)).toEqual(["big", "keep"]);
+    // The small field survives untouched; only the oversized leaf is truncated.
+    expect(decoded.keep).toBe("me");
+    expect(decoded).not.toHaveProperty("_raw");
+    expect(decoded.big?.startsWith("z")).toBe(true);
+    expect(decoded.big).toContain("… [truncated, ");
+    expect(out.report.tool_args_wrapped).toBe(1);
+    db.close();
+  });
+
+  test("falls back to a _raw wrap when the overage is structural", () => {
+    const db = openDb(join(workDir, "manykeys.db"));
+    // 1200 fields whose values are all shorter than the truncation marker, so no
+    // leaf can shrink usefully and the cap is only reachable by wrapping.
+    const input: Record<string, string> = {};
+    for (let index = 0; index < 1200; index += 1) {
+      input[`key${String(index).padStart(4, "0")}`] = "v".repeat(20);
+    }
+    const lines = [
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-01T00:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "go" }] },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-07-01T00:00:01.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "t1", name: "Write", input }],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-07-01T00:00:02.000Z",
+        message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+      }),
+    ].join("\n");
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("traj-9", lines),
+      "/t9.jsonl",
+      1,
+      2,
+      "h",
+    );
+    const out = exportTrajectory(db, sessionId);
+    if (!out.ok) throw new Error(`export failed: ${out.reason}`);
+    assertBothLayers(out.records);
+
+    const args = (
+      out.records.find((r) => typeof r === "object" && r != null && "tool_calls" in r) as {
+        tool_calls: { args: string }[];
+      }
+    ).tool_calls[0]?.args;
+    expect([...(args ?? "")].length).toBeLessThanOrEqual(20000);
+    expect(JSON.parse(args ?? "{}")).toHaveProperty("_raw");
+    expect(out.report.tool_args_wrapped).toBe(1);
+    db.close();
+  });
+
   test("refuses sessions without user or assistant records", () => {
     const db = openDb(join(workDir, "empty.db"));
     const lines = JSON.stringify({

--- a/test/export-trajectory.test.ts
+++ b/test/export-trajectory.test.ts
@@ -1,0 +1,304 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { validateTranscript } from "@letta-ai/trajectory";
+import { openDb } from "../src/db.ts";
+import { exportTrajectory } from "../src/export.ts";
+import { upsertSession } from "../src/ingest.ts";
+import { parseClaudeSession } from "../src/sources/claude.ts";
+
+const workDir = mkdtempSync(join(tmpdir(), "decant-trajectory-test-"));
+afterAll(() => rmSync(workDir, { recursive: true, force: true }));
+
+function fixtureContent(name: string): string {
+  return readFileSync(join(import.meta.dir, "..", "fixtures", "claude", name), "utf8");
+}
+
+const Ajv2020 = (await import("ajv/dist/2020.js")).default;
+const trajectorySchema = (await import("@letta-ai/trajectory/schema", {
+  with: { type: "json" },
+})) as { default: object };
+const validateSchema = new Ajv2020().compile(trajectorySchema.default);
+
+function assertBothLayers(records: unknown[]): void {
+  expect(() => validateTranscript(records)).not.toThrow();
+  expect(validateSchema(records)).toBe(true);
+}
+
+describe("exportTrajectory", () => {
+  test("emits a transcript both their validator and schema accept", () => {
+    const db = openDb(join(workDir, "basic.db"));
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("traj-1", fixtureContent("sample.jsonl")),
+      "/t1.jsonl",
+      1,
+      2,
+      "h",
+    );
+    const out = exportTrajectory(db, sessionId);
+    if (!out.ok) throw new Error(`export failed: ${out.reason}`);
+    assertBothLayers(out.records);
+    const meta = out.records[0] as { role: string; source: string };
+    expect(meta.role).toBe("meta");
+    expect(meta.source).toBe("claude-code");
+    db.close();
+  });
+
+  test("truncates long tool results marker-inclusive within 2500 code points", () => {
+    const db = openDb(join(workDir, "long.db"));
+    const lines = [
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-01T00:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "run it" }] },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-07-01T00:00:01.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "t1", name: "Bash", input: { cmd: "make" } }],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-01T00:00:02.000Z",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "t1",
+              content: `HEAD${"x".repeat(5000)}TAIL-ERROR`,
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-07-01T00:00:03.000Z",
+        message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+      }),
+    ].join("\n");
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("traj-5", lines),
+      "/t5.jsonl",
+      1,
+      2,
+      "h",
+    );
+    const out = exportTrajectory(db, sessionId);
+    if (!out.ok) throw new Error(`export failed: ${out.reason}`);
+    assertBothLayers(out.records);
+    const tool = out.records.find((r) => (r as { role?: string }).role === "tool") as {
+      content: string;
+    };
+    expect([...tool.content].length).toBeLessThanOrEqual(2500);
+    expect(tool.content.startsWith("HEAD")).toBe(true);
+    expect(tool.content.endsWith("TAIL-ERROR")).toBe(true);
+    expect(tool.content).toContain("… [truncated, ");
+    expect(out.report.tool_results_truncated).toBe(1);
+    db.close();
+  });
+
+  test("assistant tool calls carry explicit null content and one call each", () => {
+    const db = openDb(join(workDir, "calls.db"));
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("traj-2", fixtureContent("mcp.jsonl")),
+      "/t2.jsonl",
+      1,
+      2,
+      "h",
+    );
+    const out = exportTrajectory(db, sessionId);
+    if (!out.ok) throw new Error(`export failed: ${out.reason}`);
+    const calls = out.records.filter(
+      (r): r is { role: string; content: null; tool_calls: unknown[] } =>
+        typeof r === "object" && r != null && "tool_calls" in r,
+    );
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      expect(call.content).toBeNull();
+      expect(call.tool_calls).toHaveLength(1);
+    }
+    db.close();
+  });
+
+  test("drops orphan results, wraps non-object args, fills missing timestamps, drops noise users", () => {
+    const db = openDb(join(workDir, "repairs.db"));
+    const lines = [
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-01T00:00:00.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "<command-name>/model</command-name>" }],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-01T00:00:01.000Z",
+        message: { role: "user", content: [{ type: "text", text: "real question" }] },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-07-01T00:00:02.000Z",
+        message: {
+          role: "assistant",
+          model: "test-model",
+          content: [
+            { type: "text", text: "on it" },
+            { type: "tool_use", id: "t1", name: "Bash", input: "not-an-object" },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "t1", content: "ok" },
+            { type: "tool_result", tool_use_id: "ghost", content: "orphan" },
+          ],
+        },
+      }),
+    ].join("\n");
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("traj-3", lines),
+      "/t3.jsonl",
+      1,
+      2,
+      "h",
+    );
+    const out = exportTrajectory(db, sessionId);
+    if (!out.ok) throw new Error(`export failed: ${out.reason}`);
+    assertBothLayers(out.records);
+    expect(out.report.noise_user_records_dropped).toBe(1);
+    expect(out.report.orphan_tool_results_dropped).toBe(1);
+    expect(out.report.tool_args_wrapped).toBe(1);
+    expect(out.report.timestamps_filled).toBeGreaterThan(0);
+    const args = (
+      out.records.find((r) => typeof r === "object" && r != null && "tool_calls" in r) as {
+        tool_calls: { args: string }[];
+      }
+    ).tool_calls[0]?.args;
+    expect(JSON.parse(args ?? "{}")).toHaveProperty("_raw");
+    db.close();
+  });
+
+  test("renames duplicate call ids, pairs results temporally, counts dropped blocks", () => {
+    const db = openDb(join(workDir, "dupes.db"));
+    const lines = [
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-01T00:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "go" }] },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-07-01T00:00:01.000Z",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "   " },
+            { type: "tool_use", id: "t1", name: "Bash", input: { n: 1 } },
+            { type: "tool_use", id: "t1", name: "Bash", input: { n: 2 } },
+            { type: "tool_use", name: "NoId", input: { n: 3 } },
+            { type: "image", source: { type: "base64", data: "AAA" } },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-01T00:00:02.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t1", content: "first" }],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-01T00:00:03.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t1", content: "second" }],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-01T00:00:04.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t1", content: "third" }],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-07-01T00:00:05.000Z",
+        message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+      }),
+    ].join("\n");
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("traj-6", lines),
+      "/t6.jsonl",
+      1,
+      2,
+      "h",
+    );
+    const out = exportTrajectory(db, sessionId);
+    if (!out.ok) throw new Error(`export failed: ${out.reason}`);
+    assertBothLayers(out.records);
+
+    const callIds = out.records
+      .filter((r): r is { tool_calls: { id: string }[] } => {
+        return typeof r === "object" && r != null && "tool_calls" in r;
+      })
+      .map((r) => r.tool_calls[0]?.id);
+    expect(callIds).toEqual(["t1", "t1__dup2", `decant-${sessionId}-3`]);
+    expect(out.report.tool_call_ids_renamed).toBe(1);
+    expect(out.report.tool_call_ids_synthesized).toBe(1);
+
+    // Two calls, three results: each result pairs with the next unanswered call
+    // in appearance order, and the surplus is dropped rather than duplicated.
+    const results = out.records.filter(
+      (r): r is { tool_call_id: string; content: string } =>
+        typeof r === "object" && r != null && (r as { role?: string }).role === "tool",
+    );
+    expect(results.map((r) => [r.tool_call_id, r.content])).toEqual([
+      ["t1", "first"],
+      ["t1__dup2", "second"],
+    ]);
+    expect(out.report.duplicate_tool_results_dropped).toBe(1);
+
+    // The empty text block and the image block carry no wire content.
+    expect(out.report.dropped_blocks).toEqual({ text: 1, other: 1 });
+    db.close();
+  });
+
+  test("refuses sessions without user or assistant records", () => {
+    const db = openDb(join(workDir, "empty.db"));
+    const lines = JSON.stringify({
+      type: "assistant",
+      timestamp: "2026-07-01T00:00:00.000Z",
+      message: { role: "assistant", content: [{ type: "text", text: "hello" }] },
+    });
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("traj-4", lines),
+      "/t4.jsonl",
+      1,
+      2,
+      "h",
+    );
+    const out = exportTrajectory(db, sessionId);
+    expect(out).toEqual({ ok: false, reason: "missing_user_records" });
+    expect(exportTrajectory(db, 999999)).toEqual({ ok: false, reason: "not_found" });
+    db.close();
+  });
+});

--- a/test/export-trajectory.test.ts
+++ b/test/export-trajectory.test.ts
@@ -281,6 +281,93 @@ describe("exportTrajectory", () => {
     db.close();
   });
 
+  test("probes past a source id that already looks like one of our renames", () => {
+    const db = openDb(join(workDir, "collide.db"));
+    const lines = [
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-01T00:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "go" }] },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-07-01T00:00:01.000Z",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "t1", name: "Bash", input: { n: 1 } },
+            { type: "tool_use", id: "t1", name: "Bash", input: { n: 2 } },
+            // Renaming the line above to t1__dup2 would collide with this id.
+            { type: "tool_use", id: "t1__dup2", name: "Bash", input: { n: 3 } },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-01T00:00:02.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t1", content: "first" }],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-01T00:00:03.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t1", content: "second" }],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-07-01T00:00:04.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t1__dup2", content: "third" }],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-07-01T00:00:05.000Z",
+        message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+      }),
+    ].join("\n");
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("traj-7", lines),
+      "/t7.jsonl",
+      1,
+      2,
+      "h",
+    );
+    const out = exportTrajectory(db, sessionId);
+    if (!out.ok) throw new Error(`export failed: ${out.reason}`);
+    assertBothLayers(out.records);
+
+    const callIds = out.records
+      .filter((r): r is { tool_calls: { id: string }[] } => {
+        return typeof r === "object" && r != null && "tool_calls" in r;
+      })
+      .map((r) => r.tool_calls[0]?.id);
+    expect(callIds).toEqual(["t1", "t1__dup2", "t1__dup2__dup2"]);
+    expect(new Set(callIds).size).toBe(callIds.length);
+    expect(out.report.tool_call_ids_renamed).toBe(2);
+
+    // Results stay keyed to the call that produced them: the third result names
+    // source id t1__dup2, whose own call was renamed to t1__dup2__dup2.
+    const results = out.records.filter(
+      (r): r is { tool_call_id: string; content: string } =>
+        typeof r === "object" && r != null && (r as { role?: string }).role === "tool",
+    );
+    expect(results.map((r) => [r.tool_call_id, r.content])).toEqual([
+      ["t1", "first"],
+      ["t1__dup2", "second"],
+      ["t1__dup2__dup2", "third"],
+    ]);
+    expect(out.report.duplicate_tool_results_dropped).toBe(0);
+    db.close();
+  });
+
   test("refuses sessions without user or assistant records", () => {
     const db = openDb(join(workDir, "empty.db"));
     const lines = JSON.stringify({

--- a/test/export-trajectory.test.ts
+++ b/test/export-trajectory.test.ts
@@ -525,7 +525,14 @@ describe("exportTrajectory", () => {
         message: { role: "assistant", content: [{ type: "text", text: "offset answer" }] },
       }),
     ].join("\n");
-    const sessionId = upsertSession(db, parseClaudeSession("traj-tz", lines), "/tz.jsonl", 1, 2, "h");
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("traj-tz", lines),
+      "/tz.jsonl",
+      1,
+      2,
+      "h",
+    );
     const out = exportTrajectory(db, sessionId);
     if (!out.ok) throw new Error(`export failed: ${out.reason}`);
     assertBothLayers(out.records);

--- a/test/golden/cli/ls.json
+++ b/test/golden/cli/ls.json
@@ -26,7 +26,8 @@
     "peak_context_tokens": 0,
     "compaction_count": 0,
     "subagent_count": 0,
-    "subagent_estimated_cost_usd": 0
+    "subagent_estimated_cost_usd": 0,
+    "ingest_issue_count": 0
   },
   {
     "tool": "claude_code",
@@ -53,7 +54,8 @@
     "peak_context_tokens": 1400,
     "compaction_count": 0,
     "subagent_count": 0,
-    "subagent_estimated_cost_usd": 0
+    "subagent_estimated_cost_usd": 0,
+    "ingest_issue_count": 0
   },
   {
     "tool": "claude_code",
@@ -80,7 +82,8 @@
     "peak_context_tokens": 120,
     "compaction_count": 0,
     "subagent_count": 0,
-    "subagent_estimated_cost_usd": 0
+    "subagent_estimated_cost_usd": 0,
+    "ingest_issue_count": 0
   },
   {
     "tool": "codex",
@@ -109,7 +112,8 @@
     "peak_context_tokens": 0,
     "compaction_count": 0,
     "subagent_count": 0,
-    "subagent_estimated_cost_usd": 0
+    "subagent_estimated_cost_usd": 0,
+    "ingest_issue_count": 0
   },
   {
     "tool": "claude_code",
@@ -136,7 +140,8 @@
     "peak_context_tokens": 1200,
     "compaction_count": 1,
     "subagent_count": 0,
-    "subagent_estimated_cost_usd": 0
+    "subagent_estimated_cost_usd": 0,
+    "ingest_issue_count": 0
   },
   {
     "tool": "codex",
@@ -165,7 +170,8 @@
     "peak_context_tokens": 0,
     "compaction_count": 0,
     "subagent_count": 0,
-    "subagent_estimated_cost_usd": 0
+    "subagent_estimated_cost_usd": 0,
+    "ingest_issue_count": 0
   },
   {
     "tool": "claude_code",
@@ -192,6 +198,7 @@
     "peak_context_tokens": 7500,
     "compaction_count": 0,
     "subagent_count": 0,
-    "subagent_estimated_cost_usd": 0
+    "subagent_estimated_cost_usd": 0,
+    "ingest_issue_count": 0
   }
 ]

--- a/test/golden/rows/recommendations.json
+++ b/test/golden/rows/recommendations.json
@@ -119,6 +119,23 @@
     "note": null
   },
   {
+    "key": "catalog:trajectory-export",
+    "kind": "catalog",
+    "category": "Connect and automate",
+    "title": "Feed your sessions to memory tooling",
+    "detail": "Export archived sessions as trajectory-v1 records — the token-lean transcript format memory and evaluation pipelines consume. Your archive keeps sessions the CLIs have already pruned.",
+    "suggestion": null,
+    "prompt": "Using `decant export --all --as trajectory --out <dir>` (add --project or date filters via ls to curate), export the sessions I care about and wire them into my memory/evaluation tooling of choice.",
+    "url": "https://github.com/letta-ai/trajectory",
+    "link_label": "trajectory format",
+    "icon": "hero-arrow-up-tray",
+    "tone": null,
+    "score": 0,
+    "status": "open",
+    "status_source": null,
+    "note": null
+  },
+  {
     "key": "signal:cost-concentration",
     "kind": "signal",
     "category": null,

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -620,6 +620,45 @@ describe("sync", () => {
     db.close();
   });
 
+  test("tallies issues by code and stores the code on every issue row", () => {
+    const dir = freshCase();
+    const config: IngestConfig = {
+      claudeDir: join(dir, "claude"),
+      codexDir: join(dir, "codex"),
+    };
+    const sourcePath = join(config.claudeDir, "proj", "mixed.jsonl");
+    write(
+      sourcePath,
+      [
+        fixture("claude", "sample.jsonl").trimEnd(),
+        '{"type":"mystery","uuid":"m1","timestamp":"2026-05-01T10:01:00.000Z"}',
+        '{"type":"mystery","uuid":"m2","timestamp":"2026-05-01T10:02:00.000Z"}',
+        "{not json",
+      ].join("\n"),
+    );
+    const db = openFreshDb(dir);
+
+    const report = sync(db, config);
+    expect(report).toMatchObject({ scanned: 1, ingested: 1, issues: 2, failed: 0 });
+    // Two mystery lines collapse into one unknown_record_type issue.
+    expect(report.issuesByCode).toEqual({ unparsed_line: 1, unknown_record_type: 1 });
+    expect(
+      db
+        .query("SELECT code, COUNT(*) AS n FROM ingest_issue GROUP BY code ORDER BY code")
+        .all() as { code: string; n: number }[],
+    ).toEqual([
+      { code: "unknown_record_type", n: 1 },
+      { code: "unparsed_line", n: 1 },
+    ]);
+
+    // A clean source reports no codes at all.
+    write(sourcePath, fixture("claude", "sample.jsonl"));
+    const clean = sync(db, config);
+    expect(clean).toMatchObject({ ingested: 1, issues: 0 });
+    expect(clean.issuesByCode).toEqual({});
+    db.close();
+  });
+
   test("backfills effort for an unchanged source once after the schema upgrade", () => {
     const dir = freshCase();
     const config: IngestConfig = {

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -380,6 +380,99 @@ describe("upsertSession", () => {
     });
     db.close();
   });
+
+  test("stores head-tail preview for long tool output", () => {
+    const dir = freshCase();
+    const db = openFreshDb(dir);
+
+    // Create a synthetic session with a tool call that has >500 char output
+    const headText = "Starting output";
+    const middleText = "x".repeat(2000);
+    const tailText = "Error: something failed";
+    const longOutput = headText + middleText + tailText;
+
+    const content = [
+      JSON.stringify({
+        type: "user",
+        uuid: "u1",
+        parentUuid: null,
+        sessionId: "preview-test",
+        timestamp: "2026-07-01T10:00:00.000Z",
+        cwd: "/tmp",
+        gitBranch: "main",
+        version: "2.1.0",
+        message: {
+          role: "user",
+          content: "Test",
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        uuid: "a1",
+        parentUuid: "u1",
+        sessionId: "preview-test",
+        timestamp: "2026-07-01T10:00:05.000Z",
+        cwd: "/tmp",
+        gitBranch: "main",
+        version: "2.1.0",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-7",
+          stop_reason: "tool_use",
+          usage: {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+          content: [
+            {
+              type: "tool_use",
+              id: "tool-1",
+              name: "Bash",
+              input: { command: "test" },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        uuid: "u2",
+        parentUuid: "a1",
+        sessionId: "preview-test",
+        timestamp: "2026-07-01T10:00:06.000Z",
+        cwd: "/tmp",
+        gitBranch: "main",
+        version: "2.1.0",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-1",
+              is_error: false,
+              content: longOutput,
+            },
+          ],
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parseClaudeSession("preview-test", content);
+    const sessionId = upsertSession(db, parsed, "/x/preview-test.jsonl", 1, 2, "hash");
+
+    const toolCall = db
+      .query("SELECT output_preview FROM tool_call WHERE session_id = ?1")
+      .get(sessionId) as { output_preview: string };
+
+    expect(toolCall.output_preview).toContain("Starting output");
+    expect(toolCall.output_preview).toContain("Error: something failed");
+    expect(toolCall.output_preview).toContain("chars omitted");
+    expect(toolCall.output_preview.startsWith("Starting output")).toBe(true);
+    expect(toolCall.output_preview.includes("\n[… ")).toBe(true);
+
+    db.close();
+  });
 });
 
 describe("sync", () => {

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -465,10 +465,9 @@ describe("upsertSession", () => {
       .query("SELECT output_preview FROM tool_call WHERE session_id = ?1")
       .get(sessionId) as { output_preview: string };
 
-    expect(toolCall.output_preview).toContain("Starting output");
-    expect(toolCall.output_preview).toContain("Error: something failed");
-    expect(toolCall.output_preview).toContain("chars omitted");
     expect(toolCall.output_preview.startsWith("Starting output")).toBe(true);
+    expect(toolCall.output_preview.endsWith("Error: something failed")).toBe(true);
+    expect(toolCall.output_preview).toContain("chars omitted");
     expect(toolCall.output_preview.includes("\n[… ")).toBe(true);
 
     db.close();

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -6,6 +6,7 @@ import { basename, dirname, join } from "node:path";
 import { openDb } from "../src/db.ts";
 import {
   discover,
+  discoverSourcePaths,
   type IngestConfig,
   resolveSubagentParents,
   sync,
@@ -433,6 +434,35 @@ describe("sync", () => {
       { tool: "codex", name: "rollout-old.jsonl", archived: true },
       { tool: "codex", name: "rollout-one.jsonl", archived: false },
     ]);
+  });
+
+  test("discover skips workflow journal files", () => {
+    const dir = freshCase();
+    const claudeDir = join(dir, "claude");
+    const wfDir = join(
+      claudeDir,
+      "proj-a",
+      "1111aaaa-1111-aaaa-1111-aaaa1111aaaa",
+      "subagents",
+      "workflows",
+      "wf_test1",
+    );
+    const journalLine = '{"type":"agent_result","key":"a1","agentId":"agent-abc123"}\n';
+    write(join(claudeDir, "proj-a", "1111aaaa-1111-aaaa-1111-aaaa1111aaaa.jsonl"), "");
+    write(join(wfDir, "agent-abc123.jsonl"), "");
+    write(join(wfDir, "journal.jsonl"), journalLine);
+    const files = discover({ claudeDir, codexDir: join(dir, "codex") });
+    const names = files.map((file) => basename(file.path)).sort();
+    expect(names).toEqual(["1111aaaa-1111-aaaa-1111-aaaa1111aaaa.jsonl", "agent-abc123.jsonl"]);
+  });
+
+  test("discoverSourcePaths skips workflow journal files", () => {
+    const dir = freshCase();
+    const journal = join(dir, "journal.jsonl");
+    const journalLine = '{"type":"agent_result","key":"a1","agentId":"agent-abc123"}\n';
+    write(journal, journalLine);
+    expect(discoverSourcePaths([journal])).toEqual([]);
+    expect(discoverSourcePaths([dir])).toEqual([]);
   });
 
   test("is idempotent, records parse issues, and refreshes issues on reingest", () => {

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   BLOCK_TYPES,
   emptyUsage,
+  INGEST_ISSUE_CODES,
   normalizeReasoningEffort,
   REASONING_SOURCES,
   ROLES,
@@ -29,6 +30,13 @@ describe("model wire strings", () => {
     ]);
     expect(TOOL_KINDS).toEqual(["builtin", "mcp", "custom", "web_search", "tool_search"]);
     expect(REASONING_SOURCES).toEqual(["reported", "inferred", "none"]);
+    expect(INGEST_ISSUE_CODES).toEqual([
+      "unparsed_line",
+      "unknown_record_type",
+      "orphan_tool_result",
+      "duplicate_tool_use_id",
+      "duplicate_tool_result",
+    ]);
   });
 
   test("emptyUsage is all zeros (TokenUsage::default)", () => {

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -12,6 +12,7 @@ import {
   listProjects,
   listSessions,
   search,
+  sessionIngestIssues,
 } from "../src/query.ts";
 import { parseClaudeSession } from "../src/sources/claude.ts";
 import { preview } from "../src/tools.ts";
@@ -415,6 +416,52 @@ describe("query reads", () => {
       cursor = cursor[0]?.subagents ?? [];
     }
     expect(level).toBe(5);
+    db.close();
+  });
+
+  test("sessionIngestIssues returns typed rows joined by source path", () => {
+    const db = freshDb();
+    const content = readFileSync(
+      join(import.meta.dir, "..", "fixtures", "claude", "sample.jsonl"),
+      "utf8",
+    );
+    const withBadLine = `${content}not json\n`;
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("sess-issues", withBadLine),
+      "/issues.jsonl",
+      1,
+      2,
+      "h",
+    );
+    // upsertSession does not write ingest_issue (writeIngestedFile does); simulate the sync path:
+    db.query(
+      `INSERT INTO ingest_issue (source_path, line_no, error, raw_line, code, created_at)
+       VALUES ('/issues.jsonl', 99, 'x', 'not json', 'unparsed_line', datetime('now'))`,
+    ).run();
+    const issues = sessionIngestIssues(db, sessionId);
+    expect(issues).toEqual([
+      {
+        code: "unparsed_line",
+        line_no: 99,
+        error: "x",
+        raw_line: "not json",
+        created_at: expect.any(String),
+      },
+    ]);
+    expect(sessionIngestIssues(db, 999_999)).toBeNull();
+    const detail = getSession(db, sessionId);
+    expect(detail?.summary.ingest_issue_count).toBe(1);
+    expect(listSessions(db)[0]?.ingest_issue_count).toBe(1);
+
+    // A session with no source file cannot match issue rows by path, and must
+    // not fall through to every row whose source_path is also NULL.
+    db.exec("INSERT INTO session(tool, source_session_id) VALUES ('claude_code', 'no-source')");
+    db.query("INSERT INTO ingest_issue (source_path, error, code) VALUES (NULL, 'y', 'x')").run();
+    const pathless = db
+      .query("SELECT id FROM session WHERE source_session_id = 'no-source'")
+      .get() as { id: number };
+    expect(sessionIngestIssues(db, pathless.id)).toEqual([]);
     db.close();
   });
 

--- a/test/recommendations.test.ts
+++ b/test/recommendations.test.ts
@@ -164,6 +164,7 @@ describe("recommendations", () => {
       ["signal:churn:src/main.ts", "signal", "Cold", "Runbook or regression test"],
       ["signal:search-heavy", "signal", "Hot", "AGENTS.md code map"],
       ["signal:abandoned-rate", "signal", "Governance", "Planning checklist or Skill"],
+      ["signal:ingest-health", "signal", "Governance", "Release notes or upstream issue"],
       ["catalog:agents-md", "catalog", "Hot", "AGENTS.md"],
       ["catalog:claude-md", "catalog", "Hot", "Project memory"],
       ["catalog:skills", "catalog", "Procedural", "SKILL.md"],
@@ -327,6 +328,7 @@ describe("recommendations", () => {
     const out = signals(db).filter((rec) => rec.key === "signal:ingest-health");
     expect(out).toHaveLength(1);
     expect(out[0]?.title).toContain("5");
+    db.close();
   });
 
   test("regenerate is idempotent and preserves implemented state", () => {

--- a/test/recommendations.test.ts
+++ b/test/recommendations.test.ts
@@ -309,6 +309,26 @@ describe("recommendations", () => {
     db.close();
   });
 
+  test("ingest-health signal fires when recent sessions carry drift diagnostics", () => {
+    const db = freshDb();
+    // 20 recent sessions, 5 with unknown_record_type issues on their source
+    for (let i = 0; i < 20; i += 1) {
+      db.query(
+        `INSERT INTO session (tool, source_session_id, source_path, started_at)
+         VALUES ('claude_code', ?1, ?2, datetime('now','-1 day'))`,
+      ).run(`s${i}`, `/src/s${i}.jsonl`);
+    }
+    for (let i = 0; i < 5; i += 1) {
+      db.query(
+        `INSERT INTO ingest_issue (source_path, line_no, error, raw_line, code, created_at)
+         VALUES (?1, NULL, 'unknown record type "fallback" on 3 line(s)', NULL, 'unknown_record_type', datetime('now'))`,
+      ).run(`/src/s${i}.jsonl`);
+    }
+    const out = signals(db).filter((rec) => rec.key === "signal:ingest-health");
+    expect(out).toHaveLength(1);
+    expect(out[0]?.title).toContain("5");
+  });
+
   test("regenerate is idempotent and preserves implemented state", () => {
     const db = base();
     seedTool(db, "fetch", "mcp", "svc", 25, 5);

--- a/test/recommendations.test.ts
+++ b/test/recommendations.test.ts
@@ -87,6 +87,7 @@ describe("recommendations", () => {
       "catalog:subagents",
       "catalog:mcp",
       "catalog:hooks",
+      "catalog:trajectory-export",
     ]);
     expect(rows[0]).toMatchObject({
       kind: "catalog",
@@ -335,7 +336,9 @@ describe("recommendations", () => {
     const db = base();
     seedTool(db, "fetch", "mcp", "svc", 25, 5);
     regenerate(db);
-    expect((db.query("SELECT COUNT(*) AS n FROM recommendation").get() as { n: number }).n).toBe(9);
+    expect((db.query("SELECT COUNT(*) AS n FROM recommendation").get() as { n: number }).n).toBe(
+      10,
+    );
     const firstSeen = (
       db
         .query("SELECT first_seen_at FROM recommendation WHERE key = 'catalog:agents-md'")

--- a/test/recommendations.test.ts
+++ b/test/recommendations.test.ts
@@ -173,6 +173,7 @@ describe("recommendations", () => {
       ["catalog:subagents", "catalog", "Governance", "Subagent workflow"],
       ["catalog:mcp", "catalog", "Cold", "MCP integration"],
       ["catalog:hooks", "catalog", "Governance", "Hook or preflight gate"],
+      ["catalog:trajectory-export", "catalog", "Cold", "Export integration"],
       ["signal:unknown", "signal", "Cold", "Runbook"],
     ];
     for (const [key, kind] of cases) {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -409,6 +409,30 @@ describe("server routes", () => {
     expect((await route(config, "/api/sessions/999999/context-window")).status).toBe(404);
   });
 
+  test("serves per-session ingest issues", async () => {
+    const config = freshConfig();
+    seed(config);
+    const db = openDb(config.dbPath);
+    db.query(
+      `INSERT INTO ingest_issue (source_path, line_no, error, raw_line, code, created_at)
+       VALUES ('/x/claude-sample.jsonl', 99, 'not json', 'not json', 'unparsed_line', datetime('now'))`,
+    ).run();
+    db.close();
+
+    const sessions = await route(config, "/api/sessions?tool=claude_code&limit=10");
+    const id =
+      (sessions.body as { id: number; source_session_id: string }[]).find(
+        (session) => session.source_session_id === "sess-claude-sample",
+      )?.id ?? 0;
+
+    const issues = await route(config, `/api/sessions/${id}/issues`);
+    expect(issues.status).toBe(200);
+    expect(issues.body).toEqual([
+      expect.objectContaining({ code: "unparsed_line", line_no: 99, error: "not json" }),
+    ]);
+    expect((await route(config, "/api/sessions/999999/issues")).status).toBe(404);
+  });
+
   test("returns stats, files, tools, and recommendations", async () => {
     const config = freshConfig();
     seed(config);

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { classifyTool, preview } from "../src/tools.ts";
+import { classifyTool, preview, previewHeadTail } from "../src/tools.ts";
 
 // Ports tools.rs tests verbatim.
 describe("classifyTool", () => {
@@ -43,5 +43,28 @@ describe("preview", () => {
     // and truncation at 2 must not split a surrogate pair.
     expect(preview("🎉🎉🎉", 3)).toBe("🎉🎉🎉");
     expect(preview("🎉🎉🎉", 2)).toBe("🎉🎉…");
+  });
+});
+
+describe("previewHeadTail", () => {
+  test("returns short strings unchanged", () => {
+    expect(previewHeadTail("all good", 500)).toBe("all good");
+  });
+
+  test("keeps head and tail with an elision marker", () => {
+    const s = `HEAD${"x".repeat(2000)}Error: assertion failed at foo.ts:42`;
+    const out = previewHeadTail(s, 100);
+    expect(out.startsWith("HEAD")).toBe(true);
+    expect(out.endsWith("Error: assertion failed at foo.ts:42".slice(-40))).toBe(true);
+    expect(out).toContain("chars omitted");
+  });
+
+  test("counts Unicode scalars without splitting surrogate pairs", () => {
+    const s = "🎉".repeat(300);
+    const out = previewHeadTail(s, 100);
+    expect(out).not.toContain("�");
+    for (const part of out.split(/\n\[… \d+ chars omitted …\]\n/)) {
+      expect([...part].every((c) => c === "🎉")).toBe(true);
+    }
   });
 });

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -67,4 +67,7 @@ describe("previewHeadTail", () => {
       expect([...part].every((c) => c === "🎉")).toBe(true);
     }
   });
+  test("keeps no tail when max is too small for one, without leaking the whole string", () => {
+    expect(previewHeadTail("abcdef", 2)).toBe("ab\n[… 4 chars omitted …]\n");
+  });
 });

--- a/test/ui-ingest-issues.test.ts
+++ b/test/ui-ingest-issues.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "bun:test";
+import { formatIssueBadge } from "../src/ui/ingest-issues.ts";
+
+test("formats the badge label", () => {
+  expect(formatIssueBadge(1)).toBe("1 ingest issue");
+  expect(formatIssueBadge(3)).toBe("3 ingest issues");
+});

--- a/test/watch.test.ts
+++ b/test/watch.test.ts
@@ -146,6 +146,7 @@ describe("watch mode", () => {
           ingested: 2,
           skipped: 1,
           issues: 0,
+          issuesByCode: {},
           failed: 0,
           cancelled: false,
         };


### PR DESCRIPTION
## Summary

Two phases, 20 commits, executed task-by-task with per-task review gates and a final whole-branch review.

**Phase A — ingest trust**
- Exclude Claude Code workflow `journal.jsonl` files from discovery (both doors), and purge phantom sessions earlier builds created from them (**schema v16**, data-only, FK-safe)
- Head-tail previews for stored tool output (`previewHeadTail`), so error tails survive in `tool_call.output_preview`
- Typed ingest-diagnostics taxonomy (5 codes: `unparsed_line`, `unknown_record_type`, `orphan_tool_result`, `duplicate_tool_use_id`, `duplicate_tool_result`) emitted by both parsers, with a format-drift sensor for unknown record types
- **Schema v17**: `ingest_issue.code` + source-path index; issue counts on session summaries; new `GET /api/sessions/:id/issues` route; `sync --json` gains `issues_by_code`; exit 3 now keys on data-loss issues only (behavior-identical today)
- UI: warning badge + on-demand issues panel on session detail (`raw_line` deliberately never rendered)
- Recommendations: `signal:ingest-health` drift signal + promotion card

**Phase B — trajectory-v1 interop**
- `exportTrajectory` serializer emitting letta-ai/trajectory v1 records — meta-first single JSON array, five wire roles, globally unique call ids (collision-probing rename), their exact marker-inclusive truncation (verified byte-identical to `@letta-ai/trajectory`'s normalizer), noise-prefix filtering, structure-preserving leaf-shrinking for over-cap args
- `decant export --as trajectory` (`--all`, `--include-subagents`, `--out`), writing `<id>.trajectory.json`; repairs/drops summary on stderr
- Tests validate every emitted transcript against **both** `validateTranscript` and the shipped JSON Schema (ajv) — both devDependencies only; runtime stays dependency-free (invariant 3)
- Catalog card pointing users at the export path; agent-executable `docs/prompts/add-source.md` contributor prompt

## Notes for review
- Export's format flag is `--as` (not `--format`): the global `--format` collides under Commander, and the alternative root-parsing change broke post-subcommand globals everywhere (justfile wrappers, bug-report template). Regression tests now pin that invocation shape.
- Migrations are narrow and stacked-tested (v15→17 in one reopen, v8→17 ladder, populated-table cases).
- AGENTS.md invariant 5 updated v15 → v17.
- Test suite 437 → 468; `bunx tsc --noEmit` and `bunx biome check .` clean; all commits signed.

https://claude.ai/code/session_018GuzzTXskGEh7cejBLgyLk