### PR TITLE
Scorecard hardening: CodeQL, parser fuzzing, offline-verifiable releases

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,67 @@
+name: CodeQL
+
+# Static analysis (SAST) for the two CodeQL-supported languages in this repo:
+# the TypeScript app and the GitHub Actions workflows that release it.
+# Advanced setup on purpose — default setup must stay unconfigured (GitHub
+# rejects advanced-workflow SARIF otherwise) and this way the configuration is
+# reviewable, SHA-pinned, and linted like every other workflow here. Findings
+# land in the Security tab under code scanning.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly refresh so updated query packs re-scan main even when it is
+    # quiet. Deliberately offset from scorecard.yml's Monday 05:27 slot.
+    - cron: "43 6 * * 2"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Default-deny, then grant per job. A job that needs more than `contents: read`
+# has to say so at its own level, so widening this file later cannot silently
+# widen a job that never asked for it.
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write # upload CodeQL results to code scanning
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Neither language compiles; `none` skips the autobuild step.
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Nothing here pushes; don't leave the token in .git/config.
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # security-extended: this codebase parses untrusted JSONL from disk
+          # and serves a loopback web API, exactly the territory of the
+          # extended suite's lower-severity security queries (prototype
+          # pollution, ReDoS, path traversal). Not security-and-quality —
+          # Biome owns code quality, and mixing the two buries security
+          # findings in style noise.
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -553,7 +553,7 @@ jobs:
         run: bun run scripts/build-npm.ts --target all --binary-dir dist/bin --out-dir dist/npm --no-build --clean --version "$VERSION"
 
       # Every published package must carry the license texts (Apache-2.0 §4(d)) —
-      # the four platform packages plus both launchers.
+      # the four platform packages plus the launcher.
       - name: Assert LICENSE and NOTICE staged in all five packages
         run: |
           set -euo pipefail
@@ -584,11 +584,13 @@ jobs:
       # npx user hits — against the STAGED packages, before anything is
       # irrevocably published. No DECANT_BINARY_PATH override.
       #
-      # BOTH launchers run here. They ship identical content under different
-      # names, but npm-smoke only exercises the unscoped one post-publish, so this
-      # is the only place `@dosu/decant` is ever executed — and a launcher that
-      # cannot resolve its platform package is unrecoverable once published. Each
-      # gets its own scratch project, which is how a real user installs them.
+      # The launcher (`@dosu/decant`, staged under dist/npm/decant — npm refuses
+      # the unscoped name, see scripts/distribution.ts) runs here in its own
+      # scratch project, which is how a real user installs it. This is its only
+      # pre-publish execution — npm-smoke exercises it again after publishing,
+      # but a launcher that cannot resolve its platform package is
+      # unrecoverable once published, so it must prove itself before anything
+      # ships.
       - name: Pack-and-install smoke on staged packages (pre-publish)
         run: |
           set -euo pipefail
