### PR TITLE
fix: repair schema v19 drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,10 +99,13 @@ A change is ready when:
 4. **Costs are computed at ingest** with `cost::estimateCost` and stored on the
    session row. Editing pricing does not rewrite historical rows; rebuild the
    archive to recompute.
-5. **The schema baseline is v18.** Pre-v8 archives are intentionally rebuild-only:
+5. **The schema baseline is v19.** Pre-v8 archives are intentionally rebuild-only:
    delete the archive and re-ingest from the source directories. Do not add
    broad forward migrations unless that product decision changes; the narrow
-   v8-to-v18 migrations preserve existing TypeScript-cutover archives.
+   v8-to-v19 migrations preserve existing TypeScript-cutover archives. A
+   migration is frozen as soon as it is committed to a branch because a
+   dogfooding archive may already have run it. During review, put any schema
+   adjustment in a new version; never edit a committed migration.
 6. **Parsers are the extension point.** A new source tool means
    `src/sources/<tool>.ts`, synthetic fixtures, parser tests, ingest/query tests,
    and golden updates.

--- a/src/db.ts
+++ b/src/db.ts
@@ -219,6 +219,18 @@ export function openDb(path: string): Database {
 }
 
 function negotiateWalMode(db: Database): void {
+  try {
+    const current = db.query("PRAGMA journal_mode;").get() as {
+      journal_mode?: unknown;
+    } | null;
+    if (typeof current?.journal_mode === "string" && current.journal_mode.toLowerCase() === "wal") {
+      return;
+    }
+  } catch {
+    // Fall through to the write pragma, which retains the bounded contention
+    // retry and surfaces any persistent failure.
+  }
+
   const deadline = Date.now() + 5_000;
   while (true) {
     try {

--- a/src/db.ts
+++ b/src/db.ts
@@ -675,7 +675,18 @@ function migrate(db: Database, current: number): void {
             WHERE result_block.id = tool_call.result_block_id
           )
           WHERE duration_ms IS NULL
-            AND result_block_id IS NOT NULL;
+            AND result_block_id IS NOT NULL
+            AND EXISTS (
+              SELECT 1
+              FROM block AS result_block
+              JOIN message AS result_message ON result_message.id = result_block.message_id
+              LEFT JOIN message AS call_message ON call_message.id = tool_call.message_id
+              WHERE result_block.id = tool_call.result_block_id
+                AND result_message.timestamp IS NOT NULL
+                AND COALESCE(call_message.timestamp, tool_call.timestamp) IS NOT NULL
+                AND julianday(result_message.timestamp) >=
+                  julianday(COALESCE(call_message.timestamp, tool_call.timestamp))
+            );
         `);
       }
       db.query(
@@ -686,7 +697,12 @@ function migrate(db: Database, current: number): void {
     assertContiguousMigrationHistory(db, LATEST_SCHEMA_VERSION);
     db.exec("COMMIT;");
   } catch (error) {
-    db.exec("ROLLBACK;");
+    try {
+      db.exec("ROLLBACK;");
+    } catch {
+      // Preserve the migration failure if SQLite already aborted or closed
+      // the transaction, or if rollback itself encounters a secondary error.
+    }
     throw error;
   }
 }
@@ -740,14 +756,31 @@ function assertContiguousMigrationHistory(db: Database, current: number): void {
 function assertSchemaMatchesBaseline(db: Database): void {
   const expected = getExpectedSchemaManifest();
   const actual = buildSchemaManifest(db);
-  if (actual.fingerprint !== expected.fingerprint) {
-    throwSchemaDrift(
-      db,
-      `owned schema objects differ from the v${LATEST_SCHEMA_VERSION} baseline`,
-      expected,
-      actual,
-    );
+  if (actual.fingerprint === expected.fingerprint) {
+    return;
   }
+  const differences = compareSchemaManifests(expected, actual);
+  const hasFatalDifference =
+    differences.missingObjects.length > 0 ||
+    differences.changedObjects.length > 0 ||
+    differences.missingColumns.length > 0 ||
+    differences.unexpectedColumns.length > 0;
+  if (!hasFatalDifference && differences.unexpectedObjects.length > 0) {
+    logger.warning("Archive includes additive operator-owned schema objects.", {
+      "event.name": "decant.schema.additive_drift",
+      "schema.version": LATEST_SCHEMA_VERSION,
+      "schema.fingerprint.expected": expected.fingerprint,
+      "schema.fingerprint.actual": actual.fingerprint,
+      "schema.drift.unexpected_objects": summarize(differences.unexpectedObjects),
+    });
+    return;
+  }
+  throwSchemaDrift(
+    db,
+    `owned schema objects differ from the v${LATEST_SCHEMA_VERSION} baseline`,
+    expected,
+    actual,
+  );
 }
 
 function getExpectedSchemaManifest(): SchemaManifest {

--- a/src/db.ts
+++ b/src/db.ts
@@ -10,14 +10,38 @@ import {
 } from "node:fs";
 import { getDecantLogger } from "./logging.ts";
 import schemaSql from "./schema.sql" with { type: "text" };
+import {
+  buildSchemaManifest,
+  compareSchemaManifests,
+  type SchemaDifference,
+  type SchemaManifest,
+} from "./schema-manifest.ts";
 
 /// Highest schema version this build understands. src/schema.sql is the
 /// effective DDL with migrations 1..LATEST_SCHEMA_VERSION already applied
 /// and is now the frozen baseline, so a fresh archive is created in one step
 /// and stamped with the full migration history.
-export const LATEST_SCHEMA_VERSION = 18;
+export const LATEST_SCHEMA_VERSION = 19;
 
 const logger = getDecantLogger("db");
+let expectedSchemaManifest: SchemaManifest | null = null;
+const SQLITE_BUSY_RETRY_SIGNAL = new Int32Array(
+  new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT),
+);
+
+export class SchemaDriftError extends Error {
+  readonly code = "schema_drift";
+
+  constructor(
+    message: string,
+    readonly expectedFingerprint: string,
+    readonly actualFingerprint: string,
+    readonly differences: SchemaDifference,
+  ) {
+    super(message);
+    this.name = "SchemaDriftError";
+  }
+}
 
 /// Owner-only mode for the archive and its SQLite sidecars. The transcripts
 /// decant ingests sit in 0600 files under 0700 directories; the aggregate of
@@ -178,20 +202,48 @@ export function openDb(path: string): Database {
   restrictArchiveFile(`${path}-wal`);
   restrictArchiveFile(`${path}-shm`);
   const db = new Database(path, { create: true, strict: true });
-  db.exec("PRAGMA busy_timeout = 5000;");
-  db.exec("PRAGMA foreign_keys = ON;");
-  db.exec("PRAGMA synchronous = NORMAL;");
-  db.exec("PRAGMA journal_mode = WAL;");
-  // Memory-map reads: archives grow to multiple GB and large scans (FTS, block
-  // aggregation) measure 2-7x faster via mmap than via pread on such files.
-  db.exec("PRAGMA mmap_size = 1073741824;");
   try {
+    db.exec("PRAGMA busy_timeout = 5000;");
+    db.exec("PRAGMA foreign_keys = ON;");
+    db.exec("PRAGMA synchronous = NORMAL;");
+    negotiateWalMode(db);
+    // Memory-map reads: archives grow to multiple GB and large scans (FTS, block
+    // aggregation) measure 2-7x faster via mmap than via pread on such files.
+    db.exec("PRAGMA mmap_size = 1073741824;");
     ensureSchema(db);
   } catch (error) {
     closeDb(db);
     throw error;
   }
   return db;
+}
+
+function negotiateWalMode(db: Database): void {
+  const deadline = Date.now() + 5_000;
+  while (true) {
+    try {
+      db.exec("PRAGMA journal_mode = WAL;");
+      return;
+    } catch (error) {
+      if (!isSqliteContention(error) || Date.now() >= deadline) {
+        throw error;
+      }
+      Atomics.wait(
+        SQLITE_BUSY_RETRY_SIGNAL,
+        0,
+        0,
+        Math.min(10, Math.max(1, deadline - Date.now())),
+      );
+    }
+  }
+}
+
+function isSqliteContention(error: unknown): boolean {
+  const code =
+    typeof error === "object" && error != null && "code" in error
+      ? String((error as { code?: unknown }).code).toUpperCase()
+      : "";
+  return code.startsWith("SQLITE_BUSY") || code.startsWith("SQLITE_LOCKED");
 }
 
 function ensureSchema(db: Database): void {
@@ -202,6 +254,44 @@ function ensureSchema(db: Database): void {
   if (!hasMigrations) {
     db.exec("BEGIN IMMEDIATE;");
     try {
+      // A second opener can observe the same empty schema before either takes
+      // the write lock. Re-check under the lock so only one creates the
+      // baseline; the waiter validates what won the race instead of replaying
+      // CREATE TABLE statements over it.
+      if (hasTable(db, "schema_migrations")) {
+        const versions = readMigrationHistory(db);
+        const current = versions.at(-1) ?? 0;
+        if (current > LATEST_SCHEMA_VERSION) {
+          throw new Error(
+            `archive schema version ${current} is newer than this build supports ` +
+              `(${LATEST_SCHEMA_VERSION}); upgrade Decant`,
+          );
+        }
+        if (current < 8) {
+          throw new Error(
+            `archive schema version ${current} predates this build's baseline ` +
+              "(8); back up or move the archive aside before rebuilding it because " +
+              "manual recommendation state and source-pruned sessions may exist only in the database; " +
+              "then re-ingest from the source directories",
+          );
+        }
+        assertVersionSequence(db, versions, current);
+        if (current === LATEST_SCHEMA_VERSION) {
+          assertSchemaMatchesBaseline(db);
+        }
+        db.exec("COMMIT;");
+        if (current < LATEST_SCHEMA_VERSION) {
+          migrate(db, current);
+        }
+        return;
+      }
+      const existingObjects = schemaObjectNames(db);
+      if (existingObjects.length > 0) {
+        throwSchemaDrift(
+          db,
+          `schema_migrations is missing from a non-empty database (${summarize(existingObjects)})`,
+        );
+      }
       db.exec(schemaSql);
       const mark = db.prepare(
         "INSERT INTO schema_migrations (version, applied_at) VALUES (?1, datetime('now'))",
@@ -213,17 +303,24 @@ function ensureSchema(db: Database): void {
       } finally {
         mark.finalize();
       }
+      assertSchemaMatchesBaseline(db);
+      assertContiguousMigrationHistory(db, LATEST_SCHEMA_VERSION);
       db.exec("COMMIT;");
     } catch (error) {
-      db.exec("ROLLBACK;");
+      try {
+        db.exec("ROLLBACK;");
+      } catch {
+        // A concurrent initializer may have committed before handing a
+        // lower-version winner to migrate(); never mask that later error with
+        // "cannot rollback - no transaction is active".
+      }
       throw error;
     }
     return;
   }
 
