### PR TITLE
chore(release): remove the npm bootstrap-token path — OIDC only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,10 @@
 #     Signing runs only on tag pushes and the guarded dispatch fallback — this
 #     workflow has no PR trigger. See
 #     docs/releasing.md#macos-signing-and-notarization.
-#   NPM_TOKEN            bootstrap-only granular token for the v0.1.0 first publish
-#                        (trusted publishers can only be configured on packages that
-#                        already exist). Revoke the token and delete this secret after
-#                        v0.1.0 — the OIDC path takes over automatically
-#                        (docs/releasing.md#npm-bootstrap-and-trusted-publishing).
 #   HOMEBREW_TOKEN       PAT with push access to dosu-ai/homebrew-dosu (tap-update).
+#
+# npm needs no secret: publishing is OIDC trusted publishing, configured on all
+# five packages (docs/releasing.md#npm-bootstrap-and-trusted-publishing).
 #
 # Re-run safety: every publish job is idempotent — npm skips versions
 # that already exist, github-release refreshes assets instead of 422ing, Docker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -514,15 +514,9 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-      id-token: write # OIDC trusted publishing; also required for --provenance on the bootstrap token path
+      id-token: write # OIDC trusted publishing
     env:
       VERSION: ${{ needs.meta.outputs.version }}
-      # Secrets cannot be referenced in `if:` conditionals — hence the env
-      # indirection (docs/releasing.md#npm-bootstrap-and-trusted-publishing).
-      # NPM_TOKEN exists only for the v0.1.0 bootstrap publish; once the trusted
-      # publishers are configured and the secret is deleted, the OIDC step below
-      # takes over automatically.
-      HAS_NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -630,7 +624,10 @@ jobs:
           echo "CHANNEL=$CHANNEL" >> "$GITHUB_ENV"
 
       # OIDC trusted publishing: NO NODE_AUTH_TOKEN anywhere in this step — its
-      # presence silently flips npm onto the legacy token path.
+      # presence silently flips npm onto the legacy token path. The v0.1.0
+      # bootstrap-token step that used to sit beside this one is gone: trusted
+      # publishers now exist on all five packages
+      # (docs/releasing.md#npm-bootstrap-and-trusted-publishing).
       #
       # Publish ORDER MATTERS: the four platform packages first, because the
       # launcher declares optionalDependencies on them, then `@dosu/decant`.
@@ -639,27 +636,6 @@ jobs:
       # would make the `npm view` idempotency check test a different package
       # than the one `npm publish` ships. Same channel on all five.
       - name: Publish packages (OIDC trusted publishing)
-        if: env.HAS_NPM_TOKEN != 'true'
-        run: |
-          set -euo pipefail
-          for dir in decant-darwin-arm64 decant-darwin-x64 decant-linux-arm64 decant-linux-x64 decant; do
-            pkg="$(node -p "JSON.parse(require('fs').readFileSync('dist/npm/${dir}/package.json','utf8')).name")"
-            if npm view "${pkg}@${VERSION}" version >/dev/null 2>&1; then
-              echo "::notice::${pkg}@${VERSION} already published — skipping (idempotent re-run)"
-              continue
-            fi
-            npm publish "dist/npm/${dir}" --access public --tag "$CHANNEL" --provenance
-          done
-
-      # Bootstrap token path — v0.1.0 only
-      # (docs/releasing.md#npm-bootstrap-and-trusted-publishing). Token auth on a
-      # GitHub-hosted runner emits the same Sigstore provenance as OIDC. Delete
-      # this step together with the NPM_TOKEN secret after v0.1.0. Same five
-      # packages, same order, same reasons as the OIDC step above.
-      - name: Publish packages (bootstrap token, v0.1.0 only)
-        if: env.HAS_NPM_TOKEN == 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
           for dir in decant-darwin-arm64 decant-darwin-x64 decant-linux-arm64 decant-linux-x64 decant; do

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -251,9 +251,14 @@ The shape, which `release.yml` already makes visible:
    private repository, so the repo must already be public.
 2. With the packages in existence, a trusted publisher is configured on each
    (org `dosu-ai`, repo `decant`, workflow `release.yml`).
-3. The bootstrap credential is then removed. The workflow selects its publish
-   path from whether `NPM_TOKEN` is present, so removing the secret is what
-   hands the next release to OIDC — there is no second edit to remember.
+3. The bootstrap credential is then removed and the token-path step deleted
+   from `release.yml`, leaving OIDC as the only publish path.
+
+**Status: completed 2026-07-27.** v0.1.0 published via the bootstrap token;
+trusted publishers were then configured on all five packages (org `dosu-ai`,
+repo `decant`, workflow `release.yml`, no environment, `npm publish` only),
+`NPM_TOKEN` was deleted, and the bootstrap step was removed. Every release
+from here publishes via OIDC.
 
 npm is independently deprecating this path: 2FA-bypassing tokens lose account
 and package management in August 2026 and direct publishing around January


### PR DESCRIPTION
Completes the OIDC cutover from docs/releasing.md#npm-bootstrap-and-trusted-publishing:

- Trusted publishers are live on all five packages (org `dosu-ai`, repo `decant`, workflow `release.yml`, no environment, `npm publish` only) — configured 2026-07-27
- `NPM_TOKEN` repo secret is deleted, so the token path is already dead; this removes the bootstrap step and its `HAS_NPM_TOKEN` env plumbing per the runbook's own teardown instruction
- Runbook section updated with a completed-status note
- Fixes two stale "unscoped launcher" comments left from the pre-#57 naming plan

actionlint clean locally; the workflow-lint job re-checks on this PR.

https://claude.ai/code/session_018GuzzTXskGEh7cejBLgyLk