### PR TITLE
feat: polish tools and session UI

### DIFF
--- a/src/ui/date-time.ts
+++ b/src/ui/date-time.ts
@@ -108,6 +108,10 @@ export function fullDateTime(
 function compactRelativeTime(deltaMs: number): string {
   const deltaSeconds = Math.round(deltaMs / 1000);
   const abs = Math.abs(deltaSeconds);
+  const roundedHours = Math.round(abs / 3_600);
+  if (abs < 86_400 && roundedHours >= 24) {
+    return deltaSeconds < 0 ? "in 1d" : "1d ago";
+  }
   const units: [suffix: string, seconds: number][] = [
     ["d", 86_400],
     ["h", 3_600],

--- a/src/ui/date-time.ts
+++ b/src/ui/date-time.ts
@@ -4,6 +4,9 @@ export interface DateTimeFormatOptions {
   timeZone?: string;
 }
 
+const DAY_MS = 86_400_000;
+const RECENT_SESSION_MS = 7 * DAY_MS;
+
 export function compactDateTime(
   value: string | null | undefined,
   options: DateTimeFormatOptions = {},
@@ -28,6 +31,63 @@ export function compactDateTime(
     .replace(/,\s*/g, " ");
 }
 
+export function relativeTime(
+  value: string | null | undefined,
+  options: DateTimeFormatOptions = {},
+): string {
+  if (value == null || value === "") {
+    return "-";
+  }
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    return value;
+  }
+  const deltaSeconds = Math.round(((options.now ?? new Date()).getTime() - timestamp) / 1000);
+  const abs = Math.abs(deltaSeconds);
+  const units: [Intl.RelativeTimeFormatUnit, number][] = [
+    ["year", 31_536_000],
+    ["month", 2_592_000],
+    ["day", 86_400],
+    ["hour", 3_600],
+    ["minute", 60],
+  ];
+  const formatter = new Intl.RelativeTimeFormat(options.locale, { numeric: "auto" });
+  for (const [unit, seconds] of units) {
+    if (abs >= seconds) {
+      return formatter.format(Math.round(-deltaSeconds / seconds), unit);
+    }
+  }
+  return "just now";
+}
+
+export function sessionListDate(
+  value: string | null | undefined,
+  options: DateTimeFormatOptions = {},
+): string | null {
+  const date = parsedDate(value);
+  if (date == null) {
+    return null;
+  }
+  const now = options.now ?? new Date();
+  const deltaMs = now.getTime() - date.getTime();
+  if (Math.abs(deltaMs) < RECENT_SESSION_MS) {
+    return compactRelativeTime(deltaMs);
+  }
+  const includeYear =
+    calendarYear(date, options.locale, options.timeZone) !==
+    calendarYear(now, options.locale, options.timeZone);
+  return new Intl.DateTimeFormat(options.locale, {
+    year: includeYear ? "numeric" : undefined,
+    month: "short",
+    day: "numeric",
+    hour: includeYear ? undefined : "numeric",
+    minute: includeYear ? undefined : "2-digit",
+    timeZone: options.timeZone,
+  })
+    .format(date)
+    .replace(/\s+at\s+/, ", ");
+}
+
 export function fullDateTime(
   value: string | null | undefined,
   options: Omit<DateTimeFormatOptions, "now"> = {},
@@ -41,6 +101,23 @@ export function fullDateTime(
     timeStyle: "long",
     timeZone: options.timeZone,
   }).format(date);
+}
+
+function compactRelativeTime(deltaMs: number): string {
+  const deltaSeconds = Math.round(deltaMs / 1000);
+  const abs = Math.abs(deltaSeconds);
+  const units: [suffix: string, seconds: number][] = [
+    ["d", 86_400],
+    ["h", 3_600],
+    ["m", 60],
+  ];
+  for (const [suffix, seconds] of units) {
+    if (abs >= seconds) {
+      const amount = Math.round(abs / seconds);
+      return deltaSeconds < 0 ? `in ${amount}${suffix}` : `${amount}${suffix} ago`;
+    }
+  }
+  return "just now";
 }
 
 function calendarYear(

--- a/src/ui/date-time.ts
+++ b/src/ui/date-time.ts
@@ -6,6 +6,8 @@ export interface DateTimeFormatOptions {
 
 const DAY_MS = 86_400_000;
 const RECENT_SESSION_MS = 7 * DAY_MS;
+const dateTimeFormatCache = new Map<string, Intl.DateTimeFormat>();
+const relativeTimeFormatCache = new Map<string, Intl.RelativeTimeFormat>();
 
 export function compactDateTime(
   value: string | null | undefined,
@@ -19,7 +21,7 @@ export function compactDateTime(
   const includeYear =
     calendarYear(date, options.locale, options.timeZone) !==
     calendarYear(now, options.locale, options.timeZone);
-  return new Intl.DateTimeFormat(options.locale, {
+  return getDateTimeFormatter(options.locale, {
     year: includeYear ? "2-digit" : undefined,
     month: "numeric",
     day: "numeric",
@@ -51,7 +53,7 @@ export function relativeTime(
     ["hour", 3_600],
     ["minute", 60],
   ];
-  const formatter = new Intl.RelativeTimeFormat(options.locale, { numeric: "auto" });
+  const formatter = getRelativeTimeFormatter(options.locale, { numeric: "auto" });
   for (const [unit, seconds] of units) {
     if (abs >= seconds) {
       return formatter.format(Math.round(-deltaSeconds / seconds), unit);
@@ -76,7 +78,7 @@ export function sessionListDate(
   const includeYear =
     calendarYear(date, options.locale, options.timeZone) !==
     calendarYear(now, options.locale, options.timeZone);
-  return new Intl.DateTimeFormat(options.locale, {
+  return getDateTimeFormatter(options.locale, {
     year: includeYear ? "numeric" : undefined,
     month: "short",
     day: "numeric",
@@ -96,7 +98,7 @@ export function fullDateTime(
   if (date == null) {
     return null;
   }
-  return new Intl.DateTimeFormat(options.locale, {
+  return getDateTimeFormatter(options.locale, {
     dateStyle: "medium",
     timeStyle: "long",
     timeZone: options.timeZone,
@@ -125,7 +127,7 @@ function calendarYear(
   locale: string | undefined,
   timeZone: string | undefined,
 ): string {
-  return new Intl.DateTimeFormat(locale, { year: "numeric", timeZone }).format(date);
+  return getDateTimeFormatter(locale, { year: "numeric", timeZone }).format(date);
 }
 
 function parsedDate(value: string | null | undefined): Date | null {
@@ -134,4 +136,30 @@ function parsedDate(value: string | null | undefined): Date | null {
   }
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getDateTimeFormatter(
+  locale: string | undefined,
+  options: Intl.DateTimeFormatOptions,
+): Intl.DateTimeFormat {
+  const key = JSON.stringify([locale ?? null, options]);
+  let formatter = dateTimeFormatCache.get(key);
+  if (formatter == null) {
+    formatter = new Intl.DateTimeFormat(locale, options);
+    dateTimeFormatCache.set(key, formatter);
+  }
+  return formatter;
+}
+
+function getRelativeTimeFormatter(
+  locale: string | undefined,
+  options: Intl.RelativeTimeFormatOptions,
+): Intl.RelativeTimeFormat {
+  const key = JSON.stringify([locale ?? null, options]);
+  let formatter = relativeTimeFormatCache.get(key);
+  if (formatter == null) {
+    formatter = new Intl.RelativeTimeFormat(locale, options);
+    relativeTimeFormatCache.set(key, formatter);
+  }
+  return formatter;
 }

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -75,7 +75,7 @@ import {
   layoutContextTooltip,
 } from "./context-window-layout.ts";
 import { contextWindowDisplayMode, isFullCacheMiss } from "./context-window-state.ts";
-import { compactDateTime, fullDateTime } from "./date-time.ts";
+import { fullDateTime, relativeTime, sessionListDate } from "./date-time.ts";
 import { dosuBadgeAriaLabel, dosuBadgeVisualLabel, dosuEvidenceSummary } from "./dosu-badge.ts";
 import { DOSU_ANALYTICS_DISMISSAL_KEY, shouldShowDosuCta } from "./dosu-cta.ts";
 import { dosuLink } from "./dosu-links.ts";
@@ -112,6 +112,7 @@ import {
   shareCardTitle,
 } from "./share-card.ts";
 import { collectSliceResults } from "./slice-loading.ts";
+import { toolCallStatus } from "./tool-call-status.ts";
 import {
   isDrilldownActivationKey,
   type ToolFilters,
@@ -120,6 +121,7 @@ import {
   toolFiltersHref,
   withToolDateRange,
 } from "./tool-filters.ts";
+import { toolTableColumns } from "./tool-table-layout.ts";
 import { TranscriptCodeBlock, TranscriptMarkdown } from "./transcript-markdown.tsx";
 import {
   hasOpenModal,
@@ -1596,7 +1598,7 @@ function SessionTableSkeletonRows() {
         <span className="skeleton-line table-skeleton-line title" />
       </td>
       <td>
-        <span className="skeleton-line table-skeleton-line model" />
+        <span className="skeleton-line table-skeleton-line project" />
       </td>
       <td>
         <span className="skeleton-line table-skeleton-line model" />
@@ -2003,13 +2005,13 @@ function DosuProvenanceBadge({ session }: { session: SessionSummary }) {
 }
 
 function SessionStartedAt({ value }: { value: string | null }) {
-  const compact = compactDateTime(value);
-  if (compact == null || value == null) {
+  const display = sessionListDate(value);
+  if (display == null || value == null) {
     return <span>-</span>;
   }
   return (
-    <time dateTime={value} title={fullDateTime(value) ?? compact}>
-      {compact}
+    <time dateTime={value} title={fullDateTime(value) ?? display}>
+      {display}
     </time>
   );
 }
@@ -2841,7 +2843,15 @@ function ExportReviewSheet({
     return null;
   }
   return createPortal(
-    <div className="report-review-backdrop">
+    // biome-ignore lint/a11y/noStaticElementInteractions: backdrop dismissal supplements Escape and the explicit close button.
+    <div
+      className="report-review-backdrop"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
       <section
         aria-labelledby={titleId}
         aria-modal="true"
@@ -4122,7 +4132,15 @@ function ShareChartButton({
       </button>
       {open
         ? createPortal(
-            <div className="share-review-backdrop">
+            // biome-ignore lint/a11y/noStaticElementInteractions: backdrop dismissal supplements Escape and the explicit close button.
+            <div
+              className="share-review-backdrop"
+              onMouseDown={(event) => {
+                if (event.target === event.currentTarget) {
+                  closeShareReview();
+                }
+              }}
+            >
               <section
                 aria-labelledby={`share-title-${input.kind}`}
                 aria-modal="true"
@@ -5657,32 +5675,6 @@ function duration(ms: number): string {
   return `${hours}h ${minutes % 60}m`;
 }
 
-function relativeTime(value: string | null | undefined): string {
-  if (value == null || value === "") {
-    return "-";
-  }
-  const timestamp = Date.parse(value);
-  if (!Number.isFinite(timestamp)) {
-    return value;
-  }
-  const deltaSeconds = Math.round((Date.now() - timestamp) / 1000);
-  const abs = Math.abs(deltaSeconds);
-  const units: [Intl.RelativeTimeFormatUnit, number][] = [
-    ["year", 31_536_000],
-    ["month", 2_592_000],
-    ["day", 86_400],
-    ["hour", 3_600],
-    ["minute", 60],
-  ];
-  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
-  for (const [unit, seconds] of units) {
-    if (abs >= seconds) {
-      return formatter.format(Math.round(-deltaSeconds / seconds), unit);
-    }
-  }
-  return "just now";
-}
-
 function capitalize(value: string): string {
   return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
 }
@@ -6055,21 +6047,12 @@ function prettyToolValue(value: string | null): string {
 }
 
 function ToolCallStatus({ call }: { call: ToolCallRow }) {
-  const status =
-    call.is_error === true
-      ? { className: "is-error", label: "Error" }
-      : call.is_error === false
-        ? { className: "is-success", label: "Succeeded" }
-        : call.has_result === false
-          ? { className: "is-pending", label: "No result" }
-          : { className: "is-unknown", label: "Unknown" };
+  const status = toolCallStatus(call.is_error);
   return (
-    <span
-      aria-label={status.label}
-      className={`tool-call-status ${status.className}`}
-      role="img"
-      title={status.label}
-    />
+    <Badge className="tool-call-status" title={status.title ?? undefined} tone={status.tone}>
+      <Icon name={status.icon} />
+      {status.label}
+    </Badge>
   );
 }
 
@@ -6291,6 +6274,9 @@ function ToolsView({
   const durationAvailable =
     data.tools.some((row) => row.p50_ms != null) ||
     callPage.calls.some((row) => row.duration_ms != null);
+  const mcpColumns = toolTableColumns("mcp", durationAvailable);
+  const toolColumns = toolTableColumns("tools", durationAvailable);
+  const callColumns = toolTableColumns("calls", durationAvailable);
 
   useEffect(() => {
     const restored = toolDateRangeFromFilters({
@@ -6414,14 +6400,15 @@ function ToolsView({
           />
         ) : (
           <div className="table-scroll">
-            <table className="data-table mcp-table">
+            <table className={`data-table mcp-table${durationAvailable ? " has-duration" : ""}`}>
               <colgroup>
-                <col className="col-wide" />
-                <col className="col-number" />
-                <col className="col-number" />
-                <col className="col-number" />
-                {durationAvailable ? <col className="col-number" /> : null}
-                <col className="col-number" />
+                {mcpColumns.map((column) => (
+                  <col
+                    className={column.className}
+                    key={column.className}
+                    style={{ width: `${column.width}%` }}
+                  />
+                ))}
               </colgroup>
               <thead>
                 <tr>
@@ -6519,15 +6506,15 @@ function ToolsView({
           </div>
         </div>
         <div className="table-scroll">
-          <table className="data-table tools-table">
+          <table className={`data-table tools-table${durationAvailable ? " has-duration" : ""}`}>
             <colgroup>
-              <col className="col-tool" />
-              <col className="col-kind" />
-              <col className="col-server" />
-              <col className="col-number" />
-              <col className="col-number" />
-              {durationAvailable ? <col className="col-number" /> : null}
-              <col className="col-number" />
+              {toolColumns.map((column) => (
+                <col
+                  className={column.className}
+                  key={column.className}
+                  style={{ width: `${column.width}%` }}
+                />
+              ))}
             </colgroup>
             <thead>
               <tr>
@@ -6609,7 +6596,7 @@ function ToolsView({
                       {row.mcp_server != null && row.mcp_server !== "" ? (
                         <span className="icon-cell">
                           <Icon name="cpu" />
-                          {row.mcp_server}
+                          <span>{row.mcp_server}</span>
                         </span>
                       ) : (
                         <span className="faint">-</span>
@@ -6727,7 +6714,18 @@ function ToolsView({
         ) : (
           <>
             <div className="table-scroll">
-              <table className="data-table tool-calls-table">
+              <table
+                className={`data-table tool-calls-table${durationAvailable ? " has-duration" : ""}`}
+              >
+                <colgroup>
+                  {callColumns.map((column) => (
+                    <col
+                      className={column.className}
+                      key={column.className}
+                      style={{ width: `${column.width}%` }}
+                    />
+                  ))}
+                </colgroup>
                 <thead>
                   <tr>
                     <th>Status</th>

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -6048,11 +6048,24 @@ function prettyToolValue(value: string | null): string {
 
 function ToolCallStatus({ call }: { call: ToolCallRow }) {
   const status = toolCallStatus(call.is_error);
-  return (
-    <Badge className="tool-call-status" title={status.title ?? undefined} tone={status.tone}>
+  const badge = (
+    <Badge className="tool-call-status" tone={status.tone}>
       <Icon name={status.icon} />
       {status.label}
     </Badge>
+  );
+  if (status.title == null) {
+    return badge;
+  }
+  return (
+    <Tooltip content={status.title}>
+      {(tooltipProps) => (
+        <span {...tooltipProps}>
+          {badge}
+          <span className="sr-only">{status.title}</span>
+        </span>
+      )}
+    </Tooltip>
   );
 }
 
@@ -6400,7 +6413,7 @@ function ToolsView({
           />
         ) : (
           <div className="table-scroll">
-            <table className={`data-table mcp-table${durationAvailable ? " has-duration" : ""}`}>
+            <table className="data-table mcp-table">
               <colgroup>
                 {mcpColumns.map((column) => (
                   <col
@@ -6506,7 +6519,7 @@ function ToolsView({
           </div>
         </div>
         <div className="table-scroll">
-          <table className={`data-table tools-table${durationAvailable ? " has-duration" : ""}`}>
+          <table className="data-table tools-table">
             <colgroup>
               {toolColumns.map((column) => (
                 <col
@@ -6714,9 +6727,7 @@ function ToolsView({
         ) : (
           <>
             <div className="table-scroll">
-              <table
-                className={`data-table tool-calls-table${durationAvailable ? " has-duration" : ""}`}
-              >
+              <table className="data-table tool-calls-table">
                 <colgroup>
                   {callColumns.map((column) => (
                     <col

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -840,15 +840,19 @@ table {
 }
 
 .mcp-table {
-  min-width: 680px;
+  min-width: 720px;
 }
 
 .tools-table {
-  min-width: 1080px;
+  min-width: 900px;
 }
 
 .tool-calls-table {
-  min-width: 980px;
+  min-width: 960px;
+}
+
+.tool-stat-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .tool-stat-grid .stat-card strong {
@@ -928,27 +932,8 @@ table {
 }
 
 .tool-call-status {
-  display: inline-block;
-  width: 9px;
-  height: 9px;
-  border-radius: 999px;
-  background: var(--faint);
-  box-shadow: 0 0 0 3px color-mix(in oklab, var(--faint) 16%, transparent);
-}
-
-.tool-call-status.is-success {
-  background: var(--success);
-  box-shadow: 0 0 0 3px color-mix(in oklab, var(--success) 16%, transparent);
-}
-
-.tool-call-status.is-error {
-  background: var(--danger);
-  box-shadow: 0 0 0 3px color-mix(in oklab, var(--danger) 16%, transparent);
-}
-
-.tool-call-status.is-pending {
-  background: var(--warning);
-  box-shadow: 0 0 0 3px color-mix(in oklab, var(--warning) 16%, transparent);
+  min-width: 64px;
+  justify-content: center;
 }
 
 .tool-call-pagination {
@@ -961,6 +946,9 @@ table {
 }
 
 .tool-call-detail-button {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
   border: 0;
   background: transparent;
   color: inherit;
@@ -968,6 +956,8 @@ table {
   font: inherit;
   padding: 0;
   text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .tool-call-detail-button:hover,
@@ -1180,24 +1170,8 @@ table {
   height: 12px;
 }
 
-.col-wide {
-  width: 58%;
-}
-
 .col-number {
   width: 14%;
-}
-
-.col-tool {
-  width: 30%;
-}
-
-.col-kind {
-  width: 12%;
-}
-
-.col-server {
-  width: 30%;
 }
 
 .col-file {
@@ -1274,6 +1248,12 @@ tbody tr:hover {
 
 .tool-calls-table tbody tr {
   cursor: pointer;
+}
+
+.tool-calls-table th:first-child,
+.tool-calls-table td:first-child {
+  padding-right: 12px;
+  padding-left: 12px;
 }
 
 th {
@@ -1373,6 +1353,10 @@ td a:hover {
 
 .table-skeleton-line.title {
   width: min(420px, 72%);
+}
+
+.table-skeleton-line.project {
+  width: min(180px, 72%);
 }
 
 .table-skeleton-line.model {
@@ -4662,6 +4646,10 @@ pre {
   }
 
   .stat-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .tool-stat-grid {
     grid-template-columns: 1fr;
   }
 

--- a/src/ui/tool-call-status.ts
+++ b/src/ui/tool-call-status.ts
@@ -1,0 +1,21 @@
+export type ToolCallStatus = {
+  icon: "check" | "minus" | "x";
+  label: "Error" | "OK" | "Unknown";
+  title: string | null;
+  tone: "danger" | "neutral" | "success";
+};
+
+export function toolCallStatus(isError: boolean | null): ToolCallStatus {
+  if (isError === true) {
+    return { icon: "x", label: "Error", title: null, tone: "danger" };
+  }
+  if (isError === false) {
+    return { icon: "check", label: "OK", title: null, tone: "success" };
+  }
+  return {
+    icon: "minus",
+    label: "Unknown",
+    title: "The archive can't determine whether this call failed.",
+    tone: "neutral",
+  };
+}

--- a/src/ui/tool-table-layout.ts
+++ b/src/ui/tool-table-layout.ts
@@ -1,0 +1,76 @@
+export type ToolTableKind = "calls" | "mcp" | "tools";
+
+export type ToolTableColumn = {
+  className: string;
+  width: number;
+};
+
+const TABLE_COLUMNS: Record<
+  ToolTableKind,
+  { withDuration: readonly ToolTableColumn[]; withoutDuration: readonly ToolTableColumn[] }
+> = {
+  mcp: {
+    withoutDuration: [
+      { className: "col-mcp-server", width: 52 },
+      { className: "col-mcp-tools", width: 12 },
+      { className: "col-mcp-calls", width: 12 },
+      { className: "col-mcp-errors", width: 12 },
+      { className: "col-mcp-last", width: 12 },
+    ],
+    withDuration: [
+      { className: "col-mcp-server", width: 40 },
+      { className: "col-mcp-tools", width: 10 },
+      { className: "col-mcp-calls", width: 10 },
+      { className: "col-mcp-errors", width: 10 },
+      { className: "col-mcp-elapsed", width: 15 },
+      { className: "col-mcp-last", width: 15 },
+    ],
+  },
+  tools: {
+    withoutDuration: [
+      { className: "col-tool-name", width: 28 },
+      { className: "col-tool-kind", width: 11 },
+      { className: "col-tool-server", width: 25 },
+      { className: "col-tool-calls", width: 12 },
+      { className: "col-tool-errors", width: 12 },
+      { className: "col-tool-last", width: 12 },
+    ],
+    withDuration: [
+      { className: "col-tool-name", width: 24 },
+      { className: "col-tool-kind", width: 10 },
+      { className: "col-tool-server", width: 22 },
+      { className: "col-tool-calls", width: 9 },
+      { className: "col-tool-errors", width: 9 },
+      { className: "col-tool-elapsed", width: 13 },
+      { className: "col-tool-last", width: 13 },
+    ],
+  },
+  calls: {
+    withoutDuration: [
+      { className: "col-call-status", width: 11 },
+      { className: "col-call-tool", width: 22 },
+      { className: "col-call-input", width: 28 },
+      { className: "col-call-output", width: 11 },
+      { className: "col-call-when", width: 12 },
+      { className: "col-call-session", width: 16 },
+    ],
+    withDuration: [
+      { className: "col-call-status", width: 12 },
+      { className: "col-call-tool", width: 20 },
+      { className: "col-call-input", width: 22 },
+      { className: "col-call-elapsed", width: 10 },
+      { className: "col-call-output", width: 10 },
+      { className: "col-call-when", width: 11 },
+      { className: "col-call-session", width: 15 },
+    ],
+  },
+};
+
+export function toolTableColumns(
+  table: ToolTableKind,
+  durationAvailable: boolean,
+): readonly ToolTableColumn[] {
+  return durationAvailable
+    ? TABLE_COLUMNS[table].withDuration
+    : TABLE_COLUMNS[table].withoutDuration;
+}

--- a/src/ui/tool-table-layout.ts
+++ b/src/ui/tool-table-layout.ts
@@ -47,9 +47,9 @@ const TABLE_COLUMNS: Record<
   },
   calls: {
     withoutDuration: [
-      { className: "col-call-status", width: 11 },
+      { className: "col-call-status", width: 12 },
       { className: "col-call-tool", width: 22 },
-      { className: "col-call-input", width: 28 },
+      { className: "col-call-input", width: 27 },
       { className: "col-call-output", width: 11 },
       { className: "col-call-when", width: 12 },
       { className: "col-call-session", width: 16 },

--- a/test/ui-date-time.test.ts
+++ b/test/ui-date-time.test.ts
@@ -80,3 +80,53 @@ describe("sessionListDate", () => {
     expect(sessionListDate("not-a-date", UTC_OPTIONS)).toBeNull();
   });
 });
+
+describe("formatter reuse", () => {
+  test("reuses date-time and relative-time formatters for identical options", () => {
+    const OriginalDateTimeFormat = Intl.DateTimeFormat;
+    const OriginalRelativeTimeFormat = Intl.RelativeTimeFormat;
+    let dateTimeConstructions = 0;
+    let relativeTimeConstructions = 0;
+    Object.defineProperty(Intl, "DateTimeFormat", {
+      configurable: true,
+      value: new Proxy(OriginalDateTimeFormat, {
+        construct(target, args, newTarget) {
+          dateTimeConstructions += 1;
+          return Reflect.construct(target, args, newTarget);
+        },
+      }),
+    });
+    Object.defineProperty(Intl, "RelativeTimeFormat", {
+      configurable: true,
+      value: new Proxy(OriginalRelativeTimeFormat, {
+        construct(target, args, newTarget) {
+          relativeTimeConstructions += 1;
+          return Reflect.construct(target, args, newTarget);
+        },
+      }),
+    });
+
+    const options = {
+      locale: "en-US-u-ca-gregory",
+      now: new Date("2026-07-18T12:00:00Z"),
+      timeZone: "UTC",
+    };
+    try {
+      expect(sessionListDate("2026-01-17T23:28:00Z", options)).toBe("Jan 17, 11:28 PM");
+      expect(sessionListDate("2026-01-17T23:28:00Z", options)).toBe("Jan 17, 11:28 PM");
+      expect(relativeTime("2026-07-18T10:00:00Z", options)).toBe("2 hours ago");
+      expect(relativeTime("2026-07-18T10:00:00Z", options)).toBe("2 hours ago");
+      expect(dateTimeConstructions).toBe(2);
+      expect(relativeTimeConstructions).toBe(1);
+    } finally {
+      Object.defineProperty(Intl, "DateTimeFormat", {
+        configurable: true,
+        value: OriginalDateTimeFormat,
+      });
+      Object.defineProperty(Intl, "RelativeTimeFormat", {
+        configurable: true,
+        value: OriginalRelativeTimeFormat,
+      });
+    }
+  });
+});

--- a/test/ui-date-time.test.ts
+++ b/test/ui-date-time.test.ts
@@ -55,8 +55,10 @@ describe("relativeTime", () => {
 describe("sessionListDate", () => {
   test("uses compact relative copy strictly within seven days", () => {
     expect(sessionListDate("2026-07-18T10:00:00Z", UTC_OPTIONS)).toBe("2h ago");
+    expect(sessionListDate("2026-07-17T12:20:00Z", UTC_OPTIONS)).toBe("1d ago");
     expect(sessionListDate("2026-07-15T12:00:00Z", UTC_OPTIONS)).toBe("3d ago");
     expect(sessionListDate("2026-07-18T14:00:00Z", UTC_OPTIONS)).toBe("in 2h");
+    expect(sessionListDate("2026-07-19T11:40:00Z", UTC_OPTIONS)).toBe("in 1d");
     expect(sessionListDate("2026-07-11T12:00:01Z", UTC_OPTIONS)).toBe("7d ago");
     expect(sessionListDate("2026-07-11T12:00:00Z", UTC_OPTIONS)).toBe("Jul 11, 12:00 PM");
   });

--- a/test/ui-date-time.test.ts
+++ b/test/ui-date-time.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { compactDateTime, fullDateTime } from "../src/ui/date-time.ts";
+import {
+  compactDateTime,
+  fullDateTime,
+  relativeTime,
+  sessionListDate,
+} from "../src/ui/date-time.ts";
 
 const UTC_OPTIONS = {
   locale: "en-US",
@@ -31,5 +36,47 @@ describe("fullDateTime", () => {
     expect(formatted).toContain("Jul 17, 2026");
     expect(formatted).toContain("11:28:00 PM");
     expect(formatted).toEndWith("UTC");
+  });
+});
+
+describe("relativeTime", () => {
+  test("preserves the existing long-form relative copy", () => {
+    expect(relativeTime("2026-07-18T10:00:00Z", UTC_OPTIONS)).toBe("2 hours ago");
+    expect(relativeTime("2026-07-15T12:00:00Z", UTC_OPTIONS)).toBe("3 days ago");
+    expect(relativeTime("2026-07-18T14:00:00Z", UTC_OPTIONS)).toBe("in 2 hours");
+  });
+
+  test("preserves missing and invalid timestamp behavior", () => {
+    expect(relativeTime(null, UTC_OPTIONS)).toBe("-");
+    expect(relativeTime("not-a-date", UTC_OPTIONS)).toBe("not-a-date");
+  });
+});
+
+describe("sessionListDate", () => {
+  test("uses compact relative copy strictly within seven days", () => {
+    expect(sessionListDate("2026-07-18T10:00:00Z", UTC_OPTIONS)).toBe("2h ago");
+    expect(sessionListDate("2026-07-15T12:00:00Z", UTC_OPTIONS)).toBe("3d ago");
+    expect(sessionListDate("2026-07-18T14:00:00Z", UTC_OPTIONS)).toBe("in 2h");
+    expect(sessionListDate("2026-07-11T12:00:01Z", UTC_OPTIONS)).toBe("7d ago");
+    expect(sessionListDate("2026-07-11T12:00:00Z", UTC_OPTIONS)).toBe("Jul 11, 12:00 PM");
+  });
+
+  test("uses the selected timezone to choose current-year and older formats", () => {
+    expect(sessionListDate("2026-01-17T23:28:00Z", UTC_OPTIONS)).toBe("Jan 17, 11:28 PM");
+    const boundaryNow = new Date("2027-01-01T00:30:00Z");
+    const losAngeles = {
+      locale: "en-US",
+      now: boundaryNow,
+      timeZone: "America/Los_Angeles",
+    };
+    const utc = { locale: "en-US", now: boundaryNow, timeZone: "UTC" };
+    expect(sessionListDate("2026-07-17T23:28:00Z", losAngeles)).toBe("Jul 17, 4:28 PM");
+    expect(sessionListDate("2026-07-17T23:28:00Z", utc)).toBe("Jul 17, 2026");
+    expect(sessionListDate("2025-07-17T23:28:00Z", UTC_OPTIONS)).toBe("Jul 17, 2025");
+  });
+
+  test("returns null for missing or invalid timestamps", () => {
+    expect(sessionListDate(null, UTC_OPTIONS)).toBeNull();
+    expect(sessionListDate("not-a-date", UTC_OPTIONS)).toBeNull();
   });
 });

--- a/test/ui-interaction-contracts.test.ts
+++ b/test/ui-interaction-contracts.test.ts
@@ -47,6 +47,26 @@ describe("UI interaction contracts", () => {
     expect(tools).toContain("Inspect ${call.tool_name");
   });
 
+  test("closes report and share reviews only from direct backdrop presses", () => {
+    const reportReview = sourceBetween(
+      "function ExportReviewSheet(",
+      "function ReportExportButton(",
+    );
+    const shareReview = sourceBetween(
+      "function ShareChartButton(",
+      "async function renderShareCardPng(",
+    );
+
+    expect(reportReview).toContain('className="report-review-backdrop"');
+    expect(reportReview).toMatch(
+      /onMouseDown=\{\(event\) => \{\s*if \(event\.target === event\.currentTarget\) \{\s*onClose\(\);/,
+    );
+    expect(shareReview).toContain('className="share-review-backdrop"');
+    expect(shareReview).toMatch(
+      /onMouseDown=\{\(event\) => \{\s*if \(event\.target === event\.currentTarget\) \{\s*closeShareReview\(\);/,
+    );
+  });
+
   test("keeps compaction anchors exposed in the accessibility tree", () => {
     const chart = sourceBetween("function ContextWindowStrip(", "function compactionTokenRange(");
 

--- a/test/ui-loading-state.test.ts
+++ b/test/ui-loading-state.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { planSessionLoad, shouldShowSessionSkeleton } from "../src/ui/loading-state.ts";
+
+const main = readFileSync(join(import.meta.dir, "..", "src", "ui", "main.tsx"), "utf8");
 
 describe("session loading state", () => {
   test("refreshes the first page without depending on currently rendered rows", () => {
@@ -44,5 +48,37 @@ describe("session loading state", () => {
       false,
     );
     expect(shouldShowSessionSkeleton({ isLoading: true, loadedRows: 0, query: "" })).toBe(true);
+  });
+});
+
+describe("session table skeleton", () => {
+  test("keeps one placeholder aligned with each of the eleven session columns", () => {
+    const start = main.indexOf("function SessionTableSkeletonRows()");
+    const end = main.indexOf("function ProjectsView(", start);
+    const skeleton = main.slice(start, end);
+    expect(skeleton.match(/<td(?:\s|>)/g)).toHaveLength(11);
+    expect([...skeleton.matchAll(/table-skeleton-line ([^"]+)/g)].map((match) => match[1])).toEqual(
+      [
+        "tool",
+        "title",
+        "project",
+        "model",
+        "effort",
+        "number",
+        "number",
+        "number",
+        "number",
+        "cost",
+        "started",
+      ],
+    );
+  });
+
+  test("keeps the Started cell as a precise semantic time element", () => {
+    const start = main.indexOf("function SessionStartedAt(");
+    const end = main.indexOf("function SessionContextPeak(", start);
+    const startedCell = main.slice(start, end);
+    expect(startedCell).toContain("const display = sessionListDate(value)");
+    expect(startedCell).toContain("<time dateTime={value} title={fullDateTime(value) ?? display}>");
   });
 });

--- a/test/ui-tool-call-status.test.ts
+++ b/test/ui-tool-call-status.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { toolCallStatus } from "../src/ui/tool-call-status.ts";
+
+describe("tool call status", () => {
+  test("distinguishes confirmed success and error with icon and tone metadata", () => {
+    expect(toolCallStatus(false)).toEqual({
+      icon: "check",
+      label: "OK",
+      title: null,
+      tone: "success",
+    });
+    expect(toolCallStatus(true)).toEqual({
+      icon: "x",
+      label: "Error",
+      title: null,
+      tone: "danger",
+    });
+  });
+
+  test("keeps every indeterminate archive result explicitly unknown", () => {
+    expect(toolCallStatus(null)).toEqual({
+      icon: "minus",
+      label: "Unknown",
+      title: "The archive can't determine whether this call failed.",
+      tone: "neutral",
+    });
+  });
+});

--- a/test/ui-tool-table-layout.test.ts
+++ b/test/ui-tool-table-layout.test.ts
@@ -68,9 +68,11 @@ describe("tool table column layouts", () => {
   }
 
   test("reserves enough minimum-width space for the full Unknown status badge", () => {
-    const status = toolTableColumns("calls", true).find(
-      (column) => column.className === "col-call-status",
-    );
-    expect(status?.width).toBeGreaterThanOrEqual(12);
+    for (const durationAvailable of [false, true]) {
+      const status = toolTableColumns("calls", durationAvailable).find(
+        (column) => column.className === "col-call-status",
+      );
+      expect(status?.width).toBeGreaterThanOrEqual(12);
+    }
   });
 });

--- a/test/ui-tool-table-layout.test.ts
+++ b/test/ui-tool-table-layout.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { type ToolTableKind, toolTableColumns } from "../src/ui/tool-table-layout.ts";
+
+const expectedColumns: Record<ToolTableKind, { absent: string[]; present: string[] }> = {
+  mcp: {
+    absent: ["col-mcp-server", "col-mcp-tools", "col-mcp-calls", "col-mcp-errors", "col-mcp-last"],
+    present: [
+      "col-mcp-server",
+      "col-mcp-tools",
+      "col-mcp-calls",
+      "col-mcp-errors",
+      "col-mcp-elapsed",
+      "col-mcp-last",
+    ],
+  },
+  tools: {
+    absent: [
+      "col-tool-name",
+      "col-tool-kind",
+      "col-tool-server",
+      "col-tool-calls",
+      "col-tool-errors",
+      "col-tool-last",
+    ],
+    present: [
+      "col-tool-name",
+      "col-tool-kind",
+      "col-tool-server",
+      "col-tool-calls",
+      "col-tool-errors",
+      "col-tool-elapsed",
+      "col-tool-last",
+    ],
+  },
+  calls: {
+    absent: [
+      "col-call-status",
+      "col-call-tool",
+      "col-call-input",
+      "col-call-output",
+      "col-call-when",
+      "col-call-session",
+    ],
+    present: [
+      "col-call-status",
+      "col-call-tool",
+      "col-call-input",
+      "col-call-elapsed",
+      "col-call-output",
+      "col-call-when",
+      "col-call-session",
+    ],
+  },
+};
+
+describe("tool table column layouts", () => {
+  for (const table of ["mcp", "tools", "calls"] as const) {
+    test(`${table} keeps exact column order and normalized widths`, () => {
+      for (const durationAvailable of [false, true]) {
+        const columns = toolTableColumns(table, durationAvailable);
+        expect(columns.map((column) => column.className)).toEqual(
+          durationAvailable ? expectedColumns[table].present : expectedColumns[table].absent,
+        );
+        expect(columns.reduce((total, column) => total + column.width, 0)).toBe(100);
+        expect(columns.every((column) => column.width > 0)).toBe(true);
+      }
+    });
+  }
+
+  test("reserves enough minimum-width space for the full Unknown status badge", () => {
+    const status = toolTableColumns("calls", true).find(
+      (column) => column.className === "col-call-status",
+    );
+    expect(status?.width).toBeGreaterThanOrEqual(12);
+  });
+});

--- a/test/ui-tools-presentation.test.ts
+++ b/test/ui-tools-presentation.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const main = readFileSync(join(import.meta.dir, "..", "src", "ui", "main.tsx"), "utf8");
+const styles = readFileSync(join(import.meta.dir, "..", "src", "ui", "styles.css"), "utf8");
+
+function sourceBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(endIndex).toBeGreaterThan(startIndex);
+  return source.slice(startIndex, endIndex);
+}
+
+describe("Tools and MCP presentation", () => {
+  test("renders accessible icon-and-text statuses in the table and detail dialog", () => {
+    const status = sourceBetween(main, "function ToolCallStatus(", "function DrilldownTableRow(");
+    const detail = sourceBetween(main, "function ToolCallDetail(", "function ToolsView(");
+    const tools = sourceBetween(main, "function ToolsView(", "function FilesView(");
+
+    expect(status).toContain("toolCallStatus(call.is_error)");
+    expect(status).not.toContain("call.has_result");
+    expect(status).toContain("<Badge");
+    expect(status).toContain("<Icon name={status.icon} />");
+    expect(status).toContain("{status.label}");
+    expect(status).toContain("title={status.title ?? undefined}");
+    expect(detail).toContain("<ToolCallStatus call={call} />");
+    expect(tools).toContain("<ToolCallStatus call={call} />");
+  });
+
+  test("uses normalized table colgroups and ellipsizes long tool and server names", () => {
+    const tools = sourceBetween(main, "function ToolsView(", "function FilesView(");
+
+    expect(tools).toContain('toolTableColumns("mcp", durationAvailable)');
+    expect(tools).toContain('toolTableColumns("tools", durationAvailable)');
+    expect(tools).toContain('toolTableColumns("calls", durationAvailable)');
+    expect(tools.match(/<colgroup>/g)).toHaveLength(3);
+    expect(tools.match(/style=\{\{ width: `\$\{column\.width\}%` \}\}/g)).toHaveLength(3);
+    expect(tools).toMatch(
+      /className=\{`data-table tool-calls-table\$\{durationAvailable \? " has-duration" : ""\}`\}/,
+    );
+    expect(tools).toMatch(
+      /<span className="icon-cell">\s*<Icon name="cpu" \/>\s*<span>\{row\.mcp_server\}<\/span>/,
+    );
+    expect(styles).toMatch(
+      /\.tool-call-detail-button \{[\s\S]*?max-width: 100%;[\s\S]*?text-overflow: ellipsis;/,
+    );
+  });
+
+  test("lays out summary cards as two by two and collapses only at phone width", () => {
+    expect(styles).toMatch(
+      /\.tool-stat-grid \{[\s\S]*?grid-template-columns: repeat\(2, minmax\(0, 1fr\)\);/,
+    );
+    const phone = sourceBetween(
+      styles,
+      "@media (max-width: 640px)",
+      "@media (prefers-reduced-motion: reduce)",
+    );
+    expect(phone).toMatch(/\.tool-stat-grid \{[\s\S]*?grid-template-columns: 1fr;/);
+  });
+});

--- a/test/ui-tools-presentation.test.ts
+++ b/test/ui-tools-presentation.test.ts
@@ -24,7 +24,10 @@ describe("Tools and MCP presentation", () => {
     expect(status).toContain("<Badge");
     expect(status).toContain("<Icon name={status.icon} />");
     expect(status).toContain("{status.label}");
-    expect(status).toContain("title={status.title ?? undefined}");
+    expect(status).toContain("<Tooltip content={status.title}>");
+    expect(status).toContain("{(tooltipProps) =>");
+    expect(status).toContain('<span className="sr-only">{status.title}</span>');
+    expect(status).not.toContain("title={status.title ?? undefined}");
     expect(detail).toContain("<ToolCallStatus call={call} />");
     expect(tools).toContain("<ToolCallStatus call={call} />");
   });
@@ -37,9 +40,10 @@ describe("Tools and MCP presentation", () => {
     expect(tools).toContain('toolTableColumns("calls", durationAvailable)');
     expect(tools.match(/<colgroup>/g)).toHaveLength(3);
     expect(tools.match(/style=\{\{ width: `\$\{column\.width\}%` \}\}/g)).toHaveLength(3);
-    expect(tools).toMatch(
-      /className=\{`data-table tool-calls-table\$\{durationAvailable \? " has-duration" : ""\}`\}/,
-    );
+    expect(tools).toContain('<table className="data-table mcp-table">');
+    expect(tools).toContain('<table className="data-table tools-table">');
+    expect(tools).toContain('<table className="data-table tool-calls-table">');
+    expect(tools).not.toContain("has-duration");
     expect(tools).toMatch(
       /<span className="icon-cell">\s*<Icon name="cpu" \/>\s*<span>\{row\.mcp_server\}<\/span>/,
     );


### PR DESCRIPTION
## Summary

- Polish Tools & MCP with a responsive 2×2 summary, deterministic table column budgets, contained long-name overflow, and explicit Error / OK / Unknown status badges in both the table and detail drawer.
- Add compact session-list timestamps and guard report/share backdrops so only direct backdrop clicks dismiss their dialogs.

`is_error = null` intentionally maps to Unknown. The archive does not expose an independent pending state, so presenting Pending would invent information.

## Why

The Tools page could widen unpredictably around long MCP names, tool outcomes were ambiguous, session rows lost useful date context, and clicks inside report/share dialogs could bubble into their dismissal backdrops.

## Validation

- [x] `just check` passes: 658 tests, TypeScript, Biome, and the darwin-arm64 distribution staging smoke.
- [x] New behavior has focused tests. No existing test was weakened or deleted to make this pass.
- [x] Adversarial PR-style review is clean after increasing the status-column budget to preserve the full Unknown label.
- [x] Synthetic-archive browser validation at 1440px light and 1024px/680px dark: long names truncate, table overflow remains contained, the 2×2 summary holds at 680px, all status labels remain readable, and the console reports zero errors.
- [x] Browser behavior validation: the Unknown detail drawer renders the same status; inner report-sheet clicks keep it open; a direct backdrop click dismisses it.

## Archive schema

The baseline is `LATEST_SCHEMA_VERSION` in `src/db.ts`. Check one:

- [x] This change does not touch the archive schema.
- [ ] This change bumps the schema. It ships the migration, and the summary above says what happens to archives created before it.