@@ -601,6 +603,11 @@ jobs:
             smoke_dir="$(mktemp -d)"
             ( cd "$smoke_dir"
               npm init -y >/dev/null
+              # Scorecard's Pinned-Dependencies check flags every `npm install`
+              # that is not `npm ci`, but these are the two tarballs this run
+              # just built and packed — there is no registry fetch to hash-pin,
+              # and `npm ci` cannot install local tarballs. The corresponding
+              # code-scanning alert is dismissed as won't-fix.
               npm install --ignore-scripts --no-audit --no-fund \
                 "$GITHUB_WORKSPACE/dist/npm/decant-linux-x64/$platform_tgz" \
                 "$GITHUB_WORKSPACE/dist/npm/${launcher_dir}/$launcher_tgz"
@@ -625,12 +632,12 @@ jobs:
       # OIDC trusted publishing: NO NODE_AUTH_TOKEN anywhere in this step — its
       # presence silently flips npm onto the legacy token path.
       #
-      # Publish ORDER MATTERS: the four platform packages first, because both
-      # launchers declare optionalDependencies on them, then `decant` (unscoped),
-      # then `@dosu/decant`. Package names come from each staged manifest — the
-      # directory name is not the package name for the two launchers, and a
-      # hard-coded guess would make the `npm view` idempotency check test a
-      # different package than the one `npm publish` ships. Same channel on all five.
+      # Publish ORDER MATTERS: the four platform packages first, because the
+      # launcher declares optionalDependencies on them, then `@dosu/decant`.
+      # Package names come from each staged manifest — the launcher's directory
+      # name (dist/npm/decant) is not its package name, and a hard-coded guess
+      # would make the `npm view` idempotency check test a different package
+      # than the one `npm publish` ships. Same channel on all five.
       - name: Publish packages (OIDC trusted publishing)
         if: env.HAS_NPM_TOKEN != 'true'
         run: |
@@ -665,7 +672,7 @@ jobs:
           done
 
   # Post-publish smoke: the exact code path every real `npx @dosu/decant` user hits —
-  # the unscoped launcher is the invocation the docs tell people to type —
+  # the scoped launcher is the invocation the docs tell people to type —
   # including real optionalDependencies resolution off the live registry.
   npm-smoke:
     name: Post-publish npx smoke (${{ matrix.target }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,14 +333,35 @@ jobs:
           done
           (cd dist/release && sha256sum decant-*.tar.gz | tee SHA256SUMS)
 
-      # Default mode = SLSA build provenance. Raw binaries are attested too, so a
-      # user can verify the extracted `decant` after unpacking a tarball.
-      - name: Attest build provenance (tarballs + raw binaries)
+      # Default mode = SLSA build provenance. Raw binaries are attested too, so
+      # a user can verify the extracted `decant` after unpacking a tarball, and
+      # SHA256SUMS so the checksum file everything else verifies against is
+      # itself provenance-covered.
+      - name: Attest build provenance (tarballs, raw binaries, SHA256SUMS)
+        id: attest
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: |
             dist/release/decant-*.tar.gz
             dist/bin/*/decant
+            dist/release/SHA256SUMS
+
+      # Ship the Sigstore bundle actions/attest just wrote as a release asset:
+      # anyone can then verify provenance offline (gh attestation verify
+      # --bundle) without the GitHub API, and OpenSSF Scorecard's
+      # Signed-Releases probe recognizes the .sigstore.json suffix.
+      # Deliberately NOT listed in SHA256SUMS — SHA256SUMS is one of the
+      # bundle's attested subjects, so covering the bundle there would be
+      # circular; the Sigstore signature is its integrity. Staged into
+      # dist/release so it rides the release-tarballs artifact into the
+      # github-release job.
+      - name: Stage attestation bundle as a release asset
+        env:
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          set -euo pipefail
+          [ -s "$BUNDLE_PATH" ] || { echo "::error::actions/attest reported no bundle at '${BUNDLE_PATH}'"; exit 1; }
+          cp "$BUNDLE_PATH" "dist/release/decant-${VERSION}.sigstore.json"
 
       - name: Upload pre-signing hashes
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -730,15 +751,20 @@ jobs:
           IS_LATEST: ${{ needs.meta.outputs.is_latest }}
         run: |
           set -euo pipefail
+          # The attestation bundle is a named asset on every release; a missing
+          # bundle means the build job's staging step silently changed — fail
+          # closed rather than publish a release without it.
+          bundle="decant-${TAG#v}.sigstore.json"
+          [ -f "$bundle" ] || { echo "::error::attestation bundle ${bundle} missing from the release-tarballs artifact"; exit 1; }
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "::notice::$TAG already has a release — refreshing assets only (gh release create would 422)"
-            gh release upload "$TAG" ./*.tar.gz SHA256SUMS install.sh --clobber
+            gh release upload "$TAG" ./*.tar.gz "$bundle" SHA256SUMS install.sh --clobber
           else
             flags=(--verify-tag --generate-notes)
             [ "$PRERELEASE" = "true" ] && flags+=(--prerelease)
             [ "$IS_LATEST" = "true" ] || flags+=(--latest=false)  # GitHub marks the newest-created
               # release "Latest" by default — a backport would hijack releases/latest/download/
-            gh release create "$TAG" ./*.tar.gz SHA256SUMS install.sh "${flags[@]}"
+            gh release create "$TAG" ./*.tar.gz "$bundle" SHA256SUMS install.sh "${flags[@]}"
           fi
 
   docker:

--- a/README.md
+++ b/README.md
@@ -244,8 +244,9 @@ notarized, so a tarball downloaded through a browser carries
 `com.apple.quarantine` and Gatekeeper blocks the first run. Clear it with
 `xattr -d com.apple.quarantine ./decant`. `brew install`, `npx @dosu/decant`, and the
 install script are unaffected, because none of them set the quarantine
-attribute. Integrity comes from SLSA build provenance, `SHA256SUMS`, and the
-`gh attestation verify` check `install.sh` runs.
+attribute. Integrity comes from SLSA build provenance (published with each
+release as an offline-verifiable `decant-<version>.sigstore.json` bundle),
+`SHA256SUMS`, and the `gh attestation verify` check `install.sh` runs.
 
 **Upgrading.** `npx @dosu/decant@latest` always resolves the newest published
 version. For a persistent install, run `npm i -g @dosu/decant@latest`,

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "ajv": "^8.20.0",
+        "fast-check": "^4.9.0",
         "typescript": "^7.0.2",
       },
     },
@@ -104,6 +105,8 @@
 
     "echarts": ["echarts@6.1.0", "", { "dependencies": { "tslib": "2.3.0", "zrender": "6.1.0" } }, "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA=="],
 
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
@@ -111,6 +114,8 @@
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "lucide-react": ["lucide-react@1.23.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw=="],
+
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -247,11 +247,11 @@ current project, so install the release into a scratch project first:
 ```sh
 mkdir -p /tmp/decant-verify && cd /tmp/decant-verify
 npm init -y >/dev/null
-npm install decant@0.1.0
+npm install @dosu/decant@0.1.0
 npm audit signatures
 ```
 
-**LICENSE and NOTICE.** Every published package — both launchers and all four
+**LICENSE and NOTICE.** Every published package — the launcher and all four
 platform packages — ships both files. `npm pack <pkg>@<version>` downloads the
 registry tarball so you can inspect exactly what users receive:
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -48,9 +48,9 @@ bun run scripts/build-npm.ts --target all --clean --version 0.1.0
 ```
 
 Release builds stamp the same version into package metadata and the compiled
-binary. The release workflow publishes all platform packages first, then both
-launcher packages, so `optionalDependencies` always point at packages that
-already exist.
+binary. The release workflow publishes all platform packages first, then the
+launcher, so `optionalDependencies` always point at packages that already
+exist.
 
 The launcher prints a clear reinstall message if optional dependencies were
 disabled and the matching platform package is missing. Windows packages are

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -231,6 +231,15 @@ gh attestation verify oci://ghcr.io/dosu-ai/decant:0.1.0 -R dosu-ai/decant
 
 The `oci://` form needs a registry login first (`docker login ghcr.io`).
 
+Each release also ships its attestation as `decant-<version>.sigstore.json`
+(covering the tarballs, the raw binaries, and `SHA256SUMS` itself), so
+verification works offline from release assets alone:
+
+```sh
+gh attestation verify decant-darwin-arm64.tar.gz -R dosu-ai/decant \
+  --bundle decant-0.2.0.sigstore.json
+```
+
 **npm provenance.** Confirm the published packages carry Sigstore-signed
 provenance. `npm audit signatures` checks the packages installed in the
 current project, so install the release into a scratch project first:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -92,8 +92,11 @@ Every release after the bootstrap:
    - `curl -fsSL .../install.sh | sh` on one machine.
    - On a Mac, run the darwin tarball binary once — this catches signature
      regressions no Linux job can.
-   - Confirm the release page has all four tarballs plus `SHA256SUMS`, and run
-     `gh attestation verify` on one asset.
+   - Confirm the release page has all four tarballs, `SHA256SUMS`, and the
+     `decant-<version>.sigstore.json` attestation bundle, and run
+     `gh attestation verify` on one asset (append
+     `--bundle decant-<version>.sigstore.json` to verify offline from the
+     bundle the release ships).
    - `brew upgrade decant` — the tap is a published channel, so a stale
      formula is a user-visible regression, not a cosmetic one.
 5. **Failure recovery.** Fix the problem, don't delete anything, and re-run.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "ajv": "^8.20.0",
+    "fast-check": "^4.9.0",
     "typescript": "^7.0.2"
   },
   "dependencies": {

--- a/test/parser-properties.test.ts
+++ b/test/parser-properties.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import fc from "fast-check";
+import { INGEST_ISSUE_CODES } from "../src/model.ts";
 import { parseClaudeSession } from "../src/sources/claude.ts";
 import { parseCodexSession } from "../src/sources/codex.ts";
 
 // Property-based coverage for the parser totality invariant (AGENTS.md:
 // core modules return data and Result-style errors): arbitrary bytes on
-// disk must never make a parser throw, and malformed JSONL lines must be
-// reported exactly, as issues, without derailing neighboring lines.
+// disk must never make a parser throw, malformed JSONL lines must be
+// reported exactly as unparsed_line issues without derailing neighboring
+// lines, and every issue must obey the typed-diagnostics contract in
+// src/model.ts (known code, in-bounds lineNo, rawLine only on
+// unparsed_line).
 
 const jsonLine = fc.json({ maxDepth: 3, stringUnit: "binary" });
 const blankLine = fc.constantFrom("", " ", "\t", " \t ");
@@ -54,9 +58,20 @@ for (const { name, tool, parse } of parsers) {
       fc.assert(
         fc.property(arbitraryContent, (content) => {
           const parsed = parse(content);
+          const lineCount = content.split(/\n/).length;
           expect(parsed.session.tool).toBe(tool);
-          expect(Array.isArray(parsed.issues)).toBe(true);
           expect(Array.isArray(parsed.session.messages)).toBe(true);
+          for (const issue of parsed.issues) {
+            expect(INGEST_ISSUE_CODES).toContain(issue.code);
+            expect(issue.error).not.toBe("");
+            if (issue.lineNo != null) {
+              expect(issue.lineNo).toBeGreaterThanOrEqual(1);
+              expect(issue.lineNo).toBeLessThanOrEqual(lineCount);
+            }
+            if (issue.code !== "unparsed_line") {
+              expect(issue.rawLine).toBeNull();
+            }
+          }
         }),
       );
     });
@@ -69,24 +84,26 @@ for (const { name, tool, parse } of parsers) {
       );
     });
 
-    test("flags exactly the malformed lines", () => {
+    test("flags exactly the malformed lines as unparsed", () => {
       fc.assert(
         fc.property(taggedLines, (lines) => {
           const { issues } = parse(lines.map((tagged) => tagged.line).join("\n"));
+          const unparsed = issues.filter((issue) => issue.code === "unparsed_line");
           const expected = lines.flatMap((tagged, index) => (tagged.broken ? [index + 1] : []));
-          expect(issues.map((issue) => issue.lineNo)).toEqual(expected);
-          for (const issue of issues) {
+          expect(unparsed.map((issue) => issue.lineNo)).toEqual(expected);
+          for (const issue of unparsed) {
             expect(issue.error).not.toBe("");
-            expect(issue.rawLine).toBe(lines[issue.lineNo - 1]?.line ?? "");
+            expect(issue.rawLine).toBe(lines[(issue.lineNo ?? 0) - 1]?.line ?? "");
           }
         }),
       );
     });
 
-    test("valid json lines and blank lines never produce issues", () => {
+    test("valid json lines and blank lines never become unparsed-line issues", () => {
       fc.assert(
         fc.property(fc.array(fc.oneof(jsonLine, blankLine), { maxLength: 30 }), (lines) => {
-          expect(parse(lines.join("\n")).issues).toEqual([]);
+          const { issues } = parse(lines.join("\n"));
+          expect(issues.filter((issue) => issue.code === "unparsed_line")).toEqual([]);
         }),
       );
     });

--- a/test/parser-properties.test.ts
+++ b/test/parser-properties.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import { parseClaudeSession } from "../src/sources/claude.ts";
+import { parseCodexSession } from "../src/sources/codex.ts";
+
+// Property-based coverage for the parser totality invariant (AGENTS.md:
+// core modules return data and Result-style errors): arbitrary bytes on
+// disk must never make a parser throw, and malformed JSONL lines must be
+// reported exactly, as issues, without derailing neighboring lines.
+
+const jsonLine = fc.json({ maxDepth: 3, stringUnit: "binary" });
+const blankLine = fc.constantFrom("", " ", "\t", " \t ");
+// A complete JSON value with a trailing brace is always a syntax error,
+// never blank, and never spans lines.
+const brokenLine = jsonLine.map((line) => `${line}}`);
+
+interface TaggedLine {
+  line: string;
+  broken: boolean;
+}
+
+const taggedLines = fc.array(
+  fc.oneof(
+    jsonLine.map((line): TaggedLine => ({ line, broken: false })),
+    blankLine.map((line): TaggedLine => ({ line, broken: false })),
+    brokenLine.map((line): TaggedLine => ({ line, broken: true })),
+  ),
+  { maxLength: 30 },
+);
+
+const arbitraryContent = fc.oneof(
+  fc.string({ unit: "binary", maxLength: 2000 }),
+  fc
+    .array(fc.string({ unit: "binary", maxLength: 200 }), { maxLength: 20 })
+    .map((lines) => lines.join("\n")),
+);
+
+const parsers = [
+  {
+    name: "parseClaudeSession",
+    tool: "claude_code",
+    parse: (content: string) => parseClaudeSession("prop-session", content),
+  },
+  {
+    name: "parseCodexSession",
+    tool: "codex",
+    parse: (content: string) => parseCodexSession("prop-session", content, new Map()),
+  },
+] as const;
+
+for (const { name, tool, parse } of parsers) {
+  describe(name, () => {
+    test("never throws and returns a well-formed session for arbitrary content", () => {
+      fc.assert(
+        fc.property(arbitraryContent, (content) => {
+          const parsed = parse(content);
+          expect(parsed.session.tool).toBe(tool);
+          expect(Array.isArray(parsed.issues)).toBe(true);
+          expect(Array.isArray(parsed.session.messages)).toBe(true);
+        }),
+      );
+    });
+
+    test("parses the same content to the same result", () => {
+      fc.assert(
+        fc.property(arbitraryContent, (content) => {
+          expect(parse(content)).toEqual(parse(content));
+        }),
+      );
+    });
+
+    test("flags exactly the malformed lines", () => {
+      fc.assert(
+        fc.property(taggedLines, (lines) => {
+          const { issues } = parse(lines.map((tagged) => tagged.line).join("\n"));
+          const expected = lines.flatMap((tagged, index) => (tagged.broken ? [index + 1] : []));
+          expect(issues.map((issue) => issue.lineNo)).toEqual(expected);
+          for (const issue of issues) {
+            expect(issue.error).not.toBe("");
+            expect(issue.rawLine).toBe(lines[issue.lineNo - 1]?.line ?? "");
+          }
+        }),
+      );
+    });
+
+    test("valid json lines and blank lines never produce issues", () => {
+      fc.assert(
+        fc.property(fc.array(fc.oneof(jsonLine, blankLine), { maxLength: 30 }), (lines) => {
+          expect(parse(lines.join("\n")).issues).toEqual([]);
+        }),
+      );
+    });
+
+    test("numbers messages sequentially from zero", () => {
+      fc.assert(
+        fc.property(arbitraryContent, (content) => {
+          const { session } = parse(content);
+          for (const [index, message] of session.messages.entries()) {
+            expect(message.seq).toBe(index);
+          }
+        }),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Addresses every OpenSSF Scorecard gap that is fixable in-repo (score today: 6.2), and stands up CodeQL so real SAST alerts exist at all.

> Rebased onto main after #63 landed: devDependency union (`ajv` + `fast-check`), and the parser property tests were adapted to the new typed-diagnostics contract (issues carry a `code`, unrecognized-but-valid JSON emits aggregated `unknown_record_type` issues, `rawLine` only on `unparsed_line`).

## What changed

| Scorecard check | Was | Change |
|---|---|---|
| SAST | 0 | New `codeql.yml`: advanced setup, `javascript-typescript` + `actions`, `security-extended`, weekly cron, SHA-pinned to the same codeql-action bundle scorecard.yml uses |
| Fuzzing | 0 | `fast-check` property tests for both JSONL session parsers (`test/parser-properties.test.ts`): totality (never throws on arbitrary bytes), determinism, exact malformed-line reporting scoped to `unparsed_line`, typed-diagnostics contract invariants, sequential message numbering |
| Signed-Releases | 0 | The build job already attests tarballs + binaries; the bundle now ships as a release asset (`decant-<version>.sigstore.json`, fail-closed on both create/refresh paths), `SHA256SUMS` joins the attested subjects, docs gain the offline `gh attestation verify --bundle` recipe |
| Pinned-Dependencies | 9 | Documented why the pre-publish smoke's `npm install` of two locally built tarballs is unpinnable (only `npm ci` satisfies the check, and it cannot install local tarballs); the alert will be dismissed as won't-fix |

Adjacent fixes found while auditing: release.yml and docs still described **two** npm launchers (a scoped and an unscoped one) — there is exactly one (`@dosu/decant`; npm's typosquat check refused the unscoped name), and `docs/distribution.md`'s provenance recipe told readers to `npm install decant@0.1.0`, an unscoped package that was never ours.

## Not fixable in code — maintainer follow-ups

- **CII-Best-Practices (0)**: register at <https://www.bestpractices.dev> ("in progress" scores 2, "passing" scores 10).
- **Branch-Protection (5)**: wants enforce-for-admins, 2 approvals, CODEOWNERS review, last-push approval — enabling those hard-blocks solo self-merges; leaving as-is is a deliberate trade-off.
- **Code-Review (1) / Contributors (3) / Maintained (0)**: process, team size, and repo age (<90 days); resolve with time, not code.
- **Signed-Releases arithmetic**: scores average over the last 5 releases, so with unsigned `v0.1.0-rc.2` in the window the next release lands at 4/10, reaching 8 as rc releases age out, get deleted, or get backfilled (`gh attestation download` → upload the bundle to the rc release).
- After merge: dismiss Scorecard alert #5 (Pinned-Dependencies) as won't-fix with the rationale now inlined in release.yml.

## Verification

- `just check` green on the rebased branch: 480 tests (10 property tests), tsc, biome, dist staging smoke.
- `actionlint -shellcheck=shellcheck` (1.7.12, same as CI) and `zizmor --persona=regular --min-severity=medium --no-online-audits` both clean on all five workflows.
- CodeQL on the rebased merge ref: **0 findings** across 103 javascript-typescript rules and 23 actions rules — including #63's new code.
- Release changes can't run without a tag; the next `v*` tag rehearses the bundle staging + publish path end-to-end (the fail-closed check makes a silent regression impossible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
