### PR TITLE
Fix the four real findings from CodeQL's first scan

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1177,11 +1177,19 @@ function emitArtifact(
   artifactOptions: ArtifactOptions,
 ): number {
   if (artifactOptions.out != null) {
-    if (existsSync(artifactOptions.out) && artifactOptions.force !== true) {
-      io.writeErr(`error: ${artifactOptions.out} exists (use --force to overwrite)\n`);
-      return 2;
+    // "wx" makes the no-clobber check and the write one atomic open(O_EXCL)
+    // instead of exists-then-write.
+    try {
+      writeFileSync(artifactOptions.out, artifact, {
+        flag: artifactOptions.force === true ? "w" : "wx",
+      });
+    } catch (error) {
+      if ((error as { code?: string }).code === "EEXIST") {
+        io.writeErr(`error: ${artifactOptions.out} exists (use --force to overwrite)\n`);
+        return 2;
+      }
+      throw error;
     }
-    writeFileSync(artifactOptions.out, artifact);
     if (!options.quiet) {
       io.writeErr(`wrote ${artifactOptions.out}\n`);
     }

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -121,38 +121,41 @@ export function sync(
       break;
     }
 
-    let stats: Stats;
+    // One descriptor for everything: the skip decision, the recorded stat,
+    // and the content read all describe the same inode, so a path swapped
+    // mid-loop can neither skip wrongly nor record metadata for content that
+    // was never read. A file that vanished before open is a silent skip,
+    // matching the old stat-failure path; any other open error counts as
+    // failed, matching the old read-failure path.
+    let fd: number;
     try {
-      stats = statSync(file.path);
-    } catch {
+      fd = openSync(file.path, "r");
+    } catch (error) {
+      if ((error as { code?: string }).code !== "ENOENT") {
+        report.failed += 1;
+      }
       continue;
     }
-    const size = stats.size;
-    const mtime = mtimeSecs(stats);
-    const prior = db
-      .query("SELECT size, mtime FROM ingest_source WHERE path = ?1")
-      .get(file.path) as { size: number; mtime: number } | null;
-    if (prior != null && prior.size === size && prior.mtime === mtime) {
-      report.skipped += 1;
-      continue;
-    }
-
+    let stats: Stats;
     let content: string;
     try {
-      // One descriptor for both: fstat and read cannot disagree about which
-      // file they saw. Stat first so a write landing mid-window records a
-      // smaller size than the content read — the next sync then re-ingests
-      // instead of silently skipping the tail.
-      const fd = openSync(file.path, "r");
-      try {
-        stats = fstatSync(fd);
-        content = readFileSync(fd, "utf8");
-      } finally {
-        closeSync(fd);
+      stats = fstatSync(fd);
+      const prior = db
+        .query("SELECT size, mtime FROM ingest_source WHERE path = ?1")
+        .get(file.path) as { size: number; mtime: number } | null;
+      if (prior != null && prior.size === stats.size && prior.mtime === mtimeSecs(stats)) {
+        report.skipped += 1;
+        continue;
       }
+      // fstat before read: a write landing mid-window records a smaller size
+      // than the content read, so the next sync re-ingests instead of
+      // silently skipping the tail.
+      content = readFileSync(fd, "utf8");
     } catch {
       report.failed += 1;
       continue;
+    } finally {
+      closeSync(fd);
     }
 
     const stem = fileStem(file.path);

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -155,7 +155,13 @@ export function sync(
       report.failed += 1;
       continue;
     } finally {
-      closeSync(fd);
+      try {
+        closeSync(fd);
+      } catch {
+        // A close failure (EIO on network/FUSE mounts) cannot invalidate a
+        // read that already succeeded, and a throw here would mask the real
+        // error on the failure path.
+      }
     }
 
     const stem = fileStem(file.path);

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -4,6 +4,7 @@ import type { Stats } from "node:fs";
 import {
   closeSync,
   existsSync,
+  fstatSync,
   openSync,
   readdirSync,
   readFileSync,
@@ -138,8 +139,17 @@ export function sync(
 
     let content: string;
     try {
-      content = readFileSync(file.path, "utf8");
-      stats = statSync(file.path);
+      // One descriptor for both: fstat and read cannot disagree about which
+      // file they saw. Stat first so a write landing mid-window records a
+      // smaller size than the content read — the next sync then re-ingests
+      // instead of silently skipping the tail.
+      const fd = openSync(file.path, "r");
+      try {
+        stats = fstatSync(fd);
+        content = readFileSync(fd, "utf8");
+      } finally {
+        closeSync(fd);
+      }
     } catch {
       report.failed += 1;
       continue;

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentKey, IdeKey, TerminalKey, UserSettings } from "./settings.ts";
@@ -63,12 +63,17 @@ export function launchAgent(
     };
   }
 
-  const promptFile = join(tmpdir(), options.tempName?.() ?? `decant-prompt-${Date.now()}.txt`);
-  writeFileSync(promptFile, fullPrompt);
+  // mkdtemp gives a fresh 0700 directory, so no other local user can
+  // pre-plant a symlink at a predictable /tmp name or read the prompt; the
+  // file itself is 0600 and the launched shell removes the whole directory
+  // after consuming it.
+  const promptDir = mkdtempSync(join(tmpdir(), "decant-launch-"));
+  const promptFile = join(promptDir, options.tempName?.() ?? "prompt.txt");
+  writeFileSync(promptFile, fullPrompt, { mode: 0o600 });
   const dir = options.env?.DECANT_SKILLS_DIR ?? process.env.DECANT_SKILLS_DIR ?? homelikeDir();
   const launchCommand =
     `cd ${shellQuote(dir)} && ${got.bin} "$(cat ${shellQuote(promptFile)}; ` +
-    `rm -f ${shellQuote(promptFile)})"`;
+    `rm -rf ${shellQuote(promptDir)})"`;
   return launchIn(settings.terminal, launchCommand, options.run ?? runCommand, options.env);
 }
 

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -1,5 +1,5 @@
 import type { Database } from "bun:sqlite";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { isAbsolute } from "node:path";
 import { compareCodePoints } from "./order.ts";
 
@@ -190,10 +190,17 @@ function stripCodename(tool: string, leaf: string): string {
 
 export function resolveGitRoot(dir: string): Resolution | null {
   const dotgit = `${dir}/.git`;
-  if (!existsSync(dotgit) || !statSync(dotgit).isFile()) {
+  // Read unconditionally instead of stat-then-read: a regular repo's `.git`
+  // directory throws EISDIR and an absent one ENOENT, both meaning "not a
+  // worktree leaf", with no window for the path to change between check and
+  // use.
+  let raw: string;
+  try {
+    raw = readFileSync(dotgit, "utf8");
+  } catch {
     return null;
   }
-  const target = readFileSync(dotgit, "utf8")
+  const target = raw
     .split(/\r?\n/)
     .map((line) => line.trim())
     .find((line) => line.startsWith("gitdir:"))

--- a/test/launcher.test.ts
+++ b/test/launcher.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { canLaunch, command, launchAgent, openIde } from "../src/launcher.ts";
 import type { UserSettings } from "../src/settings.ts";
 
@@ -39,7 +39,12 @@ describe("launcher", () => {
         return { ok: true };
       },
     });
-    rmSync(join(tmpdir(), "decant-launcher-test-prompt.txt"), { force: true });
+    // The prompt now lives in a fresh mkdtemp dir embedded in the recorded
+    // command; recover it from there to clean up.
+    const promptPath = calls[0]?.args.join(" ").match(/cat '([^']+)'/)?.[1];
+    if (promptPath != null) {
+      rmSync(dirname(promptPath), { recursive: true, force: true });
+    }
 
     expect(result).toEqual({ ok: true });
     expect(calls[0]?.bin).toBe("open");


### PR DESCRIPTION
CodeQL's first full main-branch analysis (post #64) surfaced 8 alerts. Four are real and fixed here; four are false positives dismissed with written reasons.

## Fixed

| Alert | Rule | Fix |
|---|---|---|
| #18 `src/worktree.ts` | js/file-system-race | `resolveGitRoot` reads `.git` unconditionally; ENOENT/EISDIR mean "not a worktree leaf" — no stat-then-read window |
| #17 `src/ingest.ts` | js/file-system-race | the whole per-file sequence — skip decision, recorded stat, content read — now runs on one descriptor, so a path swapped mid-loop can neither skip wrongly nor record metadata for content never read (`fstat` before read biases toward re-ingesting a mid-window write, never skipping it). The first cut left the skip-check on the path and CodeQL rightly re-flagged it (#19) — the follow-up commit closes that too |
| #16 `src/cli.ts` | js/file-system-race | artifact `--out` no-clobber uses `wx` (atomic `O_EXCL`), same message and exit code on EEXIST |
| #12 `src/launcher.ts` | js/insecure-temporary-file | prompt written 0600 inside a fresh `mkdtemp` (0700) dir; launched shell removes the whole dir after consuming it |

## Dismissed as false positives (with comments on each alert)

- **#15 `src/db.ts`** — the flagged lstat is a pre-filter; `restrictArchiveFile` re-verifies type/ownership via `fstat` on an `O_NOFOLLOW|O_NONBLOCK` descriptor before `fchmod` (see its doc comment). The race the rule describes is already closed.
- **#14/#13 workers** — dedicated workers spawned via `new Worker(new URL(...))`; message events can only come from the owning process. Cross-origin `postMessage` does not reach dedicated workers, so there is no origin to check.
- **#11 `src/server.ts`** — no `.stack` is read or serialized anywhere; the flows are `error.message`/`String(error)` (name + message only in V8/JSC), surfaced deliberately to the loopback single-operator UI (sync banner, FTS syntax feedback).

## Verification

- `just check` green: 480 tests, tsc, biome, dist staging smoke.
- CodeQL gate green on the merge ref: **0 open CodeQL alerts** for this PR.
- The launcher test recovers the mkdtemp path from the recorded command for cleanup.
- After merge, the next main CodeQL run auto-closes #16–#19 and #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