-  const current =
-    (db.query("SELECT MAX(version) AS v FROM schema_migrations").get() as { v: number | null }).v ??
-    0;
+  const versions = readMigrationHistory(db);
+  const current = versions.at(-1) ?? 0;
   if (current > LATEST_SCHEMA_VERSION) {
     throw new Error(
       `archive schema version ${current} is newer than this build supports ` +
@@ -233,18 +330,43 @@ function ensureSchema(db: Database): void {
   if (current < 8) {
     throw new Error(
       `archive schema version ${current} predates this build's baseline ` +
-        "(8); rebuild the archive: delete it and re-ingest " +
-        "(ingest is idempotent over the source directories)",
+        "(8); back up or move the archive aside before rebuilding it because " +
+        "manual recommendation state and source-pruned sessions may exist only in the database; " +
+        "then re-ingest from the source directories",
     );
   }
+  assertVersionSequence(db, versions, current);
   if (current < LATEST_SCHEMA_VERSION) {
     migrate(db, current);
+    return;
   }
+  assertSchemaMatchesBaseline(db);
 }
 
 function migrate(db: Database, current: number): void {
   db.exec("BEGIN IMMEDIATE;");
   try {
+    // Another process may have completed the migration while this connection
+    // waited for SQLite's write lock. Re-read under the lock so each version is
+    // applied and stamped at most once.
+    const lockedVersions = readMigrationHistory(db);
+    const lockedCurrent = lockedVersions.at(-1) ?? 0;
+    if (lockedCurrent > LATEST_SCHEMA_VERSION) {
+      throw new Error(
+        `archive schema version ${lockedCurrent} is newer than this build supports ` +
+          `(${LATEST_SCHEMA_VERSION}); upgrade Decant`,
+      );
+    }
+    if (lockedCurrent < 8) {
+      throw new Error(
+        `archive schema version ${lockedCurrent} predates this build's baseline ` +
+          "(8); back up or move the archive aside before rebuilding it because " +
+          "manual recommendation state and source-pruned sessions may exist only in the database; " +
+          "then re-ingest from the source directories",
+      );
+    }
+    assertVersionSequence(db, lockedVersions, lockedCurrent);
+    current = lockedCurrent;
     if (current < 9) {
       db.exec(`
         ALTER TABLE session ADD COLUMN is_subagent INTEGER NOT NULL DEFAULT 0;
@@ -496,6 +618,60 @@ function migrate(db: Database, current: number): void {
         "INSERT INTO schema_migrations (version, applied_at) VALUES (18, datetime('now'))",
       ).run();
     }
+    if (current < 19) {
+      if (hasTable(db, "block")) {
+        db.exec("CREATE INDEX IF NOT EXISTS idx_block_tool_use ON block(session_id, tool_use_id)");
+      }
+      if (hasTable(db, "recommendation") && !hasColumn(db, "recommendation", "impact_label")) {
+        db.exec("ALTER TABLE recommendation ADD COLUMN impact_label TEXT");
+      }
+      if (
+        hasTable(db, "recommendation") &&
+        !hasColumn(db, "recommendation", "impact_label_checked")
+      ) {
+        db.exec(
+          "ALTER TABLE recommendation ADD COLUMN impact_label_checked INTEGER NOT NULL DEFAULT 0",
+        );
+      }
+      if (
+        hasTable(db, "tool_call") &&
+        hasColumn(db, "tool_call", "duration_ms") &&
+        hasTable(db, "block") &&
+        hasTable(db, "message")
+      ) {
+        // The final v18 review also taught the duration backfill to fall back
+        // to tool_call.timestamp when old rows have no linked call message.
+        // Archives that stamped the earlier v18 need that repair replayed.
+        db.exec(`
+          UPDATE tool_call
+          SET duration_ms = (
+            SELECT CASE
+              WHEN result_message.timestamp IS NOT NULL
+                AND COALESCE(call_message.timestamp, tool_call.timestamp) IS NOT NULL
+                AND julianday(result_message.timestamp) >=
+                  julianday(COALESCE(call_message.timestamp, tool_call.timestamp))
+              THEN CAST(ROUND(
+                (julianday(result_message.timestamp) -
+                  julianday(COALESCE(call_message.timestamp, tool_call.timestamp)))
+                * 86400000
+              ) AS INTEGER)
+              ELSE NULL
+            END
+            FROM block AS result_block
+            JOIN message AS result_message ON result_message.id = result_block.message_id
+            LEFT JOIN message AS call_message ON call_message.id = tool_call.message_id
+            WHERE result_block.id = tool_call.result_block_id
+          )
+          WHERE duration_ms IS NULL
+            AND result_block_id IS NOT NULL;
+        `);
+      }
+      db.query(
+        "INSERT INTO schema_migrations (version, applied_at) VALUES (19, datetime('now'))",
+      ).run();
+    }
+    assertSchemaMatchesBaseline(db);
+    assertContiguousMigrationHistory(db, LATEST_SCHEMA_VERSION);
     db.exec("COMMIT;");
   } catch (error) {
     db.exec("ROLLBACK;");
@@ -515,4 +691,144 @@ function hasColumn(db: Database, table: string, column: string): boolean {
     db.query("SELECT 1 FROM pragma_table_info(?1) WHERE name = ?2 LIMIT 1").get(table, column) !=
     null
   );
+}
+
+function readMigrationHistory(db: Database): number[] {
+  try {
+    return (
+      db.query("SELECT version, applied_at FROM schema_migrations ORDER BY version").all() as {
+        version: number;
+        applied_at: string;
+      }[]
+    ).map((row) => row.version);
+  } catch {
+    throwSchemaDrift(db, "schema_migrations is malformed or unreadable");
+  }
+}
+
+function assertVersionSequence(db: Database, versions: number[], current: number): void {
+  const expected = Array.from({ length: current }, (_, index) => index + 1);
+  if (
+    versions.length !== expected.length ||
+    versions.some((version, index) => version !== expected[index])
+  ) {
+    throwSchemaDrift(
+      db,
+      `schema_migrations is non-contiguous; expected versions 1..${current}, found ${summarize(
+        versions.map(String),
+      )}`,
+    );
+  }
+}
+
+function assertContiguousMigrationHistory(db: Database, current: number): void {
+  assertVersionSequence(db, readMigrationHistory(db), current);
+}
+
+function assertSchemaMatchesBaseline(db: Database): void {
+  const expected = getExpectedSchemaManifest();
+  const actual = buildSchemaManifest(db);
+  if (actual.fingerprint !== expected.fingerprint) {
+    throwSchemaDrift(
+      db,
+      `owned schema objects differ from the v${LATEST_SCHEMA_VERSION} baseline`,
+      expected,
+      actual,
+    );
+  }
+}
+
+function getExpectedSchemaManifest(): SchemaManifest {
+  if (expectedSchemaManifest != null) {
+    return expectedSchemaManifest;
+  }
+  const expectedDb = new Database(":memory:", { strict: true });
+  try {
+    expectedDb.exec(schemaSql);
+    expectedSchemaManifest = buildSchemaManifest(expectedDb);
+    return expectedSchemaManifest;
+  } finally {
+    expectedDb.close();
+  }
+}
+
+function throwSchemaDrift(
+  db: Database,
+  reason: string,
+  expected = getExpectedSchemaManifest(),
+  actual = buildSchemaManifest(db),
+): never {
+  const differences = compareSchemaManifests(expected, actual);
+  const detail = [
+    reason,
+    describeDifference("missing columns", differences.missingColumns),
+    describeDifference("unexpected columns", differences.unexpectedColumns),
+    describeDifference("missing objects", differences.missingObjects),
+    describeDifference("unexpected objects", differences.unexpectedObjects),
+    describeDifference("changed objects", differences.changedObjects),
+  ]
+    .filter((part): part is string => part != null)
+    .join("; ");
+  const recovery =
+    "Back up or move the archive aside before recovery because manual recommendation state and " +
+    "source-pruned sessions may exist only in the database. If the source transcripts are complete, " +
+    "rebuild by moving the archive aside and re-ingesting them.";
+  const message = `archive schema drift at version ${LATEST_SCHEMA_VERSION}: ${detail}. ${recovery}`;
+  const error = new SchemaDriftError(
+    message,
+    expected.fingerprint,
+    actual.fingerprint,
+    differences,
+  );
+  logger.error("Archive schema does not match this build.", {
+    "event.name": "decant.schema.drift",
+    "schema.version": LATEST_SCHEMA_VERSION,
+    "schema.fingerprint.expected": expected.fingerprint,
+    "schema.fingerprint.actual": actual.fingerprint,
+    "schema.drift.reason": reason,
+    "schema.drift.missing_columns": summarize(differences.missingColumns),
+    "schema.drift.unexpected_columns": summarize(differences.unexpectedColumns),
+    "schema.drift.missing_objects": summarize(differences.missingObjects),
+    "schema.drift.unexpected_objects": summarize(differences.unexpectedObjects),
+    "schema.drift.changed_objects": summarize(differences.changedObjects),
+    "error.type": error.name,
+    "error.message": error.message,
+    "recovery.action": "back_up_then_rebuild_from_complete_sources",
+  });
+  throw error;
+}
+
+function schemaObjectNames(db: Database): string[] {
+  return (
+    db
+      .query(
+        `SELECT type || ':' || name AS object
+         FROM sqlite_master
+         WHERE name NOT LIKE 'sqlite\\_%' ESCAPE '\\'
+         ORDER BY type, name`,
+      )
+      .all() as { object: string }[]
+  ).map((row) => row.object);
+}
+
+function describeDifference(label: string, values: string[]): string | null {
+  return values.length === 0 ? null : `${label}: ${summarize(values)}`;
+}
+
+function summarize(values: string[], limit = 8): string {
+  const shown = values.slice(0, limit).map(sanitizeDiagnosticItem);
+  const suffix = values.length > limit ? `, and ${values.length - limit} more` : "";
+  return truncateDiagnostic(`${shown.join(", ")}${suffix}`, 384);
+}
+
+function sanitizeDiagnosticItem(value: string): string {
+  return truncateDiagnostic(value.replace(/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/gu, "�"), 96);
+}
+
+function truncateDiagnostic(value: string, limit: number): string {
+  const characters = [...value];
+  if (characters.length <= limit) {
+    return value;
+  }
+  return `${characters.slice(0, Math.max(0, limit - 1)).join("")}…`;
 }

--- a/src/schema-manifest.ts
+++ b/src/schema-manifest.ts
@@ -1,0 +1,500 @@
+import type { Database } from "bun:sqlite";
+import { createHash } from "node:crypto";
+
+interface SchemaColumn {
+  name: string;
+  type: string;
+  not_null: boolean;
+  default: string | null;
+  primary_key_position: number;
+  hidden: number;
+}
+
+interface SchemaForeignKey {
+  sequence: number;
+  table: string;
+  from: string;
+  to: string | null;
+  on_update: string;
+  on_delete: string;
+  match: string;
+}
+
+interface SchemaIndexKey {
+  sequence: number;
+  column_id: number | null;
+  name: string | null;
+  descending: boolean;
+  collation: string;
+  key: boolean;
+}
+
+export interface SchemaObjectManifest {
+  type: string;
+  name: string;
+  table: string;
+  ddl: string | null;
+  columns: SchemaColumn[];
+  foreign_keys: SchemaForeignKey[];
+  index_keys: SchemaIndexKey[];
+}
+
+export interface SchemaManifest {
+  objects: SchemaObjectManifest[];
+  fingerprint: string;
+}
+
+export interface SchemaDifference {
+  missingObjects: string[];
+  unexpectedObjects: string[];
+  changedObjects: string[];
+  missingColumns: string[];
+  unexpectedColumns: string[];
+}
+
+interface MasterRow {
+  type: string;
+  name: string;
+  tbl_name: string;
+  sql: string | null;
+}
+
+interface TableInfoRow {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+  hidden: number;
+}
+
+interface ForeignKeyRow {
+  id: number;
+  seq: number;
+  table: string;
+  from: string;
+  to: string | null;
+  on_update: string;
+  on_delete: string;
+  match: string;
+}
+
+interface IndexInfoRow {
+  seqno: number;
+  cid: number;
+  name: string | null;
+  desc: number;
+  coll: string;
+  key: number;
+}
+
+/**
+ * Build a stable manifest of Decant-owned SQLite objects. sqlite_master DDL is
+ * canonicalized so harmless whitespace, identifier quoting, IF NOT EXISTS,
+ * and regular-table column order do not split otherwise equivalent lineages.
+ * Column defaults/types, foreign keys, indexes, triggers, and FTS declarations
+ * remain part of the fingerprint.
+ */
+export function buildSchemaManifest(db: Database): SchemaManifest {
+  const shadowTables = new Set(
+    (
+      db.query("SELECT name FROM pragma_table_list WHERE type = 'shadow'").all() as {
+        name: string;
+      }[]
+    ).map((row) => row.name),
+  );
+  const rows = (
+    db
+      .query(
+        `SELECT type, name, tbl_name, sql
+       FROM sqlite_master
+       WHERE name NOT LIKE 'sqlite\\_%' ESCAPE '\\'
+       ORDER BY type, name`,
+      )
+      .all() as MasterRow[]
+  ).filter((row) => !shadowTables.has(row.name));
+
+  const objects = rows.map((row): SchemaObjectManifest => {
+    const isTable = row.type === "table";
+    const columns = isTable
+      ? (db.query("SELECT * FROM pragma_table_xinfo(?1)").all(row.name) as TableInfoRow[])
+          .map((column) => ({
+            name: column.name,
+            type: normalizeType(column.type),
+            not_null: column.notnull !== 0,
+            default: normalizeColumnDefault(row.name, column.name, column.dflt_value),
+            primary_key_position: column.pk,
+            hidden: column.hidden,
+          }))
+          .sort((left, right) => left.name.localeCompare(right.name))
+      : [];
+    const foreignKeys = isTable
+      ? (db.query("SELECT * FROM pragma_foreign_key_list(?1)").all(row.name) as ForeignKeyRow[])
+          .map((foreignKey) => ({
+            sequence: foreignKey.seq,
+            table: foreignKey.table,
+            from: foreignKey.from,
+            to: foreignKey.to,
+            on_update: foreignKey.on_update.toUpperCase(),
+            on_delete: foreignKey.on_delete.toUpperCase(),
+            match: foreignKey.match.toUpperCase(),
+          }))
+          .sort(compareJson)
+      : [];
+    const indexKeys =
+      row.type === "index"
+        ? (db.query("SELECT * FROM pragma_index_xinfo(?1)").all(row.name) as IndexInfoRow[])
+            .map((key) => ({
+              sequence: key.seqno,
+              // cid is the physical table-column ordinal and legitimately
+              // differs when an ALTER-based lineage appends the same named
+              // column that the fresh baseline groups semantically.
+              column_id: key.name == null ? key.cid : null,
+              name: key.name,
+              descending: key.desc !== 0,
+              collation: key.coll,
+              key: key.key !== 0,
+            }))
+            .sort((left, right) => left.sequence - right.sequence)
+        : [];
+    return {
+      type: row.type,
+      name: row.name,
+      table: row.tbl_name,
+      ddl: row.sql == null ? null : canonicalizeDdl(row.sql, row.name),
+      columns,
+      foreign_keys: foreignKeys,
+      index_keys: indexKeys,
+    };
+  });
+
+  return {
+    objects,
+    fingerprint: createHash("sha256").update(JSON.stringify(objects)).digest("hex"),
+  };
+}
+
+export function compareSchemaManifests(
+  expected: SchemaManifest,
+  actual: SchemaManifest,
+): SchemaDifference {
+  const expectedByKey = new Map(expected.objects.map((object) => [objectKey(object), object]));
+  const actualByKey = new Map(actual.objects.map((object) => [objectKey(object), object]));
+  const missingObjects: string[] = [];
+  const unexpectedObjects: string[] = [];
+  const changedObjects: string[] = [];
+  const missingColumns: string[] = [];
+  const unexpectedColumns: string[] = [];
+
+  for (const [key, expectedObject] of expectedByKey) {
+    const actualObject = actualByKey.get(key);
+    if (actualObject == null) {
+      missingObjects.push(key);
+      continue;
+    }
+    if (JSON.stringify(expectedObject) === JSON.stringify(actualObject)) {
+      continue;
+    }
+    if (expectedObject.type === "table") {
+      const expectedColumnNames = new Set(expectedObject.columns.map((column) => column.name));
+      const actualColumnNames = new Set(actualObject.columns.map((column) => column.name));
+      for (const name of expectedColumnNames) {
+        if (!actualColumnNames.has(name)) {
+          missingColumns.push(`${expectedObject.name}.${name}`);
+        }
+      }
+      for (const name of actualColumnNames) {
+        if (!expectedColumnNames.has(name)) {
+          unexpectedColumns.push(`${actualObject.name}.${name}`);
+        }
+      }
+    }
+    changedObjects.push(key);
+  }
+  for (const key of actualByKey.keys()) {
+    if (!expectedByKey.has(key)) {
+      unexpectedObjects.push(key);
+    }
+  }
+
+  return {
+    missingObjects,
+    unexpectedObjects,
+    changedObjects,
+    missingColumns,
+    unexpectedColumns,
+  };
+}
+
+function objectKey(object: Pick<SchemaObjectManifest, "type" | "name">): string {
+  return `${object.type}:${object.name}`;
+}
+
+function normalizeType(value: string): string {
+  return value.trim().replace(/\s+/g, " ").toUpperCase();
+}
+
+function normalizeDefault(value: string | null): string | null {
+  if (value == null) {
+    return null;
+  }
+  let normalized = value.trim();
+  while (normalized.startsWith("(") && normalized.endsWith(")")) {
+    normalized = normalized.slice(1, -1).trim();
+  }
+  return normalizeSqlSpacing(lowerOutsideStrings(normalized));
+}
+
+function normalizeColumnDefault(
+  table: string,
+  column: string,
+  value: string | null,
+): string | null {
+  const normalized = normalizeDefault(value);
+  if (
+    table === "recommendation" &&
+    column === "impact_label_checked" &&
+    (normalized === "0" || normalized === "1")
+  ) {
+    return "<v18-compatible-0-or-1>";
+  }
+  return normalized;
+}
+
+function canonicalizeDdl(value: string, objectName: string): string {
+  let normalized = transformOutsideStringLiterals(stripSqlComments(value), (segment) =>
+    segment
+      .replace(/\bIF\s+NOT\s+EXISTS\b/gi, " ")
+      .replace(/"([A-Za-z_][A-Za-z0-9_]*)"/g, "$1")
+      .replace(/`([A-Za-z_][A-Za-z0-9_]*)`/g, "$1")
+      .replace(/\[([A-Za-z_][A-Za-z0-9_]*)\]/g, "$1")
+      .toLowerCase(),
+  )
+    .trim()
+    .replace(/;+\s*$/, "");
+  normalized = normalizeSqlSpacing(normalized);
+
+  if (!normalized.startsWith("create table ")) {
+    return normalized;
+  }
+  const open = normalized.indexOf("(");
+  const close = findMatchingClose(normalized, open);
+  if (open < 0 || close < 0) {
+    return normalized;
+  }
+  const prefix = normalized.slice(0, open + 1);
+  const body = normalized.slice(open + 1, close);
+  const suffix = normalized.slice(close);
+  const definitions = splitTopLevel(body).map((definition) =>
+    objectName === "recommendation" && definition.startsWith("impact_label_checked ")
+      ? transformOutsideStringLiterals(definition, (segment) =>
+          segment.replace(/\bdefault [01]\b/, "default <v18-compatible-0-or-1>"),
+        )
+      : definition,
+  );
+  return `${prefix}${definitions.sort().join(",")}${suffix}`;
+}
+
+function stripSqlComments(value: string): string {
+  let result = "";
+  let quote: "'" | '"' | "`" | null = null;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index] ?? "";
+    const next = value[index + 1] ?? "";
+    if (quote != null) {
+      result += char;
+      if (char === quote) {
+        if (next === quote) {
+          result += next;
+          index += 1;
+        } else {
+          quote = null;
+        }
+      }
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") {
+      quote = char;
+      result += char;
+      continue;
+    }
+    if (char === "-" && next === "-") {
+      index += 2;
+      while (index < value.length && value[index] !== "\n") {
+        index += 1;
+      }
+      result += " ";
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      index += 2;
+      while (index < value.length - 1 && !(value[index] === "*" && value[index + 1] === "/")) {
+        index += 1;
+      }
+      index += 1;
+      result += " ";
+      continue;
+    }
+    result += char;
+  }
+  return result;
+}
+
+function lowerOutsideStrings(value: string): string {
+  return transformOutsideStringLiterals(value, (segment) => segment.toLowerCase());
+}
+
+function transformOutsideStringLiterals(
+  value: string,
+  transform: (segment: string) => string,
+): string {
+  let result = "";
+  let outsideStart = 0;
+  let index = 0;
+  while (index < value.length) {
+    if (value[index] !== "'") {
+      index += 1;
+      continue;
+    }
+    result += transform(value.slice(outsideStart, index));
+    const literalStart = index;
+    index += 1;
+    while (index < value.length) {
+      if (value[index] !== "'") {
+        index += 1;
+        continue;
+      }
+      if (value[index + 1] === "'") {
+        index += 2;
+        continue;
+      }
+      index += 1;
+      break;
+    }
+    result += value.slice(literalStart, index);
+    outsideStart = index;
+  }
+  return result + transform(value.slice(outsideStart));
+}
+
+function normalizeSqlSpacing(value: string): string {
+  let result = "";
+  let inLiteral = false;
+  let pendingSpace = false;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index] ?? "";
+    const next = value[index + 1] ?? "";
+    if (inLiteral) {
+      result += char;
+      if (char === "'") {
+        if (next === "'") {
+          result += next;
+          index += 1;
+        } else {
+          inLiteral = false;
+        }
+      }
+      continue;
+    }
+    if (char === "'") {
+      if (pendingSpace && result !== "" && !endsWithSqlPunctuation(result)) {
+        result += " ";
+      }
+      pendingSpace = false;
+      inLiteral = true;
+      result += char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      pendingSpace = true;
+      continue;
+    }
+    if (char === "(" || char === ")" || char === "," || char === "=") {
+      result = result.trimEnd();
+      result += char;
+      pendingSpace = false;
+      continue;
+    }
+    if (pendingSpace && result !== "" && !endsWithSqlPunctuation(result)) {
+      result += " ";
+    }
+    pendingSpace = false;
+    result += char;
+  }
+  return result.trim();
+}
+
+function endsWithSqlPunctuation(value: string): boolean {
+  const char = value.at(-1);
+  return char === "(" || char === ")" || char === "," || char === "=";
+}
+
+function findMatchingClose(value: string, open: number): number {
+  if (open < 0) {
+    return -1;
+  }
+  let depth = 0;
+  let quote: "'" | null = null;
+  for (let index = open; index < value.length; index += 1) {
+    const char = value[index] ?? "";
+    const next = value[index + 1] ?? "";
+    if (quote != null) {
+      if (char === quote) {
+        if (next === quote) {
+          index += 1;
+        } else {
+          quote = null;
+        }
+      }
+      continue;
+    }
+    if (char === "'") {
+      quote = char;
+    } else if (char === "(") {
+      depth += 1;
+    } else if (char === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  return -1;
+}
+
+function splitTopLevel(value: string): string[] {
+  const parts: string[] = [];
+  let start = 0;
+  let depth = 0;
+  let quote: "'" | null = null;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index] ?? "";
+    const next = value[index + 1] ?? "";
+    if (quote != null) {
+      if (char === quote) {
+        if (next === quote) {
+          index += 1;
+        } else {
+          quote = null;
+        }
+      }
+      continue;
+    }
+    if (char === "'") {
+      quote = char;
+    } else if (char === "(") {
+      depth += 1;
+    } else if (char === ")") {
+      depth -= 1;
+    } else if (char === "," && depth === 0) {
+      parts.push(value.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  parts.push(value.slice(start).trim());
+  return parts;
+}
+
+function compareJson(left: object, right: object): number {
+  return JSON.stringify(left).localeCompare(JSON.stringify(right));
+}

--- a/src/schema-manifest.ts
+++ b/src/schema-manifest.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { createHash } from "node:crypto";
+import { compareCodePoints } from "./order.ts";
 
 interface SchemaColumn {
   name: string;
@@ -139,7 +140,7 @@ export function buildSchemaManifest(db: Database): SchemaManifest {
             on_delete: foreignKey.on_delete.toUpperCase(),
             match: foreignKey.match.toUpperCase(),
           }))
-          .sort(compareJson)
+          .sort(compareForeignKeys)
       : [];
     const indexKeys =
       row.type === "index"
@@ -495,6 +496,27 @@ function splitTopLevel(value: string): string[] {
   return parts;
 }
 
-function compareJson(left: object, right: object): number {
-  return JSON.stringify(left).localeCompare(JSON.stringify(right));
+function compareForeignKeys(left: SchemaForeignKey, right: SchemaForeignKey): number {
+  return (
+    compareCodePoints(left.table, right.table) ||
+    compareCodePoints(left.from, right.from) ||
+    compareNullableStrings(left.to, right.to) ||
+    left.sequence - right.sequence ||
+    compareCodePoints(left.on_update, right.on_update) ||
+    compareCodePoints(left.on_delete, right.on_delete) ||
+    compareCodePoints(left.match, right.match)
+  );
+}
+
+function compareNullableStrings(left: string | null, right: string | null): number {
+  if (left === right) {
+    return 0;
+  }
+  if (left == null) {
+    return -1;
+  }
+  if (right == null) {
+    return 1;
+  }
+  return compareCodePoints(left, right);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import { dirname, join } from "node:path";
 import type { Config } from "./config.ts";
 import { contextWindowForSession } from "./context-window.ts";
 import { dateFilterFromSearch } from "./date-filter.ts";
-import { ARCHIVE_DIR_MODE, closeDb, openDb } from "./db.ts";
+import { ARCHIVE_DIR_MODE, closeDb, openDb, SchemaDriftError } from "./db.ts";
 import { refreshDerivedMetadata } from "./derived.ts";
 import { DECANT_VERSION } from "./distill.ts";
 import { EconomicsCache, type EconomicsCacheOptions } from "./economics-cache.ts";
@@ -139,6 +139,7 @@ export type ApiErrorCode =
   | "not_found"
   | "query_required"
   | "recommendation_not_found"
+  | "schema_drift"
   | "schema_too_new"
   | "schema_too_old"
   | "service_starting"
@@ -1144,6 +1145,9 @@ function classifyError(error: unknown): ApiError {
   const message = error instanceof Error ? error.message : String(error);
   if (error instanceof RequestBodyError) {
     return { code: "malformed_body", message, status: 400 };
+  }
+  if (error instanceof SchemaDriftError) {
+    return { code: "schema_drift", message, status: 409 };
   }
   const normalized = message.toLowerCase();
   if (normalized.includes("is newer than this build supports")) {

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -790,7 +790,7 @@ describe("openDb", () => {
       ALTER TABLE recommendation DROP COLUMN impact_label_checked;
       ALTER TABLE recommendation DROP COLUMN impact_label;
       DROP INDEX idx_block_tool_use;
-      DELETE FROM schema_migrations WHERE version = 19;
+      DELETE FROM schema_migrations WHERE version >= 19;
     `);
     db.close();
 
@@ -893,7 +893,7 @@ describe("openDb", () => {
     expect(JSON.parse(lines[0] ?? "")).toMatchObject({
       level: "WARN",
       "event.name": "decant.schema.additive_drift",
-      "schema.version": 19,
+      "schema.version": LATEST_SCHEMA_VERSION,
       "schema.drift.unexpected_objects":
         "index:operator_extra_0, index:operator_extra_1, index:operator_extra_10, " +
         "index:operator_extra_11, index:operator_extra_2, index:operator_extra_3, " +

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -828,6 +828,128 @@ describe("openDb", () => {
     expect(() => openDb(path).close()).not.toThrow();
   });
 
+  test("v19 does not rewrite duration rows when the backfill still resolves to NULL", () => {
+    const path = freshPath();
+    let db = openDb(path);
+    db.exec(`
+      INSERT INTO session (id, tool, source_session_id)
+      VALUES (1, 'claude_code', 'v19-null-duration');
+      INSERT INTO message (id, session_id, seq, timestamp, raw)
+      VALUES
+        (10, 1, 0, '2026-07-29T00:00:01.000Z', '{}'),
+        (11, 1, 1, '2026-07-29T00:00:00.000Z', '{}');
+      INSERT INTO block (
+        id, message_id, session_id, ordinal, type, tool_name, tool_use_id, tool_result
+      )
+      VALUES
+        (100, 10, 1, 0, 'tool_use', 'Read', 'toolu_invalid_duration', NULL),
+        (101, 11, 1, 0, 'tool_result', NULL, 'toolu_invalid_duration', 'done');
+      INSERT INTO tool_call (
+        id, session_id, message_id, call_block_id, result_block_id,
+        tool_name, tool_use_id, duration_ms, ordinal, timestamp
+      )
+      VALUES (
+        1000, 1, 10, 100, 101,
+        'Read', 'toolu_invalid_duration', NULL, 0, '2026-07-29T00:00:01.000Z'
+      );
+      CREATE TABLE operator_update_audit(tool_call_id INTEGER NOT NULL);
+      CREATE TRIGGER operator_duration_update
+      AFTER UPDATE OF duration_ms ON tool_call
+      BEGIN
+        INSERT INTO operator_update_audit(tool_call_id) VALUES (new.id);
+      END;
+      DELETE FROM schema_migrations WHERE version = 19;
+    `);
+    db.close();
+
+    db = openDb(path);
+    expect(db.query("SELECT duration_ms FROM tool_call WHERE id = 1000").get()).toEqual({
+      duration_ms: null,
+    });
+    expect(
+      (db.query("SELECT COUNT(*) AS n FROM operator_update_audit").get() as { n: number }).n,
+    ).toBe(0);
+    db.close();
+  });
+
+  test("allows additive operator indexes with one bounded warning", () => {
+    const path = freshPath();
+    const db = openDb(path);
+    for (let index = 0; index < 12; index += 1) {
+      db.exec(`CREATE INDEX operator_extra_${index} ON session(id)`);
+    }
+    db.close();
+
+    const lines: string[] = [];
+    configureLogging({ level: "info", write: (line) => lines.push(line) });
+    try {
+      expect(() => openDb(path).close()).not.toThrow();
+    } finally {
+      resetSync();
+    }
+
+    expect(lines).toHaveLength(1);
+    expect([...(lines[0] ?? "")].length).toBeLessThan(2_048);
+    expect(JSON.parse(lines[0] ?? "")).toMatchObject({
+      level: "WARN",
+      "event.name": "decant.schema.additive_drift",
+      "schema.version": 19,
+      "schema.drift.unexpected_objects":
+        "index:operator_extra_0, index:operator_extra_1, index:operator_extra_10, " +
+        "index:operator_extra_11, index:operator_extra_2, index:operator_extra_3, " +
+        "index:operator_extra_4, index:operator_extra_5, and 4 more",
+    });
+  });
+
+  test("keeps missing and changed owned objects fatal", () => {
+    const missingPath = freshPath();
+    const missing = openDb(missingPath);
+    missing.exec("DROP INDEX idx_session_project");
+    missing.close();
+    expect(() => openDb(missingPath)).toThrow(SchemaDriftError);
+
+    const changedPath = freshPath();
+    const changed = openDb(changedPath);
+    changed.exec(`
+      DROP INDEX idx_session_project;
+      CREATE INDEX idx_session_project ON session(tool);
+    `);
+    changed.close();
+    expect(() => openDb(changedPath)).toThrow(SchemaDriftError);
+  });
+
+  test("preserves a migration error when rollback also fails", () => {
+    const path = freshPath();
+    const db = openDb(path);
+    db.exec(`
+      ALTER TABLE session ADD COLUMN unexpected_local_state TEXT;
+      DELETE FROM schema_migrations WHERE version = 19;
+    `);
+    db.close();
+
+    const originalExec = Database.prototype.exec;
+    Database.prototype.exec = function (this: Database, sql: string) {
+      if (sql.trim().toUpperCase() === "ROLLBACK;") {
+        throw new Error("simulated rollback failure");
+      }
+      return originalExec.call(this, sql);
+    } as Database["exec"];
+    let caught: unknown;
+    try {
+      openDb(path);
+    } catch (error) {
+      caught = error;
+    } finally {
+      Database.prototype.exec = originalExec;
+    }
+
+    expect(caught).toBeInstanceOf(SchemaDriftError);
+    expect((caught as Error).message).toContain(
+      "unexpected columns: session.unexpected_local_state",
+    );
+    expect((caught as Error).message).not.toContain("simulated rollback failure");
+  });
+
   test("fails fast on owned-schema drift with one actionable error record", () => {
     const path = freshPath();
     const db = openDb(path);

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -12,8 +12,19 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { closeDb, LATEST_SCHEMA_VERSION, openDb, restrictArchiveFile } from "../src/db.ts";
+import { pathToFileURL } from "node:url";
+import { resetSync } from "@logtape/logtape";
+import {
+  closeDb,
+  LATEST_SCHEMA_VERSION,
+  openDb,
+  restrictArchiveFile,
+  SchemaDriftError,
+} from "../src/db.ts";
+import { configureLogging } from "../src/logging.ts";
 import schemaSql from "../src/schema.sql" with { type: "text" };
+import { buildSchemaManifest } from "../src/schema-manifest.ts";
+import schemaV8Sql from "./fixtures/schema-v8.sql" with { type: "text" };
 
 const workDir = mkdtempSync(join(tmpdir(), "decant-db-test-"));
 afterAll(() => rmSync(workDir, { recursive: true, force: true }));
@@ -24,7 +35,71 @@ function freshPath(): string {
   return join(workDir, `archive-${dbCounter}.db`);
 }
 
-// Inventory of the frozen v18 baseline. Shadow tables
+async function waitForFiles(paths: string[], timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!paths.every(existsSync)) {
+    if (Date.now() >= deadline) {
+      throw new Error(`timed out waiting for ${paths.join(", ")}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function historicalArchive(path: string, version: 8 | 9 | 12 | 13 | 14): Database {
+  const db = new Database(path, { create: true, strict: true });
+  db.exec(schemaV8Sql);
+  const mark = db.prepare(
+    "INSERT INTO schema_migrations(version, applied_at) VALUES (?1, datetime('now'))",
+  );
+  for (let applied = 1; applied <= 8; applied += 1) {
+    mark.run(applied);
+  }
+  if (version >= 9) {
+    db.exec(`
+      ALTER TABLE session ADD COLUMN is_subagent INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE session ADD COLUMN parent_session_id INTEGER REFERENCES session(id);
+      ALTER TABLE session ADD COLUMN spawn_tool_use_id TEXT;
+      ALTER TABLE session ADD COLUMN agent_id TEXT;
+      ALTER TABLE session ADD COLUMN agent_type TEXT;
+      ALTER TABLE session ADD COLUMN spawn_depth INTEGER;
+      CREATE INDEX idx_session_parent ON session(parent_session_id);
+      CREATE INDEX idx_session_spawn_tooluse ON session(spawn_tool_use_id);
+    `);
+    mark.run(9);
+  }
+  if (version >= 12) {
+    db.exec(`
+      CREATE TABLE session_economics (
+        session_id INTEGER PRIMARY KEY REFERENCES session(id) ON DELETE CASCADE,
+        format_version INTEGER NOT NULL,
+        vector_json TEXT NOT NULL,
+        computed_at TEXT NOT NULL
+      );
+      ALTER TABLE session ADD COLUMN context_window_tokens INTEGER;
+      ALTER TABLE session ADD COLUMN peak_context_tokens INTEGER;
+      ALTER TABLE session ADD COLUMN total_cache_creation_1h_tokens INTEGER NOT NULL DEFAULT 0;
+    `);
+    mark.run(10);
+    mark.run(11);
+    mark.run(12);
+  }
+  if (version >= 13) {
+    db.exec(`
+      ALTER TABLE session ADD COLUMN reasoning_effort TEXT;
+      ALTER TABLE session ADD COLUMN reasoning_effort_checked INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE model_pricing ADD COLUMN cache_write_1h_per_mtok REAL;
+    `);
+    mark.run(13);
+  }
+  if (version >= 14) {
+    db.exec("ALTER TABLE session ADD COLUMN reasoning_effort_levels TEXT NOT NULL DEFAULT '[]'");
+    mark.run(14);
+  }
+  mark.finalize();
+  return db;
+}
+
+// Inventory of the frozen v19 baseline. Shadow tables
 // of block_fts are excluded; they are implementation details of FTS5.
 const BASELINE_TABLES = [
   "block",
@@ -131,6 +206,57 @@ describe("openDb", () => {
     db.close();
   });
 
+  test("serializes two processes creating the same fresh archive", async () => {
+    const dbModule = pathToFileURL(join(import.meta.dir, "..", "src", "db.ts")).href;
+    const script = `
+      import { existsSync, writeFileSync } from "node:fs";
+      import { openDb } from ${JSON.stringify(dbModule)};
+      const path = process.env.DECANT_RACE_DB;
+      const ready = process.env.DECANT_RACE_READY;
+      const gate = process.env.DECANT_RACE_GATE;
+      if (path == null || ready == null || gate == null) throw new Error("missing race fixture");
+      writeFileSync(ready, "");
+      while (!existsSync(gate)) await new Promise((resolve) => setTimeout(resolve, 1));
+      openDb(path).close();
+    `;
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const path = freshPath();
+      const gate = `${path}.go`;
+      const readyPaths = [`${path}.ready-1`, `${path}.ready-2`];
+      const children = readyPaths.map((ready) =>
+        Bun.spawn([process.execPath, "-e", script], {
+          cwd: join(import.meta.dir, ".."),
+          env: {
+            ...process.env,
+            DECANT_RACE_DB: path,
+            DECANT_RACE_READY: ready,
+            DECANT_RACE_GATE: gate,
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        }),
+      );
+      try {
+        await waitForFiles(readyPaths);
+      } finally {
+        writeFileSync(gate, "");
+      }
+      const exits = await Promise.all(children.map((child) => child.exited));
+      const errors = await Promise.all(children.map((child) => new Response(child.stderr).text()));
+      expect({ attempt, exits, errors }).toEqual({
+        attempt,
+        exits: [0, 0],
+        errors: ["", ""],
+      });
+
+      const db = openDb(path);
+      expect(db.query("SELECT COUNT(*) AS count FROM schema_migrations").get()).toEqual({
+        count: LATEST_SCHEMA_VERSION,
+      });
+      db.close();
+    }
+  });
+
   test("finalizes cached query statements before closing a worker-style connection", () => {
     const db = openDb(freshPath());
     const cached = db.query("SELECT 1 AS value");
@@ -194,47 +320,7 @@ describe("openDb", () => {
 
   test("migrates a v8 archive through the latest version", () => {
     const path = freshPath();
-    const db = new Database(path, { create: true, strict: true });
-    db.exec(`
-      CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
-      CREATE TABLE session(id INTEGER PRIMARY KEY, tool TEXT NOT NULL, source_session_id TEXT NOT NULL, source_path TEXT);
-      CREATE TABLE model_pricing(
-        model TEXT PRIMARY KEY,
-        input_per_mtok REAL,
-        output_per_mtok REAL,
-        cache_read_per_mtok REAL,
-        cache_write_per_mtok REAL,
-        source TEXT,
-        updated_at TEXT
-      );
-      CREATE TABLE ingest_source (
-        path TEXT PRIMARY KEY,
-        tool TEXT,
-        size INTEGER,
-        mtime INTEGER,
-        hash TEXT,
-        session_id INTEGER REFERENCES session(id) ON DELETE SET NULL,
-        line_count INTEGER,
-        status TEXT,
-        error TEXT,
-        last_ingested_at TEXT
-      );
-      CREATE TABLE ingest_issue (
-        id INTEGER PRIMARY KEY,
-        source_path TEXT,
-        line_no INTEGER,
-        error TEXT,
-        raw_line TEXT,
-        created_at TEXT
-      );
-    `);
-    const insert = db.prepare(
-      "INSERT INTO schema_migrations(version, applied_at) VALUES (?1, datetime('now'))",
-    );
-    for (let version = 1; version <= 8; version += 1) {
-      insert.run(version);
-    }
-    db.close();
+    historicalArchive(path, 8).close();
 
     const migrated = openDb(path);
     expect(
@@ -265,55 +351,57 @@ describe("openDb", () => {
     migrated.close();
   });
 
+  test("replaying migrations from v8 is schema-equivalent to the latest baseline", () => {
+    const migratedPath = freshPath();
+    const legacy = historicalArchive(migratedPath, 8);
+    legacy.exec(`
+      INSERT INTO recommendation (
+        key, kind, title, score, status, note, first_seen_at, updated_at
+      ) VALUES (
+        'signal:v8-preserved', 'signal', 'Preserved from v8', 7, 'open',
+        'manual state', '2026-07-29T00:00:00Z', '2026-07-29T00:00:00Z'
+      )
+    `);
+    legacy.close();
+
+    const migrated = openDb(migratedPath);
+    const baseline = openDb(freshPath());
+    expect(buildSchemaManifest(migrated)).toEqual(buildSchemaManifest(baseline));
+    expect(
+      migrated
+        .query(
+          `SELECT dflt_value FROM pragma_table_info('recommendation')
+           WHERE name = 'impact_label_checked'`,
+        )
+        .get(),
+    ).toEqual({ dflt_value: "0" });
+    expect(
+      baseline
+        .query(
+          `SELECT dflt_value FROM pragma_table_info('recommendation')
+           WHERE name = 'impact_label_checked'`,
+        )
+        .get(),
+    ).toEqual({ dflt_value: "1" });
+    expect(
+      migrated
+        .query(
+          `SELECT note, impact_label, impact_label_checked
+           FROM recommendation WHERE key = 'signal:v8-preserved'`,
+        )
+        .get(),
+    ).toEqual({
+      note: "manual state",
+      impact_label: null,
+      impact_label_checked: 0,
+    });
+    migrated.close();
+    baseline.close();
+  });
+
   test("migrates a v9 archive to the persisted economics cache", () => {
     const path = freshPath();
-    const db = new Database(path, { create: true, strict: true });
-    db.exec(`
-      CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
-      CREATE TABLE session(
-        id INTEGER PRIMARY KEY,
-        tool TEXT NOT NULL,
-        source_session_id TEXT NOT NULL,
-        source_path TEXT,
-        parent_session_id INTEGER REFERENCES session(id)
-      );
-      CREATE TABLE model_pricing(
-        model TEXT PRIMARY KEY,
-        input_per_mtok REAL,
-        output_per_mtok REAL,
-        cache_read_per_mtok REAL,
-        cache_write_per_mtok REAL,
-        source TEXT,
-        updated_at TEXT
-      );
-      CREATE TABLE ingest_source (
-        path TEXT PRIMARY KEY,
-        tool TEXT,
-        size INTEGER,
-        mtime INTEGER,
-        hash TEXT,
-        session_id INTEGER REFERENCES session(id) ON DELETE SET NULL,
-        line_count INTEGER,
-        status TEXT,
-        error TEXT,
-        last_ingested_at TEXT
-      );
-      CREATE TABLE ingest_issue (
-        id INTEGER PRIMARY KEY,
-        source_path TEXT,
-        line_no INTEGER,
-        error TEXT,
-        raw_line TEXT,
-        created_at TEXT
-      );
-    `);
-    const insert = db.prepare(
-      "INSERT INTO schema_migrations(version, applied_at) VALUES (?1, datetime('now'))",
-    );
-    for (let version = 1; version <= 9; version += 1) {
-      insert.run(version);
-    }
-    db.close();
+    historicalArchive(path, 9).close();
 
     const migrated = openDb(path);
     expect(inventory(migrated, "table")).toContain("session_economics");
@@ -329,60 +417,14 @@ describe("openDb", () => {
 
   test("migrates v12 archives and invalidates stale Claude context-window rollups", () => {
     const path = freshPath();
-    const db = new Database(path, { create: true, strict: true });
+    const db = historicalArchive(path, 12);
     db.exec(`
-      CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
-      CREATE TABLE session(
-        id INTEGER PRIMARY KEY,
-        tool TEXT NOT NULL,
-        source_session_id TEXT NOT NULL,
-        source_path TEXT,
-        parent_session_id INTEGER REFERENCES session(id),
-        context_window_tokens INTEGER,
-        peak_context_tokens INTEGER,
-        total_cache_creation_1h_tokens INTEGER NOT NULL DEFAULT 0
-      );
-      CREATE TABLE model_pricing(
-        model TEXT PRIMARY KEY,
-        input_per_mtok REAL,
-        output_per_mtok REAL,
-        cache_read_per_mtok REAL,
-        cache_write_per_mtok REAL,
-        source TEXT,
-        updated_at TEXT
-      );
-      CREATE TABLE ingest_source (
-        path TEXT PRIMARY KEY,
-        tool TEXT,
-        size INTEGER,
-        mtime INTEGER,
-        hash TEXT,
-        session_id INTEGER REFERENCES session(id) ON DELETE SET NULL,
-        line_count INTEGER,
-        status TEXT,
-        error TEXT,
-        last_ingested_at TEXT
-      );
-      CREATE TABLE ingest_issue (
-        id INTEGER PRIMARY KEY,
-        source_path TEXT,
-        line_no INTEGER,
-        error TEXT,
-        raw_line TEXT,
-        created_at TEXT
-      );
       INSERT INTO session(
         id, tool, source_session_id, context_window_tokens, peak_context_tokens
       ) VALUES
         (1, 'claude_code', 'claude-old-rollup', 200000, 120000),
         (2, 'codex', 'codex-explicit-rollup', 258400, 120000);
     `);
-    const insert = db.prepare(
-      "INSERT INTO schema_migrations(version, applied_at) VALUES (?1, datetime('now'))",
-    );
-    for (let version = 1; version <= 12; version += 1) {
-      insert.run(version);
-    }
     db.close();
 
     const migrated = openDb(path);
@@ -402,38 +444,8 @@ describe("openDb", () => {
 
   test("migrates v13 effort values without changing provider labels", () => {
     const path = freshPath();
-    const db = new Database(path, { create: true, strict: true });
+    const db = historicalArchive(path, 13);
     db.exec(`
-      CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
-      CREATE TABLE session(
-        id INTEGER PRIMARY KEY,
-        tool TEXT NOT NULL,
-        source_session_id TEXT NOT NULL,
-        source_path TEXT,
-        parent_session_id INTEGER REFERENCES session(id),
-        reasoning_effort TEXT,
-        reasoning_effort_checked INTEGER NOT NULL DEFAULT 0
-      );
-      CREATE TABLE ingest_source (
-        path TEXT PRIMARY KEY,
-        tool TEXT,
-        size INTEGER,
-        mtime INTEGER,
-        hash TEXT,
-        session_id INTEGER REFERENCES session(id) ON DELETE SET NULL,
-        line_count INTEGER,
-        status TEXT,
-        error TEXT,
-        last_ingested_at TEXT
-      );
-      CREATE TABLE ingest_issue (
-        id INTEGER PRIMARY KEY,
-        source_path TEXT,
-        line_no INTEGER,
-        error TEXT,
-        raw_line TEXT,
-        created_at TEXT
-      );
       INSERT INTO session(
         id, tool, source_session_id, reasoning_effort, reasoning_effort_checked
       ) VALUES
@@ -442,12 +454,6 @@ describe("openDb", () => {
         (3, 'codex', 'codex-ultra', 'ultra', 1),
         (4, 'codex', 'codex-mixed', 'mixed', 1);
     `);
-    const insert = db.prepare(
-      "INSERT INTO schema_migrations(version, applied_at) VALUES (?1, datetime('now'))",
-    );
-    for (let version = 1; version <= 13; version += 1) {
-      insert.run(version);
-    }
     db.close();
 
     const migrated = openDb(path);
@@ -489,39 +495,8 @@ describe("openDb", () => {
 
   test("repairs the v14 Claude max-to-ultra alias without changing Codex", () => {
     const path = freshPath();
-    const db = new Database(path, { create: true, strict: true });
+    const db = historicalArchive(path, 14);
     db.exec(`
-      CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
-      CREATE TABLE session(
-        id INTEGER PRIMARY KEY,
-        tool TEXT NOT NULL,
-        source_session_id TEXT NOT NULL,
-        source_path TEXT,
-        parent_session_id INTEGER REFERENCES session(id),
-        reasoning_effort TEXT,
-        reasoning_effort_levels TEXT NOT NULL DEFAULT '[]',
-        reasoning_effort_checked INTEGER NOT NULL DEFAULT 0
-      );
-      CREATE TABLE ingest_source (
-        path TEXT PRIMARY KEY,
-        tool TEXT,
-        size INTEGER,
-        mtime INTEGER,
-        hash TEXT,
-        session_id INTEGER REFERENCES session(id) ON DELETE SET NULL,
-        line_count INTEGER,
-        status TEXT,
-        error TEXT,
-        last_ingested_at TEXT
-      );
-      CREATE TABLE ingest_issue (
-        id INTEGER PRIMARY KEY,
-        source_path TEXT,
-        line_no INTEGER,
-        error TEXT,
-        raw_line TEXT,
-        created_at TEXT
-      );
       INSERT INTO session(
         id, tool, source_session_id, reasoning_effort,
         reasoning_effort_levels, reasoning_effort_checked
@@ -531,12 +506,6 @@ describe("openDb", () => {
         (3, 'codex', 'codex-max', 'max', '["max"]', 1),
         (4, 'codex', 'codex-ultra', 'ultra', '["ultra"]', 1);
     `);
-    const insert = db.prepare(
-      "INSERT INTO schema_migrations(version, applied_at) VALUES (?1, datetime('now'))",
-    );
-    for (let version = 1; version <= 14; version += 1) {
-      insert.run(version);
-    }
     db.close();
 
     const migrated = openDb(path);
@@ -752,12 +721,236 @@ describe("openDb", () => {
     db.close();
   });
 
+  test("v19 repairs an already-recorded pre-review v18 schema without losing rows", () => {
+    const path = join(workDir, "v19-recommendation-repair.db");
+    let db = openDb(path);
+    db.exec(`
+      INSERT INTO session (id, tool, source_session_id)
+      VALUES (1, 'claude_code', 'v18-pre-review');
+      INSERT INTO message (id, session_id, seq, timestamp, raw)
+      VALUES
+        (10, 1, 0, '2026-07-29T00:00:00.000Z', '{}'),
+        (11, 1, 1, '2026-07-29T00:00:01.250Z', '{}');
+      INSERT INTO block (
+        id, message_id, session_id, ordinal, type, tool_name, tool_use_id, tool_result
+      )
+      VALUES
+        (100, 10, 1, 0, 'tool_use', 'Read', 'toolu_v19', NULL),
+        (101, 11, 1, 0, 'tool_result', NULL, 'toolu_v19', 'done');
+      INSERT INTO tool_call (
+        id, session_id, message_id, call_block_id, result_block_id,
+        tool_name, tool_use_id, duration_ms, ordinal, timestamp
+      )
+      VALUES (
+        1000, 1, NULL, 100, 101,
+        'Read', 'toolu_v19', NULL, 0, '2026-07-29T00:00:00.000Z'
+      );
+      INSERT INTO recommendation (
+        key, kind, title, score, status, note, first_seen_at, updated_at
+      ) VALUES (
+        'signal:preserved', 'signal', 'Preserve me', 42, 'open', 'operator note',
+        '2026-07-29T00:00:00Z', '2026-07-29T00:00:00Z'
+      );
+      ALTER TABLE recommendation DROP COLUMN impact_label_checked;
+      ALTER TABLE recommendation DROP COLUMN impact_label;
+      DROP INDEX idx_block_tool_use;
+      DELETE FROM schema_migrations WHERE version = 19;
+    `);
+    db.close();
+
+    db = openDb(path);
+    expect(db.query("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({
+      version: 19,
+    });
+    expect(
+      db
+        .query(
+          `SELECT key, title, note, impact_label, impact_label_checked
+           FROM recommendation WHERE key = 'signal:preserved'`,
+        )
+        .get(),
+    ).toEqual({
+      key: "signal:preserved",
+      title: "Preserve me",
+      note: "operator note",
+      impact_label: null,
+      impact_label_checked: 0,
+    });
+    expect(
+      db
+        .query("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'idx_block_tool_use'")
+        .get(),
+    ).not.toBeNull();
+    expect(db.query("SELECT message_id, duration_ms FROM tool_call WHERE id = 1000").get()).toEqual(
+      {
+        message_id: null,
+        duration_ms: 1_250,
+      },
+    );
+    db.close();
+
+    expect(() => openDb(path).close()).not.toThrow();
+  });
+
+  test("fails fast on owned-schema drift with one actionable error record", () => {
+    const path = freshPath();
+    const db = openDb(path);
+    db.exec(`
+      ALTER TABLE recommendation DROP COLUMN impact_label;
+      ALTER TABLE session ADD COLUMN unexpected_local_state TEXT;
+    `);
+    db.close();
+
+    const lines: string[] = [];
+    configureLogging({ level: "info", write: (line) => lines.push(line) });
+    let caught: unknown;
+    try {
+      openDb(path);
+    } catch (error) {
+      caught = error;
+    } finally {
+      resetSync();
+    }
+
+    expect(caught).toBeInstanceOf(SchemaDriftError);
+    expect((caught as Error).message).toContain("missing columns: recommendation.impact_label");
+    expect((caught as Error).message).toContain(
+      "unexpected columns: session.unexpected_local_state",
+    );
+    expect((caught as Error).message).toContain("Back up or move the archive aside");
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0] ?? "")).toMatchObject({
+      level: "ERROR",
+      "event.name": "decant.schema.drift",
+      "schema.version": 19,
+      "schema.drift.missing_columns": "recommendation.impact_label",
+      "schema.drift.unexpected_columns": "session.unexpected_local_state",
+      "error.type": "SchemaDriftError",
+      "recovery.action": "back_up_then_rebuild_from_complete_sources",
+    });
+  });
+
+  test("rolls back a repair and its v19 stamp when unrelated drift remains", () => {
+    const path = freshPath();
+    const db = openDb(path);
+    db.exec(`
+      ALTER TABLE recommendation DROP COLUMN impact_label_checked;
+      ALTER TABLE recommendation DROP COLUMN impact_label;
+      ALTER TABLE session ADD COLUMN unexpected_local_state TEXT;
+      DELETE FROM schema_migrations WHERE version = 19;
+    `);
+    db.close();
+
+    expect(() => openDb(path)).toThrow(SchemaDriftError);
+
+    const unchanged = new Database(path, { strict: true });
+    expect(unchanged.query("SELECT MAX(version) AS version FROM schema_migrations").get()).toEqual({
+      version: 18,
+    });
+    expect(
+      (
+        unchanged.query("SELECT name FROM pragma_table_info('recommendation')").all() as {
+          name: string;
+        }[]
+      ).map((column) => column.name),
+    ).not.toContain("impact_label");
+    expect(
+      unchanged
+        .query("SELECT 1 FROM pragma_table_info('session') WHERE name = 'unexpected_local_state'")
+        .get(),
+    ).not.toBeNull();
+    unchanged.close();
+  });
+
+  test("does not initialize a non-empty database without schema_migrations", () => {
+    const path = freshPath();
+    const db = new Database(path, { create: true, strict: true });
+    db.exec("CREATE TABLE operator_data(id INTEGER PRIMARY KEY, note TEXT)");
+    db.close();
+
+    expect(() => openDb(path)).toThrow(SchemaDriftError);
+    const untouched = new Database(path, { strict: true });
+    expect(inventory(untouched, "table")).toEqual(["operator_data"]);
+    untouched.close();
+  });
+
+  test("bounds and sanitizes adversarial schema identifiers in errors and logs", () => {
+    const path = freshPath();
+    const unsafeName = `operator🚀\n\u0007${"x".repeat(20_000)}`;
+    const db = new Database(path, { create: true, strict: true });
+    db.exec(`CREATE TABLE "${unsafeName}"(id INTEGER PRIMARY KEY)`);
+    db.close();
+
+    const lines: string[] = [];
+    configureLogging({ level: "info", write: (line) => lines.push(line) });
+    let caught: unknown;
+    try {
+      openDb(path);
+    } catch (error) {
+      caught = error;
+    } finally {
+      resetSync();
+    }
+
+    expect(caught).toBeInstanceOf(SchemaDriftError);
+    const message = (caught as Error).message;
+    expect([...message].length).toBeLessThan(4_096);
+    expect(message).toContain("operator🚀��");
+    expect(message).not.toContain("\n");
+    expect(message).not.toContain(String.fromCharCode(7));
+    expect(lines).toHaveLength(1);
+    expect([...(lines[0] ?? "")].length).toBeLessThan(8_192);
+    const record = JSON.parse(lines[0] ?? "") as Record<string, string>;
+    expect(record["schema.drift.reason"]).not.toContain("\n");
+    expect(record["schema.drift.reason"]).not.toContain(String.fromCharCode(7));
+    expect(record["error.message"]).toBe(message);
+  });
+
+  test("reports malformed and non-contiguous migration history as schema drift", () => {
+    const malformedPath = freshPath();
+    const malformed = new Database(malformedPath, { create: true, strict: true });
+    malformed.exec("CREATE TABLE schema_migrations(applied_at TEXT NOT NULL)");
+    malformed.close();
+    expect(() => openDb(malformedPath)).toThrow(/schema_migrations is malformed or unreadable/);
+
+    const gappedPath = freshPath();
+    const gapped = openDb(gappedPath);
+    gapped.exec("DELETE FROM schema_migrations WHERE version = 10");
+    gapped.close();
+    expect(() => openDb(gappedPath)).toThrow(/schema_migrations is non-contiguous/);
+  });
+
   test("rejects a pre-baseline archive and points at rebuilding it", () => {
     const path = freshPath();
     const db = openDb(path);
     db.exec("DELETE FROM schema_migrations WHERE version >= 8");
     db.close();
     expect(() => openDb(path)).toThrow(/rebuild/i);
+  });
+});
+
+describe("schema manifest", () => {
+  function manifest(defaultValue: string, triggerValue: string) {
+    const db = new Database(":memory:", { strict: true });
+    db.exec(`
+      CREATE TABLE literal_test(id INTEGER PRIMARY KEY, value TEXT DEFAULT '${defaultValue}');
+      CREATE TABLE audit(value TEXT);
+      CREATE TRIGGER literal_trigger AFTER INSERT ON literal_test BEGIN
+        INSERT INTO audit(value) VALUES ('${triggerValue}');
+      END;
+    `);
+    const result = buildSchemaManifest(db);
+    db.close();
+    return result;
+  }
+
+  test("preserves whitespace, punctuation, quotes, and keywords inside SQL literals", () => {
+    const baseline = manifest('a  b "Name" if not exists', "x, y");
+    expect(manifest('a b "Name" if not exists', "x, y").fingerprint).not.toBe(baseline.fingerprint);
+    expect(manifest('a  b "Name" if not exists', "x,y").fingerprint).not.toBe(baseline.fingerprint);
+    expect(manifest('a  b "name" if not exists', "x, y").fingerprint).not.toBe(
+      baseline.fingerprint,
+    );
   });
 });
 

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -206,6 +206,42 @@ describe("openDb", () => {
     db.close();
   });
 
+  test("does not renegotiate journal mode when reopening an already-WAL archive", () => {
+    const path = freshPath();
+    openDb(path).close();
+    const originalExec = Database.prototype.exec;
+    const journalModeWrites: string[] = [];
+    Database.prototype.exec = function (this: Database, sql: string) {
+      if (/^\s*PRAGMA\s+journal_mode\s*=/i.test(sql)) {
+        journalModeWrites.push(sql);
+      }
+      return originalExec.call(this, sql);
+    } as Database["exec"];
+    try {
+      openDb(path).close();
+    } finally {
+      Database.prototype.exec = originalExec;
+    }
+    expect(journalModeWrites).toEqual([]);
+  });
+
+  test("reopens an already-WAL archive while another connection holds the write lock", () => {
+    const path = freshPath();
+    openDb(path).close();
+    const writer = new Database(path, { strict: true });
+    writer.exec("BEGIN IMMEDIATE;");
+    try {
+      const reopened = openDb(path);
+      expect(
+        (reopened.query("PRAGMA journal_mode").get() as { journal_mode: string }).journal_mode,
+      ).toBe("wal");
+      reopened.close();
+    } finally {
+      writer.exec("ROLLBACK;");
+      writer.close();
+    }
+  });
+
   test("serializes two processes creating the same fresh archive", async () => {
     const dbModule = pathToFileURL(join(import.meta.dir, "..", "src", "db.ts")).href;
     const script = `
@@ -951,6 +987,55 @@ describe("schema manifest", () => {
     expect(manifest('a  b "name" if not exists', "x, y").fingerprint).not.toBe(
       baseline.fingerprint,
     );
+  });
+
+  test("orders foreign keys directly by their typed fields", () => {
+    const db = new Database(":memory:", { strict: true });
+    db.exec(`
+      CREATE TABLE alpha_parent(
+        first_id INTEGER NOT NULL,
+        second_id INTEGER NOT NULL,
+        UNIQUE(first_id, second_id)
+      );
+      CREATE TABLE zulu_parent(id INTEGER PRIMARY KEY);
+      CREATE TABLE child(
+        alpha_first INTEGER,
+        alpha_second INTEGER,
+        zulu_id INTEGER REFERENCES zulu_parent(id),
+        FOREIGN KEY(alpha_first, alpha_second)
+          REFERENCES alpha_parent(first_id, second_id)
+      );
+    `);
+    const child = buildSchemaManifest(db).objects.find((object) => object.name === "child");
+    db.close();
+
+    expect(
+      child?.foreign_keys.map(({ table, from, to, sequence }) => ({
+        table,
+        from,
+        to,
+        sequence,
+      })),
+    ).toEqual([
+      {
+        table: "alpha_parent",
+        from: "alpha_first",
+        to: "first_id",
+        sequence: 0,
+      },
+      {
+        table: "alpha_parent",
+        from: "alpha_second",
+        to: "second_id",
+        sequence: 1,
+      },
+      {
+        table: "zulu_parent",
+        from: "zulu_id",
+        to: "id",
+        sequence: 0,
+      },
+    ]);
   });
 });
 

--- a/test/fixtures/schema-v8.sql
+++ b/test/fixtures/schema-v8.sql
@@ -1,8 +1,6 @@
--- decant:schema_version=19
--- Effective decant schema (migrations 1..19 applied), frozen as the current
--- baseline. v19 repairs recommendation impact columns for archives that ran
--- the original v18 migration before those columns were added to it.
--- Do not edit without updating schema tests.
+-- decant:schema_version=8
+-- Effective decant schema (migrations 1..8 applied), frozen at the
+-- pre-typescript cutover. Do not edit without updating schema tests.
 CREATE TABLE schema_migrations(
             version INTEGER PRIMARY KEY,
             applied_at TEXT NOT NULL
@@ -28,9 +26,6 @@ CREATE TABLE session (
   cwd TEXT,
   git_branch TEXT,
   model TEXT,
-  reasoning_effort TEXT,
-  reasoning_effort_levels TEXT NOT NULL DEFAULT '[]',
-  reasoning_effort_checked INTEGER NOT NULL DEFAULT 0,
   cli_version TEXT,
   started_at TEXT,
   ended_at TEXT,
@@ -39,18 +34,11 @@ CREATE TABLE session (
   total_output_tokens INTEGER NOT NULL DEFAULT 0,
   total_cache_read_tokens INTEGER NOT NULL DEFAULT 0,
   total_cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
-  total_cache_creation_1h_tokens INTEGER NOT NULL DEFAULT 0,
   total_reasoning_tokens INTEGER NOT NULL DEFAULT 0,
   est_reasoning_tokens INTEGER NOT NULL DEFAULT 0,
   reasoning_source TEXT,
   estimated_cost_usd REAL NOT NULL DEFAULT 0,
   is_archived INTEGER NOT NULL DEFAULT 0,
-  is_subagent INTEGER NOT NULL DEFAULT 0,
-  parent_session_id INTEGER REFERENCES session(id),
-  spawn_tool_use_id TEXT,
-  agent_id TEXT,
-  agent_type TEXT,
-  spawn_depth INTEGER,
   source_path TEXT,
   raw_meta TEXT,
   ingested_at TEXT,
@@ -70,10 +58,6 @@ CREATE TABLE session (
   active_seconds INTEGER NOT NULL DEFAULT 0,
   outcome TEXT,
   work_type TEXT,
-  -- Context-window rollups materialized from per-message usage at ingest;
-  -- peak_context_tokens IS NULL marks a session that still needs the backfill.
-  context_window_tokens INTEGER,
-  peak_context_tokens INTEGER,
   UNIQUE(tool, source_session_id)
 );
 CREATE TABLE message (
@@ -117,9 +101,7 @@ CREATE TABLE tool_call (
   tool_base_name TEXT,
   tool_use_id TEXT,
   input TEXT,
-  input_bytes INTEGER,
   is_error INTEGER,
-  has_result INTEGER,
   output_preview TEXT,
   output_bytes INTEGER,
   duration_ms INTEGER,
@@ -153,7 +135,6 @@ CREATE TABLE ingest_issue (
   source_path TEXT,
   line_no INTEGER,
   error TEXT,
-  code TEXT NOT NULL DEFAULT 'unparsed_line',
   raw_line TEXT,
   created_at TEXT
 );
@@ -163,15 +144,8 @@ CREATE TABLE model_pricing (
   output_per_mtok REAL,
   cache_read_per_mtok REAL,
   cache_write_per_mtok REAL,
-  cache_write_1h_per_mtok REAL,
   source TEXT,
   updated_at TEXT
-);
-CREATE TABLE session_economics (
-  session_id INTEGER PRIMARY KEY REFERENCES session(id) ON DELETE CASCADE,
-  format_version INTEGER NOT NULL,
-  vector_json TEXT NOT NULL,
-  computed_at TEXT NOT NULL
 );
 CREATE TABLE recommendation (
   key            TEXT PRIMARY KEY,
@@ -185,8 +159,6 @@ CREATE TABLE recommendation (
   link_label     TEXT,
   icon           TEXT,
   tone           TEXT,
-  impact_label   TEXT,
-  impact_label_checked INTEGER NOT NULL DEFAULT 1,
   score          REAL,
   status         TEXT NOT NULL DEFAULT 'open',   -- 'open' | 'implemented'
   status_source  TEXT,               -- 'agent' | 'activity' | 'manual'
@@ -199,14 +171,11 @@ CREATE INDEX idx_session_project ON session(project_id);
 CREATE INDEX idx_session_tool ON session(tool);
 CREATE INDEX idx_session_started ON session(started_at);
 CREATE INDEX idx_session_model ON session(model);
-CREATE INDEX idx_session_parent ON session(parent_session_id);
-CREATE INDEX idx_session_spawn_tooluse ON session(spawn_tool_use_id);
 CREATE INDEX idx_message_session ON message(session_id, seq);
 CREATE INDEX idx_block_session ON block(session_id);
 CREATE INDEX idx_block_message ON block(message_id, ordinal);
 CREATE INDEX idx_block_type ON block(type);
 CREATE INDEX idx_block_tool ON block(tool_name);
-CREATE INDEX idx_block_tool_use ON block(session_id, tool_use_id);
 CREATE INDEX idx_toolcall_session ON tool_call(session_id);
 CREATE INDEX idx_toolcall_kind ON tool_call(tool_kind);
 CREATE INDEX idx_toolcall_server ON tool_call(mcp_server);
@@ -220,11 +189,9 @@ CREATE INDEX idx_toolcall_call_block ON tool_call(call_block_id);
 CREATE INDEX idx_toolcall_result_block ON tool_call(result_block_id);
 CREATE INDEX idx_fileref_message ON file_ref(message_id);
 CREATE INDEX idx_ingest_source_session ON ingest_source(session_id);
-CREATE INDEX idx_ingest_issue_source ON ingest_issue(source_path);
 CREATE VIRTUAL TABLE block_fts USING fts5(
   text, tool_name, tool_input,
-  content='block', content_rowid='id',
-  prefix='2 3'
+  content='block', content_rowid='id'
 );
 CREATE TRIGGER block_ai AFTER INSERT ON block BEGIN
   INSERT INTO block_fts(rowid, text, tool_name, tool_input)

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -906,6 +906,23 @@ describe("server routes", () => {
     }
   });
 
+  test("maps schema drift to an actionable conflict", async () => {
+    const config = freshConfig();
+    const db = openDb(config.dbPath);
+    db.exec("ALTER TABLE recommendation DROP COLUMN impact_label");
+    db.close();
+
+    const response = await route(config, "/api/sessions");
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({ code: "schema_drift" });
+    expect((response.body as { error: string }).error).toContain(
+      "missing columns: recommendation.impact_label",
+    );
+    expect((response.body as { error: string }).error).toContain(
+      "Back up or move the archive aside",
+    );
+  });
+
   test("keeps unexpected exception details in server logs, not 500 responses", async () => {
     const config = freshConfig();
     const closedDb = openDb(config.dbPath);


### PR DESCRIPTION
## Summary

- Bumps the archive baseline to v19 and safely replays every late v18 review repair for archives that had already recorded the earlier v18: recommendation impact columns, `idx_block_tool_use`, and timestamp-fallback tool duration backfill.
- Adds semantic owned-schema fingerprinting, actionable bounded drift errors, contiguous migration-history checks, concurrency-safe archive initialization/WAL negotiation, and an HTTP `schema_drift` conflict response.
- Freezes a complete v8 schema fixture and proves fresh and migrated archives converge semantically without rebuilding user data.

## Why

A dogfooding archive recorded migration v18 before the final review edits landed, so its migration history said v18 while required columns and an index were absent. Watcher syncs and analytics reports then failed repeatedly with raw SQLite errors.

The repair must also distinguish real drift from harmless SQLite representation differences caused by `ALTER TABLE`, FTS renames, and the historical `impact_label_checked` default. The new manifest compares schema semantics while preserving SQL literal contents and reporting exact missing or changed objects.

## User and developer impact

- Affected v18 archives self-repair on the next open without deleting source logs or operator-authored recommendation state.
- Non-repairable drift fails once with a bounded, actionable error that tells the operator to back up before rebuilding.
- Concurrent first opens no longer race schema creation or WAL negotiation.
- Future committed migrations are explicitly frozen; review-time schema changes require a new version.

## Validation

- [x] `just check` passes: 651 tests, TypeScript, Biome (154 files), and distribution staging smoke.
- [x] New behavior has focused tests. No existing test was weakened or deleted to make this pass.
- [x] Adversarial review reproduced the original pre-review-v18 lineage and fresh-open races; all valid findings were fixed and re-reviewed with no remaining findings.

Focused coverage includes full v8-to-v19 equivalence, exact pre-review-v18 repair and data preservation, rollback on unrelated drift, malformed/gapped histories, bounded hostile identifiers, SQL-literal-sensitive fingerprints, schema error routing, and 10 barrier-synchronized two-process initialization races.

## Archive schema

The baseline is `LATEST_SCHEMA_VERSION` in `src/db.ts`. Check one:

- [ ] This change does not touch the archive schema.
- [x] This change bumps the schema. Existing v8-v18 archives migrate to v19; affected v18 archives receive guarded additive repairs and safe NULL-only metadata backfill before the v19 stamp commits.
