### PR TITLE
feat: add command palette and fuzzy search

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@dosu/decant",
       "dependencies": {
+        "@leeoniya/ufuzzy": "^1.0.19",
         "@logtape/logtape": "^2.2.4",
         "@shikijs/langs": "^4.3.1",
         "@shikijs/themes": "^4.3.1",
@@ -48,6 +49,8 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A=="],
+
+    "@leeoniya/ufuzzy": ["@leeoniya/ufuzzy@1.0.19", "", {}, "sha512-0pikDeYt0IHEUPza5RTCDXc/17S1pTrYnReEMp8Aa6k1ovzw5QdZLwicW8TjljwEZRb6oYag0xmALohrcq/yOQ=="],
 
     "@letta-ai/trajectory": ["@letta-ai/trajectory@0.2.0", "", {}, "sha512-biCyT0z8nh4Q8kIqBrPgmzoalacPmosmCpvEjdN9ILpL85+T75b8ahcN9MHPHQUVRj/J7UyQuRahJ4/JdrpCcA=="],
 

--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -59,6 +59,8 @@ listed below; the session preview intentionally omits transcript content.
 - `GET /api/metadata/sync-status`
 - `POST /api/sync` (works even under `--no-sync`, which only stops the watcher)
 - `GET /api/sessions?from=YYYY-MM-DD&to=YYYY-MM-DD`
+- `GET /api/sessions/search-index` — lightweight, top-level, visible,
+  non-archived session metadata for the local command palette
 - `GET /api/sessions/:id`
 - `GET /api/sessions/:id/outline`
 - `GET /api/sessions/:id/issues` — ingest diagnostics recorded for the session's

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "typescript": "^7.0.2"
   },
   "dependencies": {
+    "@leeoniya/ufuzzy": "^1.0.19",
     "@logtape/logtape": "^2.2.4",
     "@shikijs/langs": "^4.3.1",
     "@shikijs/themes": "^4.3.1",

--- a/src/query.ts
+++ b/src/query.ts
@@ -191,6 +191,7 @@ export function sessionSearchIndex(db: Database): SessionSearchIndexRow[] {
        FROM session s
        LEFT JOIN project p ON p.id = s.project_id
        WHERE ${visibleSessionPredicate("s")}
+         AND s.is_subagent = 0
          AND ${sessionUserStatePredicate("s")}
        ORDER BY s.started_at DESC, s.id DESC`,
     )

--- a/src/query.ts
+++ b/src/query.ts
@@ -192,7 +192,7 @@ export function sessionSearchIndex(db: Database): SessionSearchIndexRow[] {
        LEFT JOIN project p ON p.id = s.project_id
        WHERE ${visibleSessionPredicate("s")}
          AND s.is_subagent = 0
-         AND ${sessionUserStatePredicate("s")}
+         AND ${sessionUserStatePredicateForDatabase(db, "s")}
        ORDER BY s.started_at DESC, s.id DESC`,
     )
     .all() as SessionSearchIndexRow[];

--- a/src/query.ts
+++ b/src/query.ts
@@ -78,6 +78,15 @@ export interface ListFilter {
   to?: string | null;
 }
 
+export interface SessionSearchIndexRow {
+  id: number;
+  title: string | null;
+  project: string | null;
+  tool: string;
+  model: string | null;
+  started_at: string | null;
+}
+
 interface SessionSummaryRow
   extends Omit<
     SessionSummary,
@@ -171,6 +180,23 @@ export function listSessions(db: Database, filter: ListFilter = {}): SessionSumm
   return withDosuMcpEvidence(db, nested, includeArchived);
 }
 
+/**
+ * Return the complete client-side fuzzy-search haystack without loading
+ * messages, tool calls, title fallbacks, or session rollups.
+ */
+export function sessionSearchIndex(db: Database): SessionSearchIndexRow[] {
+  return db
+    .query(
+      `SELECT s.id, s.title, p.path AS project, s.tool, s.model, s.started_at
+       FROM session s
+       LEFT JOIN project p ON p.id = s.project_id
+       WHERE ${visibleSessionPredicate("s")}
+         AND ${sessionUserStatePredicate("s")}
+       ORDER BY s.started_at DESC, s.id DESC`,
+    )
+    .all() as SessionSearchIndexRow[];
+}
+
 export interface SearchHit {
   session_id: number;
   session_title: string | null;
@@ -195,7 +221,7 @@ export function search(db: Database, query: string, limitValue = 30): SearchHit[
       offset: results.length,
     });
     results.push(...page.results);
-    if (page.results.length === 0 || results.length >= page.total) {
+    if (page.results.length === 0 || (page.total != null && results.length >= page.total)) {
       break;
     }
   }
@@ -209,6 +235,7 @@ export interface SearchFilter {
   tool?: string | null;
   project?: string | null;
   includeSubagents?: boolean;
+  includeTotal?: boolean;
   limit?: number | null;
   offset?: number | null;
   from?: string | null;
@@ -217,7 +244,7 @@ export interface SearchFilter {
 
 export interface SearchPage {
   results: SearchHit[];
-  total: number;
+  total: number | null;
   total_is_capped: boolean;
   elapsed_ms: number;
 }
@@ -265,13 +292,17 @@ export function searchPage(db: Database, query: string, filter: SearchFilter = {
     JOIN session s ON s.id = b.session_id
     LEFT JOIN project p ON p.id = s.project_id`;
   const where = `WHERE ${clauses.join(" AND ")}`;
-  const cappedCount = (
-    db
-      .query(`SELECT COUNT(*) AS count FROM (SELECT 1 ${joins} ${where} LIMIT 1001)`)
-      .get(...params) as { count: number }
-  ).count;
-  const totalIsCapped = cappedCount > 1000;
-  const total = Math.min(cappedCount, 1000);
+  let total: number | null = null;
+  let totalIsCapped = false;
+  if (filter.includeTotal !== false) {
+    const cappedCount = (
+      db
+        .query(`SELECT COUNT(*) AS count FROM (SELECT 1 ${joins} ${where} LIMIT 1001)`)
+        .get(...params) as { count: number }
+    ).count;
+    totalIsCapped = cappedCount > 1000;
+    total = Math.min(cappedCount, 1000);
+  }
   const rows = db
     .query(
       `SELECT b.session_id, s.title AS session_title, s.tool, b.id AS block_id,

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import {
   listToolCalls,
   searchPage,
   sessionIngestIssues,
+  sessionSearchIndex,
 } from "./query.ts";
 import {
   list as listRecommendations,
@@ -328,6 +329,9 @@ export async function handleRequest(
         ),
       );
     }
+    if (request.method === "GET" && url.pathname === "/api/sessions/search-index") {
+      return withDb(config, context, (db) => json(sessionSearchIndex(db)));
+    }
     if (request.method === "GET" && url.pathname === "/api/projects") {
       return withDb(config, context, (db) => json(listProjects(db)));
     }
@@ -431,30 +435,59 @@ export async function handleRequest(
       if (contentTypeFailure != null) {
         return contentTypeFailure;
       }
-      const body = await readJson<{
-        query?: string;
-        tool?: string | null;
-        project?: string | null;
-        include_subagents?: boolean;
-        from?: string | null;
-        to?: string | null;
-        limit?: number;
-        offset?: number;
-      }>(request);
+      const rawBody = await readJson<unknown>(request);
+      if (rawBody == null || typeof rawBody !== "object" || Array.isArray(rawBody)) {
+        return errorResponse("invalid_request", "request body must be a JSON object", {}, 400);
+      }
+      const body = rawBody as Record<string, unknown>;
       if (typeof body.query !== "string" || body.query.trim() === "") {
         return errorResponse("query_required", "query is required", {}, 400);
       }
+      for (const field of ["tool", "project", "from", "to"] as const) {
+        const value = body[field];
+        if (value !== undefined && value !== null && typeof value !== "string") {
+          return errorResponse("invalid_request", `${field} must be a string or null`, {}, 400);
+        }
+      }
+      for (const field of ["include_subagents", "include_total"] as const) {
+        if (field in body && typeof body[field] !== "boolean") {
+          return errorResponse("invalid_request", `${field} must be a boolean`, {}, 400);
+        }
+      }
+      if (
+        body.limit !== undefined &&
+        (!Number.isSafeInteger(body.limit) ||
+          (body.limit as number) < 1 ||
+          (body.limit as number) > 100)
+      ) {
+        return errorResponse("invalid_request", "limit must be an integer from 1 to 100", {}, 400);
+      }
+      if (
+        body.offset !== undefined &&
+        (!Number.isSafeInteger(body.offset) || (body.offset as number) < 0)
+      ) {
+        return errorResponse("invalid_request", "offset must be a non-negative integer", {}, 400);
+      }
       const query = body.query;
+      const tool = body.tool as string | null | undefined;
+      const project = body.project as string | null | undefined;
+      const includeSubagents = body.include_subagents as boolean | undefined;
+      const includeTotal = body.include_total as boolean | undefined;
+      const from = body.from as string | null | undefined;
+      const to = body.to as string | null | undefined;
+      const limit = body.limit as number | undefined;
+      const offset = body.offset as number | undefined;
       return withDb(config, context, (db) => {
         return json(
           searchPage(db, query, {
-            tool: body.tool,
-            project: body.project,
-            includeSubagents: body.include_subagents === true,
-            from: body.from,
-            to: body.to,
-            limit: body.limit,
-            offset: body.offset,
+            tool,
+            project,
+            includeSubagents: includeSubagents === true,
+            includeTotal: includeTotal !== false,
+            from,
+            to,
+            limit,
+            offset,
           }),
         );
       });

--- a/src/ui/command-palette.ts
+++ b/src/ui/command-palette.ts
@@ -1,0 +1,182 @@
+export interface CommandPaletteItem {
+  id: string;
+  label: string;
+}
+
+export interface CommandPaletteShortcutInput {
+  altKey: boolean;
+  ctrlKey: boolean;
+  interactiveTarget: boolean;
+  key: string;
+  metaKey: boolean;
+  modalOpen: boolean;
+  shiftKey: boolean;
+}
+
+export function shouldOpenCommandPalette(input: CommandPaletteShortcutInput): boolean {
+  if (input.modalOpen || input.altKey || input.shiftKey) {
+    return false;
+  }
+  const commandK = input.key.toLocaleLowerCase() === "k" && input.metaKey !== input.ctrlKey;
+  if (commandK) {
+    return true;
+  }
+  return input.key === "/" && !input.metaKey && !input.ctrlKey && !input.interactiveTarget;
+}
+
+export function paletteShortcutLabel(userAgent: string): "⌘K" | "Ctrl K" {
+  return /Mac|iPhone|iPad/.test(userAgent) ? "⌘K" : "Ctrl K";
+}
+
+export function normalizeRecentSearches(value: unknown, next?: string): string[] {
+  const raw = [...(next == null ? [] : [next]), ...(Array.isArray(value) ? value : [])];
+  const seen = new Set<string>();
+  const searches: string[] = [];
+  for (const candidate of raw) {
+    if (typeof candidate !== "string") {
+      continue;
+    }
+    const normalized = candidate.trim().slice(0, 160);
+    if (normalized === "" || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    searches.push(normalized);
+    if (searches.length === 8) {
+      break;
+    }
+  }
+  return searches;
+}
+
+export type CommandPaletteGroupId = "recent" | "sessions" | "pages" | "actions" | "content-search";
+
+export interface CommandPaletteGroup<TItem extends CommandPaletteItem = CommandPaletteItem> {
+  id: CommandPaletteGroupId;
+  label: string | null;
+  items: readonly TItem[];
+}
+
+export interface CommandPaletteGroupInput<TItem extends CommandPaletteItem = CommandPaletteItem> {
+  query: string;
+  recent: readonly TItem[];
+  sessions: readonly TItem[];
+  pages: readonly TItem[];
+  actions: readonly TItem[];
+  contentSearch: TItem | null;
+}
+
+/**
+ * Assemble groups in their rendered navigation order. Callers may compute each
+ * group's items independently; this function owns empty-group removal and the
+ * rule that recent searches appear only before the user starts typing.
+ */
+export function buildCommandPaletteGroups<TItem extends CommandPaletteItem>(
+  input: CommandPaletteGroupInput<TItem>,
+): CommandPaletteGroup<TItem>[] {
+  const groups: CommandPaletteGroup<TItem>[] = [];
+  if (input.query.trim() === "") {
+    appendGroup(groups, "recent", "Recent searches", input.recent);
+  }
+  appendGroup(groups, "sessions", "Sessions", input.sessions);
+  appendGroup(groups, "pages", "Pages", input.pages);
+  appendGroup(groups, "actions", "Actions", input.actions);
+  appendGroup(
+    groups,
+    "content-search",
+    null,
+    input.contentSearch == null ? [] : [input.contentSearch],
+  );
+  return groups;
+}
+
+export function flattenCommandPaletteItems<TItem extends CommandPaletteItem>(
+  groups: readonly CommandPaletteGroup<TItem>[],
+): TItem[] {
+  return groups.flatMap((group) => group.items);
+}
+
+export interface CommandPaletteKeyState {
+  activeIndex: number | null;
+}
+
+export interface CommandPaletteKeyInput {
+  key: string;
+  itemCount: number;
+  isComposing?: boolean;
+}
+
+export type CommandPaletteKeyEffect = "none" | "activate" | "close";
+
+export interface CommandPaletteKeyResult extends CommandPaletteKeyState {
+  effect: CommandPaletteKeyEffect;
+  handled: boolean;
+}
+
+/**
+ * Keyboard state transition over the flattened rendered item list. Arrow keys
+ * wrap so moving between visual groups has the same behavior as moving within
+ * one group; Enter and Escape are returned as effects for the React layer.
+ */
+export function reduceCommandPaletteKey(
+  state: CommandPaletteKeyState,
+  input: CommandPaletteKeyInput,
+): CommandPaletteKeyResult {
+  const itemCount = normalizeItemCount(input.itemCount);
+  const activeIndex = normalizeActiveIndex(state.activeIndex, itemCount);
+  if (input.isComposing === true) {
+    return idle(activeIndex);
+  }
+
+  switch (input.key) {
+    case "ArrowDown":
+      if (itemCount === 0) {
+        return idle(null);
+      }
+      return moved(activeIndex == null ? 0 : (activeIndex + 1) % itemCount);
+    case "ArrowUp":
+      if (itemCount === 0) {
+        return idle(null);
+      }
+      return moved(activeIndex == null ? itemCount - 1 : (activeIndex - 1 + itemCount) % itemCount);
+    case "Home":
+      return itemCount === 0 ? idle(null) : moved(0);
+    case "End":
+      return itemCount === 0 ? idle(null) : moved(itemCount - 1);
+    case "Enter":
+      return activeIndex == null ? idle(null) : { activeIndex, effect: "activate", handled: true };
+    case "Escape":
+      return { activeIndex, effect: "close", handled: true };
+    default:
+      return idle(activeIndex);
+  }
+}
+
+function appendGroup<TItem extends CommandPaletteItem>(
+  groups: CommandPaletteGroup<TItem>[],
+  id: CommandPaletteGroupId,
+  label: string | null,
+  items: readonly TItem[],
+): void {
+  if (items.length > 0) {
+    groups.push({ id, label, items: [...items] });
+  }
+}
+
+function normalizeItemCount(value: number): number {
+  return Number.isSafeInteger(value) && value > 0 ? value : 0;
+}
+
+function normalizeActiveIndex(value: number | null, itemCount: number): number | null {
+  return value != null && Number.isSafeInteger(value) && value >= 0 && value < itemCount
+    ? value
+    : null;
+}
+
+function moved(activeIndex: number): CommandPaletteKeyResult {
+  return { activeIndex, effect: "none", handled: true };
+}
+
+function idle(activeIndex: number | null): CommandPaletteKeyResult {
+  return { activeIndex, effect: "none", handled: false };
+}

--- a/src/ui/command-palette.ts
+++ b/src/ui/command-palette.ts
@@ -96,6 +96,41 @@ export function flattenCommandPaletteItems<TItem extends CommandPaletteItem>(
   return groups.flatMap((group) => group.items);
 }
 
+/**
+ * Keep the user's current choice stable when an async session index changes the
+ * rendered order. This is especially important for transcript search: rows
+ * arriving after the user typed must not silently replace that action with the
+ * first session match.
+ */
+export function reconcileCommandPaletteActiveIndex(
+  activeItemId: string | null,
+  items: readonly CommandPaletteItem[],
+): number | null {
+  if (items.length === 0) {
+    return null;
+  }
+  if (activeItemId != null) {
+    const preservedIndex = items.findIndex((item) => item.id === activeItemId);
+    if (preservedIndex >= 0) {
+      return preservedIndex;
+    }
+  }
+  return 0;
+}
+
+export interface PointerMovement {
+  movementX: number;
+  movementY: number;
+}
+
+/**
+ * Programmatic scrollIntoView calls can move an option underneath a stationary
+ * pointer. Only real pointer movement may replace a keyboard selection.
+ */
+export function pointerMovementChangesSelection(event: PointerMovement): boolean {
+  return event.movementX !== 0 || event.movementY !== 0;
+}
+
 export interface CommandPaletteKeyState {
   activeIndex: number | null;
 }

--- a/src/ui/fuzzy.ts
+++ b/src/ui/fuzzy.ts
@@ -1,0 +1,454 @@
+import uFuzzy from "@leeoniya/ufuzzy";
+
+export interface SessionSearchIndexRow {
+  id: number;
+  title: string | null;
+  project: string | null;
+  tool: string;
+  model: string | null;
+  started_at: string | null;
+}
+
+export type SessionSearchField = "title" | "project" | "tool" | "model" | "started_at";
+
+/** UTF-16 string offsets, matching JavaScript slice() and React text children. */
+export type SessionHighlightRange = readonly [start: number, end: number];
+
+export type SessionHighlights = Partial<
+  Record<SessionSearchField, readonly SessionHighlightRange[]>
+>;
+
+export interface SessionFuzzyMatch {
+  id: number;
+  highlights: SessionHighlights;
+}
+
+interface SearchSegment {
+  field: SessionSearchField;
+  start: number;
+  end: number;
+  originalOffsets: readonly number[];
+}
+
+interface SearchDocument {
+  row: SessionSearchIndexRow;
+  text: string;
+  segments: readonly SearchSegment[];
+}
+
+const SEARCH_FIELDS = [
+  "title",
+  "project",
+  "tool",
+  "model",
+  "started_at",
+] as const satisfies readonly SessionSearchField[];
+
+export const SESSION_FUZZY_RANK_LIMIT = 1_000;
+const MIN_PERMUTATION_CANDIDATES = 32;
+const PERMUTATION_CANDIDATE_FACTOR = 4;
+
+const matcher = new uFuzzy({
+  unicode: true,
+  interSplit: "[^\\p{L}\\d']+",
+  intraSplit: "\\p{Ll}\\p{Lu}",
+  intraBound: "\\p{L}\\d|\\d\\p{L}|\\p{Ll}\\p{Lu}",
+  intraChars: "[\\p{L}\\d']",
+  intraContr: "'\\p{L}{1,2}\\b",
+  // A command palette should survive one internal typo without turning every
+  // query into a broad subsequence match.
+  intraMode: 1,
+  intraIns: 1,
+  intraSub: 1,
+  intraTrn: 1,
+  intraDel: 1,
+  // Preserve the endpoint's newest-first order when all match metrics tie.
+  compare: () => 0,
+});
+
+/**
+ * Reusable fuzzy index for the lightweight `/api/sessions/search-index` rows.
+ * Each query filters the stable haystack afresh because typo-tolerant matches
+ * are not monotonic as a needle grows.
+ */
+export class SessionSearchIndex {
+  readonly size: number;
+  readonly #documents: readonly SearchDocument[];
+  readonly #haystack: string[];
+  readonly #foldedHaystack: string[];
+
+  constructor(rows: readonly SessionSearchIndexRow[]) {
+    this.#documents = rows.map(searchDocument);
+    this.#haystack = this.#documents.map((document) => document.text);
+    this.#foldedHaystack = this.#haystack.map((value) => value.toLocaleLowerCase());
+    this.size = this.#documents.length;
+  }
+
+  search(query: string, limit?: number): SessionFuzzyMatch[] {
+    const needle = normalizeNeedle(query);
+    const resultLimit = normalizeLimit(limit, this.size);
+    if (needle === "") {
+      return [];
+    }
+    if (resultLimit === 0 || this.size === 0) {
+      return [];
+    }
+
+    const terms = matcher.split(needle);
+    const candidateLimit = Math.min(
+      SESSION_FUZZY_RANK_LIMIT,
+      Math.max(MIN_PERMUTATION_CANDIDATES, resultLimit * PERMUTATION_CANDIDATE_FACTOR),
+    );
+    const filtered = filterTerms(this.#haystack, terms);
+    if (filtered.length === 0) {
+      return [];
+    }
+    const rankedCandidates = relevanceShortlist(
+      this.#foldedHaystack,
+      filtered,
+      terms,
+      needle,
+      candidateLimit,
+    );
+    if (terms.length > 1) {
+      return multiTermMatches(
+        this.#documents,
+        this.#haystack,
+        rankedCandidates,
+        terms,
+        resultLimit,
+      );
+    }
+
+    const [, info, order] = matcher.search(
+      this.#haystack,
+      needle,
+      terms.length > 1 ? terms.length : 0,
+      SESSION_FUZZY_RANK_LIMIT,
+      rankedCandidates,
+    );
+    if (info == null || order == null) {
+      return [];
+    }
+
+    const matches: SessionFuzzyMatch[] = [];
+    for (const infoIndex of order) {
+      const documentIndex = info.idx[infoIndex];
+      const document = documentIndex == null ? null : this.#documents[documentIndex];
+      if (document == null) {
+        continue;
+      }
+      matches.push({
+        id: document.row.id,
+        highlights: projectHighlightRanges(document, info.ranges[infoIndex] ?? []),
+      });
+      if (matches.length === resultLimit) {
+        break;
+      }
+    }
+    return matches;
+  }
+}
+
+/**
+ * Intersect cheap single-term filters before any ranking work. The full
+ * candidate set is then ordered by a linear-time relevance approximation so
+ * exact, dense matches cannot disappear behind the browser-work cap.
+ */
+function filterTerms(haystack: string[], terms: readonly string[]): number[] {
+  let candidates: number[] | null = null;
+  for (const term of [...terms].sort((left, right) => right.length - left.length)) {
+    candidates = matcher.filter(haystack, term, candidates ?? undefined);
+    if (candidates == null || candidates.length === 0) {
+      return [];
+    }
+  }
+  return candidates ?? [];
+}
+
+function relevanceShortlist(
+  foldedHaystack: readonly string[],
+  candidates: readonly number[],
+  terms: readonly string[],
+  needle: string,
+  limit: number,
+): number[] {
+  const foldedNeedle = needle.toLocaleLowerCase();
+  const foldedTerms = terms.map((term) => term.toLocaleLowerCase());
+  return candidates
+    .map((index) => {
+      const value = foldedHaystack[index] ?? "";
+      const exactMatches = foldedTerms.map((term) => bestExactTermMatch(value, term));
+      const positions = exactMatches.map(({ position }) => position);
+      const exactTerms = exactMatches.reduce(
+        (count, { position }) => count + Number(position >= 0),
+        0,
+      );
+      const boundaryPoints = exactMatches.reduce(
+        (total, { boundaryPoints: points }) => total + points,
+        0,
+      );
+      const exactPositions = positions.filter((position) => position >= 0);
+      const span =
+        exactPositions.length === 0
+          ? Number.POSITIVE_INFINITY
+          : Math.max(
+              ...positions.map((position, termIndex) =>
+                position < 0 ? 0 : position + (foldedTerms[termIndex]?.length ?? 0),
+              ),
+            ) - Math.min(...exactPositions);
+      return {
+        index,
+        exactPhrase: Number(value.includes(foldedNeedle)),
+        exactTerms,
+        boundaryPoints,
+        span,
+        length: value.length,
+      };
+    })
+    .sort(
+      (left, right) =>
+        right.exactTerms - left.exactTerms ||
+        right.boundaryPoints - left.boundaryPoints ||
+        right.exactPhrase - left.exactPhrase ||
+        left.span - right.span ||
+        left.length - right.length ||
+        left.index - right.index,
+    )
+    .slice(0, limit)
+    .map(({ index }) => index);
+}
+
+function bestExactTermMatch(
+  value: string,
+  term: string,
+): { position: number; boundaryPoints: number } {
+  let bestPosition = -1;
+  let bestBoundaryPoints = -1;
+  let fromIndex = 0;
+  while (fromIndex <= value.length) {
+    const position = value.indexOf(term, fromIndex);
+    if (position < 0) {
+      break;
+    }
+    const end = position + term.length;
+    const boundaryPoints =
+      Number(position === 0 || !isSearchWordCharacterAt(value, position - 1)) +
+      Number(end === value.length || !isSearchWordCharacterAt(value, end));
+    if (boundaryPoints > bestBoundaryPoints) {
+      bestPosition = position;
+      bestBoundaryPoints = boundaryPoints;
+    }
+    fromIndex = position + Math.max(1, term.length);
+  }
+  return {
+    position: bestPosition,
+    boundaryPoints: Math.max(0, bestBoundaryPoints),
+  };
+}
+
+function isSearchWordCharacterAt(value: string, index: number): boolean {
+  const codeUnit = value.charCodeAt(index);
+  if (
+    (codeUnit >= 48 && codeUnit <= 57) ||
+    (codeUnit >= 65 && codeUnit <= 90) ||
+    (codeUnit >= 97 && codeUnit <= 122) ||
+    codeUnit === 39
+  ) {
+    return true;
+  }
+  if (codeUnit < 128) {
+    return false;
+  }
+  const character =
+    codeUnit >= 0xdc00 && codeUnit <= 0xdfff && index > 0
+      ? value.slice(index - 1, index + 1)
+      : codeUnit >= 0xd800 && codeUnit <= 0xdbff
+        ? value.slice(index, index + 2)
+        : (value[index] ?? "");
+  return /^[\p{L}\d']$/u.test(character);
+}
+
+/**
+ * Permutation ranking grows factorially and has a large cold-start cost even
+ * for three terms. Rank the global shortlist above, then ask uFuzzy for each
+ * term's typo-aware ranges.
+ */
+function multiTermMatches(
+  documents: readonly SearchDocument[],
+  haystack: string[],
+  candidates: readonly number[],
+  terms: readonly string[],
+  limit: number,
+): SessionFuzzyMatch[] {
+  const rangesByDocument = new Map<number, number[]>();
+  let eligible = new Set(candidates);
+  for (const term of terms) {
+    const info = matcher.info([...eligible], haystack, term);
+    eligible = new Set(info.idx);
+    for (let index = 0; index < info.idx.length; index += 1) {
+      const documentIndex = info.idx[index];
+      if (documentIndex == null) {
+        continue;
+      }
+      const ranges = rangesByDocument.get(documentIndex) ?? [];
+      rangesByDocument.set(documentIndex, ranges);
+      ranges.push(...(info.ranges[index] ?? []));
+    }
+    if (eligible.size === 0) {
+      return [];
+    }
+  }
+
+  return candidates
+    .filter((documentIndex) => eligible.has(documentIndex))
+    .slice(0, limit)
+    .flatMap((documentIndex) => {
+      const document = documents[documentIndex];
+      if (document == null) {
+        return [];
+      }
+      return [
+        {
+          id: document.row.id,
+          highlights: projectHighlightRanges(
+            document,
+            sortedFlatRanges(rangesByDocument.get(documentIndex) ?? []),
+          ),
+        },
+      ];
+    });
+}
+
+function sortedFlatRanges(flatRanges: readonly number[]): number[] {
+  const ranges: [number, number][] = [];
+  for (let index = 0; index + 1 < flatRanges.length; index += 2) {
+    const start = flatRanges[index];
+    const end = flatRanges[index + 1];
+    if (start != null && end != null) {
+      ranges.push([start, end]);
+    }
+  }
+  return ranges.sort((left, right) => left[0] - right[0] || left[1] - right[1]).flat();
+}
+
+export function createSessionSearchIndex(
+  rows: readonly SessionSearchIndexRow[],
+): SessionSearchIndex {
+  return new SessionSearchIndex(rows);
+}
+
+function searchDocument(row: SessionSearchIndexRow): SearchDocument {
+  let text = "";
+  const segments: SearchSegment[] = [];
+  for (const field of SEARCH_FIELDS) {
+    const rawValue = row[field];
+    const value = field === "started_at" && rawValue != null ? rawValue.slice(0, 10) : rawValue;
+    if (value == null || value === "") {
+      continue;
+    }
+    if (text !== "") {
+      text += " ";
+    }
+    const normalized = normalizedField(value);
+    const start = text.length;
+    text += normalized.text;
+    segments.push({
+      field,
+      start,
+      end: text.length,
+      originalOffsets: normalized.originalOffsets,
+    });
+  }
+  return { row, text, segments };
+}
+
+function normalizedField(value: string): { text: string; originalOffsets: readonly number[] } {
+  const text = value.normalize("NFC");
+  if (text === value) {
+    return {
+      text,
+      originalOffsets: Array.from({ length: text.length + 1 }, (_, index) => index),
+    };
+  }
+
+  const originalOffsets = Array<number>(text.length + 1).fill(0);
+  const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+  let normalizedOffset = 0;
+  for (const part of segmenter.segment(value)) {
+    const normalizedPart = part.segment.normalize("NFC");
+    const originalStart = part.index;
+    const originalEnd = originalStart + part.segment.length;
+    for (let offset = 0; offset <= normalizedPart.length; offset += 1) {
+      originalOffsets[normalizedOffset + offset] =
+        offset === normalizedPart.length
+          ? originalEnd
+          : originalStart +
+            Math.min(
+              part.segment.length,
+              Math.floor((offset * part.segment.length) / Math.max(1, normalizedPart.length)),
+            );
+    }
+    normalizedOffset += normalizedPart.length;
+  }
+  originalOffsets[text.length] = value.length;
+  return { text, originalOffsets };
+}
+
+function projectHighlightRanges(
+  document: SearchDocument,
+  flatRanges: readonly number[],
+): SessionHighlights {
+  const highlights: Partial<Record<SessionSearchField, SessionHighlightRange[]>> = {};
+  for (let index = 0; index + 1 < flatRanges.length; index += 2) {
+    const rawStart = flatRanges[index];
+    const rawEnd = flatRanges[index + 1];
+    if (rawStart == null || rawEnd == null) {
+      continue;
+    }
+    const start = Math.max(0, Math.min(document.text.length, Math.trunc(rawStart)));
+    const end = Math.max(start, Math.min(document.text.length, Math.trunc(rawEnd)));
+    if (start === end) {
+      continue;
+    }
+    for (const segment of document.segments) {
+      const intersectStart = Math.max(start, segment.start);
+      const intersectEnd = Math.min(end, segment.end);
+      if (intersectStart >= intersectEnd) {
+        continue;
+      }
+      const ranges = highlights[segment.field] ?? [];
+      highlights[segment.field] = ranges;
+      const localStart = intersectStart - segment.start;
+      const localEnd = intersectEnd - segment.start;
+      appendMergedRange(ranges, [
+        segment.originalOffsets[localStart] ?? localStart,
+        segment.originalOffsets[localEnd] ?? localEnd,
+      ]);
+    }
+  }
+  return highlights;
+}
+
+function appendMergedRange(ranges: SessionHighlightRange[], range: SessionHighlightRange): void {
+  const previous = ranges.at(-1);
+  if (previous == null || previous[1] < range[0]) {
+    ranges.push(range);
+    return;
+  }
+  ranges[ranges.length - 1] = [previous[0], Math.max(previous[1], range[1])];
+}
+
+function normalizeNeedle(query: string): string {
+  return query.normalize("NFC").trim().replaceAll(/\s+/g, " ");
+}
+
+function normalizeLimit(limit: number | undefined, size: number): number {
+  if (limit == null || limit === Number.POSITIVE_INFINITY) {
+    return size;
+  }
+  if (!Number.isFinite(limit) || limit <= 0) {
+    return 0;
+  }
+  return Math.min(size, Math.floor(limit));
+}

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -75,6 +75,8 @@ import {
   flattenCommandPaletteItems,
   normalizeRecentSearches,
   paletteShortcutLabel,
+  pointerMovementChangesSelection,
+  reconcileCommandPaletteActiveIndex,
   reduceCommandPaletteKey,
   shouldOpenCommandPalette,
 } from "./command-palette.ts";
@@ -118,6 +120,7 @@ import {
   sessionsArchivedHref,
   titleFor,
 } from "./navigation.ts";
+import { exactSearchRemaining, searchPageMayHaveMore } from "./search-pagination.ts";
 import { searchRequestScope, searchRouteHref } from "./search-request.ts";
 import { searchSnippetParts, visuallyOrderedSearchHits } from "./search-results.ts";
 import {
@@ -2332,6 +2335,7 @@ function CommandPalette({
   const [indexError, setIndexError] = useState<unknown>(null);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
+  const activeItemIdRef = useRef<string | null>(null);
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const closeRef = useRef(onClose);
   const titleId = useId();
@@ -2346,7 +2350,8 @@ function CommandPalette({
     }
     setQuery("");
     setRecentSearches(readRecentSearches());
-    setActiveIndex(0);
+    activeItemIdRef.current = null;
+    setActiveIndex(null);
   }, [open]);
 
   useEffect(() => {
@@ -2500,10 +2505,21 @@ function CommandPalette({
   const items = flattenCommandPaletteItems(groups);
   const renderedItemKey = items.map((item) => item.id).join("\u0000");
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    if (!open) {
+      return;
+    }
     void renderedItemKey;
-    setActiveIndex(items.length === 0 ? null : 0);
-  }, [items.length, renderedItemKey]);
+    const nextIndex = reconcileCommandPaletteActiveIndex(activeItemIdRef.current, items);
+    activeItemIdRef.current = nextIndex == null ? null : (items[nextIndex]?.id ?? null);
+    setActiveIndex(nextIndex);
+  }, [items, open, renderedItemKey]);
+
+  const selectPaletteIndex = (index: number | null) => {
+    const nextIndex = index != null && items[index] != null ? index : null;
+    activeItemIdRef.current = nextIndex == null ? null : (items[nextIndex]?.id ?? null);
+    setActiveIndex(nextIndex);
+  };
 
   useEffect(() => {
     if (activeIndex == null) {
@@ -2577,7 +2593,7 @@ function CommandPalette({
                 activeItem?.activate();
                 return;
               }
-              setActiveIndex(result.activeIndex);
+              selectPaletteIndex(result.activeIndex);
             }}
             placeholder="Search sessions or run a command…"
             role="combobox"
@@ -2638,8 +2654,10 @@ function CommandPalette({
                       key={item.id}
                       onClick={() => item.activate()}
                       onMouseDown={(event) => event.preventDefault()}
-                      onPointerEnter={() => {
-                        setActiveIndex(index);
+                      onPointerMove={(event) => {
+                        if (pointerMovementChangesSelection(event)) {
+                          selectPaletteIndex(index);
+                        }
                       }}
                       role="option"
                       tabIndex={-1}
@@ -2770,6 +2788,7 @@ function PaletteHighlightedText({
 }
 
 function SearchView({ dateRange, path }: { dateRange: DateRangeSelection; path: string }) {
+  const pageSize = 25;
   const initialQuery = new URLSearchParams(path.split("?")[1] ?? "").get("q") ?? "";
   const [query, setQuery] = useState(initialQuery);
   const [hits, setHits] = useState<SearchHit[]>([]);
@@ -2777,6 +2796,7 @@ function SearchView({ dateRange, path }: { dateRange: DateRangeSelection; path: 
   const [error, setError] = useState<unknown>(null);
   const [total, setTotal] = useState<number | null>(null);
   const [totalIsCapped, setTotalIsCapped] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
   const [elapsedMs, setElapsedMs] = useState(0);
   const [activeIndex, setActiveIndex] = useState(-1);
   const [retryKey, setRetryKey] = useState(0);
@@ -2784,6 +2804,12 @@ function SearchView({ dateRange, path }: { dateRange: DateRangeSelection; path: 
   const searchEpochRef = useRef(0);
   const resultsQueryRef = useRef<string | null>(null);
   const loadMoreControllerRef = useRef<AbortController | null>(null);
+  const hitsLengthRef = useRef(0);
+  const totalRef = useRef<number | null>(null);
+  const totalIsCappedRef = useRef(false);
+  hitsLengthRef.current = hits.length;
+  totalRef.current = total;
+  totalIsCappedRef.current = totalIsCapped;
   const rangeFrom = dateRange.from;
   const rangeTo = dateRange.to;
   const requestScope = useMemo(
@@ -2800,7 +2826,10 @@ function SearchView({ dateRange, path }: { dateRange: DateRangeSelection; path: 
     loadMoreControllerRef.current = null;
     setHits([]);
     setTotal(null);
+    totalRef.current = null;
     setTotalIsCapped(false);
+    totalIsCappedRef.current = false;
+    setHasMore(false);
     setElapsedMs(0);
     setActiveIndex(-1);
     setQuery(initialQuery);
@@ -2820,7 +2849,10 @@ function SearchView({ dateRange, path }: { dateRange: DateRangeSelection; path: 
       resultsQueryRef.current = null;
       setHits([]);
       setTotal(null);
+      totalRef.current = null;
       setTotalIsCapped(false);
+      totalIsCappedRef.current = false;
+      setHasMore(false);
       setElapsedMs(0);
       setSearching(false);
       setError(null);
@@ -2836,7 +2868,7 @@ function SearchView({ dateRange, path }: { dateRange: DateRangeSelection; path: 
           query: trimmed,
           include_subagents: true,
           include_total: false,
-          limit: 25,
+          limit: pageSize,
           offset: 0,
           ...requestScope,
         }),
@@ -2847,6 +2879,15 @@ function SearchView({ dateRange, path }: { dateRange: DateRangeSelection; path: 
             return;
           }
           setHits(response.results);
+          setHasMore(
+            searchPageMayHaveMore({
+              lastPageSize: response.results.length,
+              loaded: response.results.length,
+              pageSize,
+              total: totalRef.current,
+              totalIsCapped: totalIsCappedRef.current,
+            }),
+          );
           setElapsedMs(response.elapsed_ms);
           setActiveIndex(response.results.length > 0 ? 0 : -1);
           resultsQueryRef.current = trimmed;
@@ -2894,8 +2935,19 @@ function SearchView({ dateRange, path }: { dateRange: DateRangeSelection; path: 
           if (controller.signal.aborted || searchEpochRef.current !== epoch) {
             return;
           }
+          totalRef.current = response.total;
+          totalIsCappedRef.current = response.total_is_capped;
           setTotal(response.total);
           setTotalIsCapped(response.total_is_capped);
+          setHasMore(
+            searchPageMayHaveMore({
+              lastPageSize: 0,
+              loaded: hitsLengthRef.current,
+              pageSize,
+              total: response.total,
+              totalIsCapped: response.total_is_capped,
+            }),
+          );
         })
         .catch(() => {
           // A count is supplementary; keep the fast ranked results usable when
@@ -2910,6 +2962,7 @@ function SearchView({ dateRange, path }: { dateRange: DateRangeSelection; path: 
 
   const orderedHits = visuallyOrderedSearchHits(hits);
   const groups = groupSearchHits(orderedHits);
+  const exactRemaining = exactSearchRemaining(total, hits.length, totalIsCapped);
   const activeHit = activeIndex < 0 ? null : (orderedHits[activeIndex] ?? null);
   const activeHitId = activeHit == null ? undefined : `search-hit-${activeHit.block_id}`;
   useEffect(() => {
@@ -2922,7 +2975,7 @@ function SearchView({ dateRange, path }: { dateRange: DateRangeSelection; path: 
   }, [activeIndex]);
   const loadMore = () => {
     const trimmed = query.trim();
-    if (searching || total == null || hits.length >= total || trimmed.length < 2) {
+    if (searching || !hasMore || trimmed.length < 2) {
       return;
     }
     setSearching(true);
@@ -2937,7 +2990,7 @@ function SearchView({ dateRange, path }: { dateRange: DateRangeSelection; path: 
         query: trimmed,
         include_subagents: true,
         include_total: false,
-        limit: 25,
+        limit: pageSize,
         offset: hits.length,
         ...requestScope,
       }),
@@ -2947,7 +3000,17 @@ function SearchView({ dateRange, path }: { dateRange: DateRangeSelection; path: 
         if (controller.signal.aborted || searchEpochRef.current !== epoch) {
           return;
         }
+        const loaded = hits.length + response.results.length;
         setHits((current) => [...current, ...response.results]);
+        setHasMore(
+          searchPageMayHaveMore({
+            lastPageSize: response.results.length,
+            loaded,
+            pageSize,
+            total: totalRef.current,
+            totalIsCapped: totalIsCappedRef.current,
+          }),
+        );
         setElapsedMs(response.elapsed_ms);
       })
       .catch((err: unknown) => {
@@ -2988,7 +3051,10 @@ function SearchView({ dateRange, path }: { dateRange: DateRangeSelection; path: 
             loadMoreControllerRef.current = null;
             setHits([]);
             setTotal(null);
+            totalRef.current = null;
             setTotalIsCapped(false);
+            totalIsCappedRef.current = false;
+            setHasMore(false);
             setElapsedMs(0);
             setActiveIndex(-1);
             setSearching(event.target.value.trim().length >= 2);
@@ -3117,14 +3183,18 @@ function SearchView({ dateRange, path }: { dateRange: DateRangeSelection; path: 
             </section>
           ))}
         </div>
-        {total != null && hits.length < total ? (
+        {hasMore ? (
           <button
             className="secondary-button search-load-more"
             disabled={searching}
             onClick={loadMore}
             type="button"
           >
-            {searching ? "Loading…" : `Load more · ${formatInt(total - hits.length)} remaining`}
+            {searching
+              ? "Loading…"
+              : exactRemaining == null
+                ? "Load more"
+                : `Load more · ${formatInt(exactRemaining)} remaining`}
           </button>
         ) : null}
       </div>

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -70,6 +70,15 @@ import {
   prepareAnalyticsChartState,
 } from "./chart-state.ts";
 import {
+  buildCommandPaletteGroups,
+  type CommandPaletteItem,
+  flattenCommandPaletteItems,
+  normalizeRecentSearches,
+  paletteShortcutLabel,
+  reduceCommandPaletteKey,
+  shouldOpenCommandPalette,
+} from "./command-palette.ts";
+import {
   contextCurveAreaPath,
   contextCurveLinePath,
   groupContextMarkers,
@@ -84,6 +93,13 @@ import { dosuLink } from "./dosu-links.ts";
 import { dosuToolDisplayName, isDosuToolName } from "./dosu-tool.ts";
 import { effortDisplayLabel, effortTooltip } from "./effort.ts";
 import { isFramed } from "./frame-guard.ts";
+import {
+  createSessionSearchIndex,
+  type SessionHighlightRange,
+  type SessionHighlights,
+  type SessionSearchIndex,
+  type SessionSearchIndexRow,
+} from "./fuzzy.ts";
 import { formatIssueBadge, unknownRecordTypeSummary } from "./ingest-issues.ts";
 import {
   planSessionLoad,
@@ -102,6 +118,7 @@ import {
   sessionsArchivedHref,
   titleFor,
 } from "./navigation.ts";
+import { searchRequestScope, searchRouteHref } from "./search-request.ts";
 import { searchSnippetParts, visuallyOrderedSearchHits } from "./search-results.ts";
 import {
   archiveActionFor,
@@ -236,7 +253,7 @@ type SearchHit = {
 type SearchResponse = {
   elapsed_ms: number;
   results: SearchHit[];
-  total: number;
+  total: number | null;
   total_is_capped: boolean;
 };
 
@@ -701,6 +718,7 @@ function App() {
   const [sessionListExhausted, setSessionListExhausted] = useState(false);
   const [sessionLimit, setSessionLimit] = useState(SESSION_PAGE_SIZE);
   const [dateRangeSelection, setDateRangeSelection] = useState<DateRangeSelection>(ALL_DATE_RANGE);
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [localSyncing, setLocalSyncing] = useState(false);
   const [syncError, setSyncError] = useState<unknown>(null);
@@ -711,7 +729,6 @@ function App() {
   const syncCompleteTimerRef = useRef<number | null>(null);
   const liveDisconnectTimerRef = useRef<number | null>(null);
   const liveDroppedRef = useRef(false);
-  const headerSearchRef = useRef<HTMLInputElement | null>(null);
   const dateQuery = dateRangeQuery(dateRangeSelection);
   const sessionProject = sessionProjectFilter(path);
   const includeArchivedSessions = sessionIncludesArchived(path);
@@ -988,32 +1005,27 @@ function App() {
   }, [liveConnectionKey, requestRefresh]);
 
   useEffect(() => {
-    const focusSearch = (event: KeyboardEvent) => {
+    const openSearch = (event: KeyboardEvent) => {
       const targetIsInteractive =
         isInteractiveTarget(event.target) || isInteractiveTarget(document.activeElement);
-      const slash =
-        event.key === "/" && !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
-      const commandK =
-        event.key.toLowerCase() === "k" &&
-        event.metaKey !== event.ctrlKey &&
-        !event.altKey &&
-        !event.shiftKey;
-      const input = headerSearchRef.current;
       if (
-        (!slash && !commandK) ||
-        targetIsInteractive ||
-        hasOpenModal(document) ||
-        input == null ||
-        input.getClientRects().length === 0
+        !shouldOpenCommandPalette({
+          altKey: event.altKey,
+          ctrlKey: event.ctrlKey,
+          interactiveTarget: targetIsInteractive,
+          key: event.key,
+          metaKey: event.metaKey,
+          modalOpen: hasOpenModal(document),
+          shiftKey: event.shiftKey,
+        })
       ) {
         return;
       }
       event.preventDefault();
-      input.focus();
-      input.select();
+      setCommandPaletteOpen(true);
     };
-    window.addEventListener("keydown", focusSearch);
-    return () => window.removeEventListener("keydown", focusSearch);
+    window.addEventListener("keydown", openSearch);
+    return () => window.removeEventListener("keydown", openSearch);
   }, []);
 
   const active = activeView;
@@ -1060,11 +1072,6 @@ function App() {
     setLiveConnectionKey((key) => key + 1);
     requestRefresh();
   };
-  const headerSearchQuery =
-    pathOnly(path) === "/search"
-      ? (new URLSearchParams(path.split("?", 2)[1] ?? "").get("q") ?? "")
-      : "";
-
   const analyticsReport = pathOnly(path) === "/reports/analytics";
   const sessionReportMatch = pathOnly(path).match(/^\/reports\/session\/(\d+)$/);
   if (analyticsReport) {
@@ -1202,27 +1209,29 @@ function App() {
             <Icon name="menu" />
           </button>
           <h1>{titleFor(active)}</h1>
-          <label className="topbar-search">
-            <Icon name="search" />
-            <input
-              aria-label="Search session logs"
-              autoComplete="off"
-              onChange={(event) => updateSearchRoute(event.target.value, setPath)}
-              placeholder="Search sessions, messages, and tools…"
-              ref={headerSearchRef}
-              value={headerSearchQuery}
-            />
-            <kbd>{navigator.platform.includes("Mac") ? "⌘K" : "Ctrl K"}</kbd>
-          </label>
-          <div className="topbar-spacer" />
-          <a
-            aria-label="Search"
-            className="icon-button topbar-search-mobile"
-            href="/search"
-            onClick={(event) => navigate(event, "/search", setPath)}
+          <button
+            aria-expanded={commandPaletteOpen}
+            aria-haspopup="dialog"
+            aria-label="Open command palette"
+            className="topbar-search"
+            onClick={() => setCommandPaletteOpen(true)}
+            type="button"
           >
             <Icon name="search" />
-          </a>
+            <span className="topbar-search-label">Search sessions, messages, and tools…</span>
+            <kbd>{paletteShortcutLabel(navigator.userAgent)}</kbd>
+          </button>
+          <div className="topbar-spacer" />
+          <button
+            aria-expanded={commandPaletteOpen}
+            aria-haspopup="dialog"
+            aria-label="Search"
+            className="icon-button topbar-search-mobile"
+            onClick={() => setCommandPaletteOpen(true)}
+            type="button"
+          >
+            <Icon name="search" />
+          </button>
           <button
             aria-label="Sync session logs"
             aria-busy={syncInProgress}
@@ -1319,6 +1328,26 @@ function App() {
           </div>
         </main>
       </div>
+      <CommandPalette
+        analyticsReportHref={withDateQuery("/reports/analytics", dateQuery)}
+        onClose={() => setCommandPaletteOpen(false)}
+        onNavigate={(href) => {
+          setCommandPaletteOpen(false);
+          visit(href, setPath);
+        }}
+        onRunSync={() => {
+          setCommandPaletteOpen(false);
+          runSync();
+        }}
+        onToggleTheme={() => {
+          setTheme((current) =>
+            current === "system" ? "light" : current === "light" ? "dark" : "system",
+          );
+        }}
+        open={commandPaletteOpen}
+        refreshKey={reloadKey}
+        syncing={syncInProgress}
+      />
     </div>
   );
 }
@@ -1375,7 +1404,7 @@ function renderView(
         <ProjectsView onSync={actions.runSync} projects={data.projects} syncing={actions.syncing} />
       );
     case "Search":
-      return <SearchView path={path} />;
+      return <SearchView dateRange={actions.dateRange} path={path} />;
     case "Analytics":
       return (
         <AnalyticsView
@@ -2266,13 +2295,477 @@ function subagentDescriptor(session: SessionSummary): string {
   return session.agent_id != null ? `${kind} · ${session.agent_id}` : kind;
 }
 
-function SearchView({ path }: { path: string }) {
+type PaletteItemKind = "recent" | "session" | "page" | "action" | "content-search";
+
+interface PaletteItem extends CommandPaletteItem {
+  activate: () => void;
+  detail?: string;
+  highlights?: SessionHighlights;
+  icon: IconName;
+  kind: PaletteItemKind;
+  row?: SessionSearchIndexRow;
+}
+
+function CommandPalette({
+  analyticsReportHref,
+  onClose,
+  onNavigate,
+  onRunSync,
+  onToggleTheme,
+  open,
+  refreshKey,
+  syncing,
+}: {
+  analyticsReportHref: string;
+  onClose: () => void;
+  onNavigate: (href: string) => void;
+  onRunSync: () => void;
+  onToggleTheme: () => void;
+  open: boolean;
+  refreshKey: number;
+  syncing: boolean;
+}) {
+  const [query, setQuery] = useState("");
+  const [rows, setRows] = useState<SessionSearchIndexRow[]>([]);
+  const [loadedRefreshKey, setLoadedRefreshKey] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [indexError, setIndexError] = useState<unknown>(null);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [recentSearches, setRecentSearches] = useState<string[]>([]);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const closeRef = useRef(onClose);
+  const titleId = useId();
+  const listboxId = useId();
+  closeRef.current = onClose;
+  const requestClose = useCallback(() => closeRef.current(), []);
+  useDialogFocusTrap(open, dialogRef, requestClose);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setQuery("");
+    setRecentSearches(readRecentSearches());
+    setActiveIndex(0);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || loadedRefreshKey === refreshKey) {
+      return;
+    }
+    const controller = new AbortController();
+    setLoading(true);
+    setIndexError(null);
+    void getJson<SessionSearchIndexRow[]>("/api/sessions/search-index", {
+      signal: controller.signal,
+    })
+      .then((nextRows) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setRows(nextRows);
+        setLoadedRefreshKey(refreshKey);
+      })
+      .catch((error: unknown) => {
+        if (!controller.signal.aborted) {
+          setIndexError(error);
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      });
+    return () => controller.abort();
+  }, [loadedRefreshKey, open, refreshKey]);
+
+  const fuzzyIndex: SessionSearchIndex = useMemo(() => createSessionSearchIndex(rows), [rows]);
+  const normalizedQuery = query.trim();
+  const matches = useMemo(
+    () => (normalizedQuery === "" ? [] : fuzzyIndex.search(normalizedQuery, 10)),
+    [fuzzyIndex, normalizedQuery],
+  );
+  const rowById = useMemo(() => new Map(rows.map((row) => [row.id, row])), [rows]);
+
+  const recentItems: PaletteItem[] = recentSearches.map((recent) => ({
+    id: `recent:${recent}`,
+    label: recent,
+    detail: "Search transcript content",
+    icon: "clock",
+    kind: "recent",
+    activate: () => {
+      rememberSearch(recent);
+      onNavigate(`/search?q=${encodeURIComponent(recent)}`);
+    },
+  }));
+  const sessionMatches =
+    normalizedQuery === ""
+      ? rows.slice(0, 6).map((row) => ({ id: row.id, highlights: {} }))
+      : matches;
+  const sessionItems: PaletteItem[] = sessionMatches.flatMap((match) => {
+    const row = rowById.get(match.id);
+    if (row == null) {
+      return [];
+    }
+    return [
+      {
+        id: `session:${row.id}`,
+        label: row.title?.trim() || `Session ${row.id}`,
+        detail: paletteSessionDetail(row),
+        highlights: match.highlights,
+        icon: "sessions",
+        kind: "session",
+        row,
+        activate: () => onNavigate(`/sessions/${row.id}`),
+      },
+    ];
+  });
+  const pageItems: PaletteItem[] = navItems
+    .filter((item) => commandPaletteTextMatches(normalizedQuery, item.label))
+    .map((item) => ({
+      id: `page:${item.key}`,
+      label: item.label,
+      detail: item.href,
+      icon: item.icon,
+      kind: "page",
+      activate: () => onNavigate(item.href),
+    }));
+  const availableActions: PaletteItem[] = [
+    ...(syncing
+      ? []
+      : [
+          {
+            id: "action:sync",
+            label: "Run sync",
+            detail: "Ingest changed local session logs",
+            icon: "refresh" as const,
+            kind: "action" as const,
+            activate: onRunSync,
+          },
+        ]),
+    {
+      id: "action:theme",
+      label: "Toggle theme",
+      detail: "Cycle system, light, and dark",
+      icon: "sun",
+      kind: "action",
+      activate: () => {
+        onToggleTheme();
+        requestClose();
+      },
+    },
+    {
+      id: "action:report",
+      label: "Analytics report",
+      detail: "Review and export the active date range",
+      icon: "chart",
+      kind: "action",
+      activate: () => onNavigate(analyticsReportHref),
+    },
+    {
+      id: "action:settings",
+      label: "Settings",
+      detail: "Agent, terminal, and editor preferences",
+      icon: "settings",
+      kind: "action",
+      activate: () => onNavigate("/settings"),
+    },
+  ];
+  const actionItems = availableActions.filter((item) =>
+    commandPaletteTextMatches(normalizedQuery, `${item.label} ${item.detail ?? ""}`),
+  );
+  const contentSearch: PaletteItem | null =
+    normalizedQuery === ""
+      ? null
+      : {
+          id: "content-search",
+          label: `Search transcript content for “${normalizedQuery}”`,
+          detail: "Messages, tool calls, and results",
+          icon: "search",
+          kind: "content-search",
+          activate: () => {
+            const remembered = rememberSearch(normalizedQuery);
+            setRecentSearches(remembered);
+            onNavigate(`/search?q=${encodeURIComponent(normalizedQuery)}`);
+          },
+        };
+  const groups = buildCommandPaletteGroups({
+    query,
+    recent: recentItems,
+    sessions: sessionItems,
+    pages: pageItems,
+    actions: actionItems,
+    contentSearch,
+  });
+  const items = flattenCommandPaletteItems(groups);
+  const renderedItemKey = items.map((item) => item.id).join("\u0000");
+
+  useEffect(() => {
+    void renderedItemKey;
+    setActiveIndex(items.length === 0 ? null : 0);
+  }, [items.length, renderedItemKey]);
+
+  useEffect(() => {
+    if (activeIndex == null) {
+      return;
+    }
+    document
+      .querySelector<HTMLElement>(`[data-palette-index="${activeIndex}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+
+  if (!open) {
+    return null;
+  }
+
+  const renderedActiveIndex =
+    activeIndex != null && items[activeIndex] != null ? activeIndex : null;
+  const activeItem = renderedActiveIndex == null ? null : (items[renderedActiveIndex] ?? null);
+  const activeDescendant =
+    renderedActiveIndex == null ? undefined : `command-palette-item-${renderedActiveIndex}`;
+  const quickMatchCount = sessionItems.length + pageItems.length + actionItems.length;
+  return createPortal(
+    // biome-ignore lint/a11y/noStaticElementInteractions: backdrop dismissal supplements Escape and the explicit close button.
+    <div
+      className="command-palette-backdrop"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          requestClose();
+        }
+      }}
+    >
+      <div
+        aria-labelledby={titleId}
+        aria-modal="true"
+        className="command-palette"
+        ref={dialogRef}
+        role="dialog"
+        tabIndex={-1}
+      >
+        <h2 className="sr-only" id={titleId}>
+          Search and commands
+        </h2>
+        <div className="command-palette-input-row">
+          <Icon name="search" />
+          <input
+            aria-activedescendant={activeDescendant}
+            aria-autocomplete="list"
+            aria-controls={listboxId}
+            aria-expanded={true}
+            aria-label="Search sessions and commands"
+            autoComplete="off"
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={(event) => {
+              const result = reduceCommandPaletteKey(
+                { activeIndex },
+                {
+                  key: event.key,
+                  itemCount: items.length,
+                  isComposing: event.nativeEvent.isComposing,
+                },
+              );
+              if (!result.handled) {
+                return;
+              }
+              event.preventDefault();
+              event.stopPropagation();
+              if (result.effect === "close") {
+                requestClose();
+                return;
+              }
+              if (result.effect === "activate") {
+                activeItem?.activate();
+                return;
+              }
+              setActiveIndex(result.activeIndex);
+            }}
+            placeholder="Search sessions or run a command…"
+            role="combobox"
+            value={query}
+          />
+          <button
+            aria-label="Close command palette"
+            className="icon-button command-palette-close"
+            onClick={requestClose}
+            type="button"
+          >
+            <Icon name="x" />
+          </button>
+        </div>
+        <div aria-live="polite" className="command-palette-state-region">
+          {loading && rows.length === 0 ? (
+            <p className="command-palette-state" role="status">
+              Loading session index…
+            </p>
+          ) : null}
+          {indexError != null && rows.length === 0 ? (
+            <p className="command-palette-state is-error" role="status">
+              Session shortcuts are unavailable. Pages and actions still work.
+            </p>
+          ) : null}
+          {normalizedQuery !== "" && quickMatchCount === 0 && !loading && indexError == null ? (
+            <p className="command-palette-state">No quick matches. Try transcript search below.</p>
+          ) : null}
+        </div>
+        <div className="command-palette-results" id={listboxId} role="listbox">
+          {groups.map((group) => (
+            <fieldset className={`command-palette-group is-${group.id}`} key={group.id}>
+              <legend className={group.label == null ? "sr-only" : undefined}>
+                {group.label ?? "Transcript search"}
+              </legend>
+              {group.items.map((item) => {
+                const index = items.indexOf(item);
+                return (
+                  <div
+                    aria-selected={index === activeIndex}
+                    className={`command-palette-item is-${item.kind}${
+                      index === activeIndex ? " is-active" : ""
+                    }`}
+                    data-palette-index={index}
+                    id={`command-palette-item-${index}`}
+                    key={item.id}
+                    onClick={() => item.activate()}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onPointerMove={() => {
+                      setActiveIndex(index);
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        item.activate();
+                      }
+                    }}
+                    role="option"
+                    tabIndex={-1}
+                  >
+                    <span className="command-palette-item-icon">
+                      <Icon name={item.icon} />
+                    </span>
+                    <span className="command-palette-item-copy">
+                      <strong>
+                        <PaletteHighlightedText ranges={item.highlights?.title} text={item.label} />
+                      </strong>
+                      {item.kind === "session" && item.row != null ? (
+                        <PaletteSessionMeta highlights={item.highlights} row={item.row} />
+                      ) : item.detail == null ? null : (
+                        <span>{item.detail}</span>
+                      )}
+                    </span>
+                    {item.kind === "session" && item.row?.started_at != null ? (
+                      <time
+                        className="command-palette-item-date"
+                        dateTime={item.row.started_at}
+                        title={fullDateTime(item.row.started_at) ?? item.row.started_at}
+                      >
+                        <PaletteHighlightedText
+                          ranges={item.highlights?.started_at}
+                          text={item.row.started_at.slice(0, 10)}
+                        />
+                      </time>
+                    ) : item.kind === "content-search" ? (
+                      <kbd>↵</kbd>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </fieldset>
+          ))}
+        </div>
+        <footer className="command-palette-footer">
+          <span>
+            <kbd>↑</kbd>
+            <kbd>↓</kbd> navigate
+          </span>
+          <span>
+            <kbd>↵</kbd> open
+          </span>
+          <span>
+            <kbd>esc</kbd> close
+          </span>
+        </footer>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function commandPaletteTextMatches(query: string, text: string): boolean {
+  if (query === "") {
+    return true;
+  }
+  const lower = text.toLocaleLowerCase();
+  return query
+    .toLocaleLowerCase()
+    .split(/\s+/)
+    .every((term) => lower.includes(term));
+}
+
+function paletteSessionDetail(row: SessionSearchIndexRow): string {
+  return [row.project, row.tool, row.model]
+    .filter((value) => value != null && value !== "")
+    .join(" · ");
+}
+
+function PaletteSessionMeta({
+  highlights,
+  row,
+}: {
+  highlights: SessionHighlights | undefined;
+  row: SessionSearchIndexRow;
+}) {
+  const values = [
+    { field: "project" as const, value: row.project },
+    { field: "tool" as const, value: row.tool },
+    { field: "model" as const, value: row.model },
+  ].filter(
+    (entry): entry is { field: "project" | "tool" | "model"; value: string } =>
+      entry.value != null && entry.value !== "",
+  );
+  return (
+    <span>
+      {values.map((entry, index) => (
+        <span key={entry.field}>
+          {index > 0 ? " · " : null}
+          <PaletteHighlightedText ranges={highlights?.[entry.field]} text={entry.value} />
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function PaletteHighlightedText({
+  ranges,
+  text,
+}: {
+  ranges: readonly SessionHighlightRange[] | undefined;
+  text: string;
+}) {
+  if (ranges == null || ranges.length === 0) {
+    return text;
+  }
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+  for (const [index, range] of ranges.entries()) {
+    const [start, end] = range;
+    if (start > cursor) {
+      parts.push(<span key={`text-${index}`}>{text.slice(cursor, start)}</span>);
+    }
+    parts.push(<mark key={`match-${index}`}>{text.slice(start, end)}</mark>);
+    cursor = end;
+  }
+  if (cursor < text.length) {
+    parts.push(<span key="text-tail">{text.slice(cursor)}</span>);
+  }
+  return <>{parts}</>;
+}
+
+function SearchView({ dateRange, path }: { dateRange: DateRangeSelection; path: string }) {
   const initialQuery = new URLSearchParams(path.split("?")[1] ?? "").get("q") ?? "";
   const [query, setQuery] = useState(initialQuery);
   const [hits, setHits] = useState<SearchHit[]>([]);
   const [searching, setSearching] = useState(false);
   const [error, setError] = useState<unknown>(null);
-  const [total, setTotal] = useState(0);
+  const [total, setTotal] = useState<number | null>(null);
   const [totalIsCapped, setTotalIsCapped] = useState(false);
   const [elapsedMs, setElapsedMs] = useState(0);
   const [activeIndex, setActiveIndex] = useState(-1);
@@ -2281,14 +2774,22 @@ function SearchView({ path }: { path: string }) {
   const searchEpochRef = useRef(0);
   const resultsQueryRef = useRef<string | null>(null);
   const loadMoreControllerRef = useRef<AbortController | null>(null);
+  const rangeFrom = dateRange.from;
+  const rangeTo = dateRange.to;
+  const requestScope = useMemo(
+    () => searchRequestScope(path, { from: rangeFrom, to: rangeTo }),
+    [path, rangeFrom, rangeTo],
+  );
+  const requestScopeKey = JSON.stringify(requestScope);
 
   useLayoutEffect(() => {
+    void requestScopeKey;
     searchEpochRef.current += 1;
     resultsQueryRef.current = null;
     loadMoreControllerRef.current?.abort();
     loadMoreControllerRef.current = null;
     setHits([]);
-    setTotal(0);
+    setTotal(null);
     setTotalIsCapped(false);
     setElapsedMs(0);
     setActiveIndex(-1);
@@ -2296,7 +2797,7 @@ function SearchView({ path }: { path: string }) {
     return () => {
       loadMoreControllerRef.current?.abort();
     };
-  }, [initialQuery]);
+  }, [initialQuery, requestScopeKey]);
 
   useEffect(() => {
     const epoch = searchEpochRef.current + 1;
@@ -2308,7 +2809,7 @@ function SearchView({ path }: { path: string }) {
     if (trimmed.length < 2) {
       resultsQueryRef.current = null;
       setHits([]);
-      setTotal(0);
+      setTotal(null);
       setTotalIsCapped(false);
       setElapsedMs(0);
       setSearching(false);
@@ -2324,8 +2825,10 @@ function SearchView({ path }: { path: string }) {
         body: JSON.stringify({
           query: trimmed,
           include_subagents: true,
+          include_total: false,
           limit: 25,
           offset: 0,
+          ...requestScope,
         }),
         signal: controller.signal,
       })
@@ -2334,8 +2837,6 @@ function SearchView({ path }: { path: string }) {
             return;
           }
           setHits(response.results);
-          setTotal(response.total);
-          setTotalIsCapped(response.total_is_capped);
           setElapsedMs(response.elapsed_ms);
           setActiveIndex(response.results.length > 0 ? 0 : -1);
           resultsQueryRef.current = trimmed;
@@ -2356,7 +2857,46 @@ function SearchView({ path }: { path: string }) {
       window.clearTimeout(timer);
       controller.abort();
     };
-  }, [query, retryKey]);
+  }, [query, requestScope, retryKey]);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    void retryKey;
+    if (trimmed.length < 2) {
+      return;
+    }
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => {
+      const epoch = searchEpochRef.current;
+      void getJson<SearchResponse>("/api/search", {
+        method: "POST",
+        body: JSON.stringify({
+          query: trimmed,
+          include_subagents: true,
+          include_total: true,
+          limit: 1,
+          offset: 0,
+          ...requestScope,
+        }),
+        signal: controller.signal,
+      })
+        .then((response) => {
+          if (controller.signal.aborted || searchEpochRef.current !== epoch) {
+            return;
+          }
+          setTotal(response.total);
+          setTotalIsCapped(response.total_is_capped);
+        })
+        .catch(() => {
+          // A count is supplementary; keep the fast ranked results usable when
+          // the slower total request is interrupted or unavailable.
+        });
+    }, 500);
+    return () => {
+      window.clearTimeout(timer);
+      controller.abort();
+    };
+  }, [query, requestScope, retryKey]);
 
   const orderedHits = visuallyOrderedSearchHits(hits);
   const groups = groupSearchHits(orderedHits);
@@ -2372,7 +2912,7 @@ function SearchView({ path }: { path: string }) {
   }, [activeIndex]);
   const loadMore = () => {
     const trimmed = query.trim();
-    if (searching || hits.length >= total || trimmed.length < 2) {
+    if (searching || total == null || hits.length >= total || trimmed.length < 2) {
       return;
     }
     setSearching(true);
@@ -2386,8 +2926,10 @@ function SearchView({ path }: { path: string }) {
       body: JSON.stringify({
         query: trimmed,
         include_subagents: true,
+        include_total: false,
         limit: 25,
         offset: hits.length,
+        ...requestScope,
       }),
       signal: controller.signal,
     })
@@ -2396,8 +2938,6 @@ function SearchView({ path }: { path: string }) {
           return;
         }
         setHits((current) => [...current, ...response.results]);
-        setTotal(response.total);
-        setTotalIsCapped(response.total_is_capped);
         setElapsedMs(response.elapsed_ms);
       })
       .catch((err: unknown) => {
@@ -2437,7 +2977,7 @@ function SearchView({ path }: { path: string }) {
             loadMoreControllerRef.current?.abort();
             loadMoreControllerRef.current = null;
             setHits([]);
-            setTotal(0);
+            setTotal(null);
             setTotalIsCapped(false);
             setElapsedMs(0);
             setActiveIndex(-1);
@@ -2470,11 +3010,16 @@ function SearchView({ path }: { path: string }) {
         />
       </form>
 
-      {query.trim().length >= 2 ? (
+      {query.trim().length >= 2 && (searching || hits.length > 0 || total != null) ? (
         <p className="result-caption">
-          {formatInt(total)}
-          {totalIsCapped ? "+" : ""} {total === 1 ? "result" : "results"} ·{" "}
-          {formatSearchTime(elapsedMs)}
+          {total == null
+            ? hits.length === 0
+              ? "Finding matches"
+              : `Showing ${formatInt(hits.length)} matches`
+            : `${formatInt(total)}${totalIsCapped ? "+" : ""} ${
+                total === 1 ? "result" : "results"
+              }`}{" "}
+          · {formatSearchTime(elapsedMs)}
         </p>
       ) : null}
       {error != null ? (
@@ -2562,7 +3107,7 @@ function SearchView({ path }: { path: string }) {
             </section>
           ))}
         </div>
-        {hits.length < total ? (
+        {total != null && hits.length < total ? (
           <button
             className="secondary-button search-load-more"
             disabled={searching}
@@ -2620,16 +3165,14 @@ function readRecentSearches(): string[] {
   try {
     const key = "decant-recent-searches";
     const current = JSON.parse(localStorage.getItem(key) ?? "[]") as unknown;
-    return Array.isArray(current)
-      ? current.filter((value): value is string => typeof value === "string")
-      : [];
+    return normalizeRecentSearches(current);
   } catch {
     return [];
   }
 }
 
 function rememberSearch(query: string): string[] {
-  const values = [query, ...readRecentSearches().filter((value) => value !== query)].slice(0, 8);
+  const values = normalizeRecentSearches(readRecentSearches(), query);
   try {
     localStorage.setItem("decant-recent-searches", JSON.stringify(values));
   } catch {
@@ -10332,8 +10875,7 @@ function locationPath(): string {
 }
 
 function updateSearchRoute(query: string, setPath?: (path: string) => void) {
-  const trimmed = query.trimStart();
-  const href = trimmed === "" ? "/search" : `/search?q=${encodeURIComponent(trimmed)}`;
+  const href = searchRouteHref(query, locationPath());
   if (pathOnly(locationPath()) === "/search") {
     window.history.replaceState(null, "", href);
   } else {

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -2395,7 +2395,7 @@ function CommandPalette({
     kind: "recent",
     activate: () => {
       rememberSearch(recent);
-      onNavigate(`/search?q=${encodeURIComponent(recent)}`);
+      onNavigate(searchRouteHref(recent, locationPath()));
     },
   }));
   const sessionMatches =
@@ -2486,7 +2486,7 @@ function CommandPalette({
           activate: () => {
             const remembered = rememberSearch(normalizedQuery);
             setRecentSearches(remembered);
-            onNavigate(`/search?q=${encodeURIComponent(normalizedQuery)}`);
+            onNavigate(searchRouteHref(normalizedQuery, locationPath()));
           },
         };
   const groups = buildCommandPaletteGroups({
@@ -2509,8 +2509,8 @@ function CommandPalette({
     if (activeIndex == null) {
       return;
     }
-    document
-      .querySelector<HTMLElement>(`[data-palette-index="${activeIndex}"]`)
+    dialogRef.current
+      ?.querySelector<HTMLElement>(`[data-palette-index="${activeIndex}"]`)
       ?.scrollIntoView({ block: "nearest" });
   }, [activeIndex]);
 
@@ -2608,68 +2608,78 @@ function CommandPalette({
           ) : null}
         </div>
         <div className="command-palette-results" id={listboxId} role="listbox">
-          {groups.map((group) => (
-            <fieldset className={`command-palette-group is-${group.id}`} key={group.id}>
-              <legend className={group.label == null ? "sr-only" : undefined}>
-                {group.label ?? "Transcript search"}
-              </legend>
-              {group.items.map((item) => {
-                const index = items.indexOf(item);
-                return (
-                  <div
-                    aria-selected={index === activeIndex}
-                    className={`command-palette-item is-${item.kind}${
-                      index === activeIndex ? " is-active" : ""
-                    }`}
-                    data-palette-index={index}
-                    id={`command-palette-item-${index}`}
-                    key={item.id}
-                    onClick={() => item.activate()}
-                    onMouseDown={(event) => event.preventDefault()}
-                    onPointerMove={() => {
-                      setActiveIndex(index);
-                    }}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter" || event.key === " ") {
-                        event.preventDefault();
-                        item.activate();
-                      }
-                    }}
-                    role="option"
-                    tabIndex={-1}
-                  >
-                    <span className="command-palette-item-icon">
-                      <Icon name={item.icon} />
-                    </span>
-                    <span className="command-palette-item-copy">
-                      <strong>
-                        <PaletteHighlightedText ranges={item.highlights?.title} text={item.label} />
-                      </strong>
-                      {item.kind === "session" && item.row != null ? (
-                        <PaletteSessionMeta highlights={item.highlights} row={item.row} />
-                      ) : item.detail == null ? null : (
-                        <span>{item.detail}</span>
-                      )}
-                    </span>
-                    {item.kind === "session" && item.row?.started_at != null ? (
-                      <time
-                        className="command-palette-item-date"
-                        dateTime={item.row.started_at}
-                        title={fullDateTime(item.row.started_at) ?? item.row.started_at}
-                      >
-                        <PaletteHighlightedText
-                          ranges={item.highlights?.started_at}
-                          text={item.row.started_at.slice(0, 10)}
-                        />
-                      </time>
-                    ) : item.kind === "content-search" ? (
-                      <kbd>↵</kbd>
-                    ) : null}
-                  </div>
-                );
-              })}
-            </fieldset>
-          ))}
+          {groups.map((group) => {
+            const labelId = `${listboxId}-${group.id}-label`;
+            return (
+              // biome-ignore lint/a11y/useSemanticElements: fieldset is not a valid listbox child; this div is an explicit ARIA group.
+              <div
+                aria-labelledby={labelId}
+                className={`command-palette-group is-${group.id}`}
+                key={group.id}
+                role="group"
+              >
+                <div
+                  className={group.label == null ? "sr-only" : "command-palette-group-label"}
+                  id={labelId}
+                >
+                  {group.label ?? "Transcript search"}
+                </div>
+                {group.items.map((item) => {
+                  const index = items.indexOf(item);
+                  return (
+                    // biome-ignore lint/a11y/useKeyWithClickEvents: keyboard activation is owned by the combobox through aria-activedescendant.
+                    <div
+                      aria-selected={index === activeIndex}
+                      className={`command-palette-item is-${item.kind}${
+                        index === activeIndex ? " is-active" : ""
+                      }`}
+                      data-palette-index={index}
+                      id={`command-palette-item-${index}`}
+                      key={item.id}
+                      onClick={() => item.activate()}
+                      onMouseDown={(event) => event.preventDefault()}
+                      onPointerEnter={() => {
+                        setActiveIndex(index);
+                      }}
+                      role="option"
+                      tabIndex={-1}
+                    >
+                      <span className="command-palette-item-icon">
+                        <Icon name={item.icon} />
+                      </span>
+                      <span className="command-palette-item-copy">
+                        <strong>
+                          <PaletteHighlightedText
+                            ranges={item.highlights?.title}
+                            text={item.label}
+                          />
+                        </strong>
+                        {item.kind === "session" && item.row != null ? (
+                          <PaletteSessionMeta highlights={item.highlights} row={item.row} />
+                        ) : item.detail == null ? null : (
+                          <span>{item.detail}</span>
+                        )}
+                      </span>
+                      {item.kind === "session" && item.row?.started_at != null ? (
+                        <time
+                          className="command-palette-item-date"
+                          dateTime={item.row.started_at}
+                          title={fullDateTime(item.row.started_at) ?? item.row.started_at}
+                        >
+                          <PaletteHighlightedText
+                            ranges={item.highlights?.started_at}
+                            text={item.row.started_at.slice(0, 10)}
+                          />
+                        </time>
+                      ) : item.kind === "content-search" ? (
+                        <kbd>↵</kbd>
+                      ) : null}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
         </div>
         <footer className="command-palette-footer">
           <span>

--- a/src/ui/search-pagination.ts
+++ b/src/ui/search-pagination.ts
@@ -1,0 +1,31 @@
+export interface SearchPageAvailability {
+  lastPageSize: number;
+  loaded: number;
+  pageSize: number;
+  total: number | null;
+  totalIsCapped?: boolean;
+}
+
+/**
+ * A total is supplementary to ranked search results. When it is unavailable,
+ * a full page is sufficient evidence to offer another page; an exact multiple
+ * may require one final empty probe to establish the end.
+ */
+export function searchPageMayHaveMore(input: SearchPageAvailability): boolean {
+  if (input.total != null && input.loaded < input.total) {
+    return true;
+  }
+  if (input.total != null && input.totalIsCapped !== true) {
+    return false;
+  }
+  return input.lastPageSize === input.pageSize;
+}
+
+/** Return an exact remaining count only when the server supplied an exact total. */
+export function exactSearchRemaining(
+  total: number | null,
+  loaded: number,
+  totalIsCapped: boolean,
+): number | null {
+  return total == null || totalIsCapped ? null : Math.max(0, total - loaded);
+}

--- a/src/ui/search-request.ts
+++ b/src/ui/search-request.ts
@@ -1,0 +1,48 @@
+export type SearchRequestScope = {
+  from?: string;
+  project?: string;
+  to?: string;
+  tool?: string;
+};
+
+export function searchRequestScope(
+  path: string,
+  dateRange: { from: string | null; to: string | null },
+): SearchRequestScope {
+  const params = new URLSearchParams(path.split("?", 2)[1] ?? "");
+  const scope: SearchRequestScope = {};
+  if (dateRange.from != null) {
+    scope.from = dateRange.from;
+  }
+  if (dateRange.to != null) {
+    scope.to = dateRange.to;
+  }
+  const tool = params.get("tool");
+  if (tool != null && tool !== "") {
+    scope.tool = tool;
+  }
+  const project = params.get("project");
+  if (project != null && project !== "") {
+    scope.project = project;
+  }
+  return scope;
+}
+
+export function searchRouteHref(query: string, currentPath: string): string {
+  const current = new URLSearchParams(
+    currentPath.startsWith("/search") ? (currentPath.split("?", 2)[1] ?? "") : "",
+  );
+  const next = new URLSearchParams();
+  for (const key of ["tool", "project"] as const) {
+    const value = current.get(key);
+    if (value != null && value !== "") {
+      next.set(key, value);
+    }
+  }
+  const trimmed = query.trimStart();
+  if (trimmed !== "") {
+    next.set("q", trimmed);
+  }
+  const params = next.toString();
+  return params === "" ? "/search" : `/search?${params}`;
+}

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -383,25 +383,26 @@ nav a[aria-current="page"] svg {
   border-radius: 8px;
   background: var(--surface);
   color: var(--faint);
+  font: inherit;
   font-size: 14px;
   padding: 0 10px;
+  text-align: left;
 }
 
-.topbar-search:focus-within,
+.topbar-search:focus-visible,
 .topbar-search:hover {
   border-color: var(--line-strong);
   color: var(--muted);
 }
 
-.topbar-search input {
+.topbar-search-label {
+  display: block;
+  flex: 1;
   width: 100%;
   min-width: 0;
-  border: 0;
-  outline: 0;
-  background: transparent;
-  box-shadow: none;
-  color: var(--fg);
-  padding: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .topbar-search kbd {
@@ -413,8 +414,206 @@ nav a[aria-current="page"] svg {
   padding: 1px 6px;
 }
 
-.topbar-search-mobile {
+.icon-button.topbar-search-mobile {
   display: none;
+}
+
+.command-palette-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  background: rgb(0 0 0 / 58%);
+  padding: min(12vh, 104px) 20px 20px;
+  backdrop-filter: blur(5px);
+}
+
+.command-palette {
+  display: flex;
+  width: min(680px, 100%);
+  max-height: min(720px, calc(100dvh - min(12vh, 104px) - 40px));
+  min-height: 240px;
+  overflow: hidden;
+  border: 1px solid var(--line-strong);
+  border-radius: 14px;
+  background: var(--surface);
+  box-shadow: 0 24px 80px rgb(0 0 0 / 38%);
+  flex-direction: column;
+}
+
+.command-palette-input-row {
+  display: grid;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid var(--line);
+  grid-template-columns: 20px minmax(0, 1fr) 34px;
+  padding: 12px 14px;
+}
+
+.command-palette-input-row > svg {
+  width: 19px;
+  color: var(--muted);
+}
+
+.command-palette-input-row input {
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--fg);
+  font: inherit;
+  font-size: 16px;
+  padding: 6px 0;
+}
+
+.command-palette-close {
+  border-color: transparent;
+  background: transparent;
+}
+
+.command-palette-results {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 8px;
+}
+
+.command-palette-group {
+  min-width: 0;
+  border: 0;
+  margin: 0;
+  padding: 4px 0 8px;
+}
+
+.command-palette-group + .command-palette-group {
+  border-top: 1px solid var(--line);
+  padding-top: 10px;
+}
+
+.command-palette-group legend {
+  width: 100%;
+  margin: 0;
+  color: var(--faint);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 4px 10px 6px;
+  text-transform: uppercase;
+}
+
+.command-palette-group.is-content-search {
+  position: sticky;
+  bottom: -8px;
+  z-index: 1;
+  border-top: 1px solid var(--line-strong);
+  background: var(--surface);
+  padding: 8px 0;
+}
+
+.command-palette-item {
+  display: grid;
+  align-items: center;
+  gap: 10px;
+  min-height: 52px;
+  border-radius: 9px;
+  color: var(--fg);
+  cursor: default;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  padding: 7px 10px;
+  user-select: none;
+}
+
+.command-palette-item.is-active {
+  background: var(--accent-soft);
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--accent) 32%, transparent);
+}
+
+.command-palette-item-icon {
+  display: inline-grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--canvas);
+  color: var(--muted);
+}
+
+.command-palette-item-icon svg {
+  width: 15px;
+}
+
+.command-palette-item-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.command-palette-item-copy strong,
+.command-palette-item-copy > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.command-palette-item-copy strong {
+  font-size: 14px;
+  font-weight: 620;
+}
+
+.command-palette-item-copy > span {
+  color: var(--faint);
+  font-size: 12px;
+}
+
+.command-palette-item-date {
+  color: var(--faint);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.command-palette-item > kbd,
+.command-palette-footer kbd {
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--canvas);
+  color: var(--faint);
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 10px;
+  padding: 1px 5px;
+}
+
+.command-palette-state {
+  margin: 0;
+  color: var(--faint);
+  font-size: 13px;
+  padding: 16px 10px;
+  text-align: center;
+}
+
+.command-palette-state.is-error {
+  color: var(--danger);
+}
+
+.command-palette-footer {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  border-top: 1px solid var(--line);
+  color: var(--faint);
+  font-size: 11px;
+  padding: 9px 16px;
+}
+
+.command-palette-footer span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .icon-button {
@@ -4695,12 +4894,41 @@ pre {
     display: none;
   }
 
-  .topbar-search-mobile {
+  .icon-button.topbar-search-mobile {
     display: inline-grid;
   }
 }
 
 @media (max-width: 640px) {
+  .command-palette-backdrop {
+    padding: 8px;
+  }
+
+  .command-palette {
+    width: 100%;
+    max-height: calc(100dvh - 16px);
+    border-radius: 11px;
+  }
+
+  .command-palette-input-row {
+    padding: 10px 11px;
+  }
+
+  .command-palette-results {
+    padding: 6px;
+  }
+
+  .command-palette-item {
+    min-height: 50px;
+    padding-inline: 8px;
+  }
+
+  .command-palette-footer {
+    justify-content: space-between;
+    gap: 8px;
+    padding-inline: 12px;
+  }
+
   .panel-heading,
   .inline-heading,
   .section-title-row {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -493,7 +493,7 @@ nav a[aria-current="page"] svg {
   padding-top: 10px;
 }
 
-.command-palette-group legend {
+.command-palette-group-label {
   width: 100%;
   margin: 0;
   color: var(--faint);

--- a/src/ui/transcript-navigation.ts
+++ b/src/ui/transcript-navigation.ts
@@ -109,8 +109,8 @@ export function revealTranscriptMessage(
 
 /**
  * Selector for anything modal enough that arrow keys should not reach the
- * transcript underneath it. Nothing in the UI matches today; this is a guard
- * against a modal added later silently scrolling the page behind itself.
+ * transcript underneath it. The command palette and detail dialogs match this
+ * guard so they cannot silently scroll the page behind themselves.
  *
  * `[role='dialog']` alone missed both of the other ways a modal is normally
  * expressed, so all three are covered: the native element (only while open,

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -15,6 +15,7 @@ import {
   search,
   searchPage,
   sessionIngestIssues,
+  sessionSearchIndex,
 } from "../src/query.ts";
 import { SEARCH_MATCH_END, SEARCH_MATCH_START } from "../src/search-query.ts";
 import { setSessionUserState } from "../src/session-user-state.ts";
@@ -706,6 +707,59 @@ describe("query reads", () => {
     db.close();
   });
 
+  test("builds a lightweight search index from visible non-archived sessions", () => {
+    const db = seeded();
+    const root = listSessions(db)[0];
+    if (root == null) {
+      throw new Error("seeded root must exist");
+    }
+    db.exec(`
+      INSERT INTO session(
+        id, tool, source_session_id, project_id, title, model, started_at,
+        is_subagent, parent_session_id
+      )
+      SELECT 7000, 'codex', 'index-no-messages', project_id, 'Index without messages',
+             'gpt-5', '2026-05-04T00:00:00Z', 0, NULL
+      FROM session WHERE id = ${root.id}
+      UNION ALL
+      SELECT 7001, 'claude_code', 'index-generated-command', project_id,
+             '<local-command-caveat>generated</local-command-caveat>',
+             NULL, '2026-05-05T00:00:00Z', 0, NULL
+      FROM session WHERE id = ${root.id}
+      UNION ALL
+      SELECT 7002, 'codex', 'index-archived-parent', project_id, 'Archived parent',
+             'gpt-5', '2026-05-06T00:00:00Z', 0, NULL
+      FROM session WHERE id = ${root.id}
+      UNION ALL
+      SELECT 7003, 'codex', 'index-archived-child', project_id, 'Archived child',
+             'gpt-5', '2026-05-06T00:01:00Z', 1, 7002
+      FROM session WHERE id = ${root.id};
+    `);
+    expect(setSessionUserState(db, 7002, "archived")).toBe(true);
+
+    const index = sessionSearchIndex(db);
+    expect(index.find((row) => row.id === 7000)).toEqual({
+      id: 7000,
+      title: "Index without messages",
+      project: "/Users/dev/proj",
+      tool: "codex",
+      model: "gpt-5",
+      started_at: "2026-05-04T00:00:00Z",
+    });
+    expect(index.some((row) => row.id === 7001)).toBe(false);
+    expect(index.some((row) => row.id === 7002)).toBe(false);
+    expect(index.some((row) => row.id === 7003)).toBe(false);
+    expect(Object.keys(index[0] ?? {}).sort()).toEqual([
+      "id",
+      "model",
+      "project",
+      "started_at",
+      "title",
+      "tool",
+    ]);
+    db.close();
+  });
+
   test("search returns matching-column snippets, deep links, totals, and pagination", () => {
     const db = seeded();
     const page = searchPage(db, "auth", { limit: 1 });
@@ -734,6 +788,13 @@ describe("query reads", () => {
     );
     expect(toolInputHit?.snippet).toContain(`${SEARCH_MATCH_START}auth_test.py${SEARCH_MATCH_END}`);
     expect(toolInputHit?.snippet).not.toBe("Read");
+
+    expect(searchPage(db, "auth", { includeTotal: false, limit: 1 })).toMatchObject({
+      results: [expect.any(Object)],
+      total: null,
+      total_is_capped: false,
+      elapsed_ms: expect.any(Number),
+    });
     db.close();
   });
 

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -733,6 +733,10 @@ describe("query reads", () => {
       UNION ALL
       SELECT 7003, 'codex', 'index-archived-child', project_id, 'Archived child',
              'gpt-5', '2026-05-06T00:01:00Z', 1, 7002
+      FROM session WHERE id = ${root.id}
+      UNION ALL
+      SELECT 7004, 'codex', 'index-visible-child', project_id, 'Visible child',
+             'gpt-5', '2026-05-06T00:02:00Z', 1, 7000
       FROM session WHERE id = ${root.id};
     `);
     expect(setSessionUserState(db, 7002, "archived")).toBe(true);
@@ -749,6 +753,7 @@ describe("query reads", () => {
     expect(index.some((row) => row.id === 7001)).toBe(false);
     expect(index.some((row) => row.id === 7002)).toBe(false);
     expect(index.some((row) => row.id === 7003)).toBe(false);
+    expect(index.some((row) => row.id === 7004)).toBe(false);
     expect(Object.keys(index[0] ?? {}).sort()).toEqual([
       "id",
       "model",

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -21,6 +21,7 @@ import {
   serve,
   type TrustedPeerSources,
 } from "../src/server.ts";
+import { setSessionUserState } from "../src/session-user-state.ts";
 import { parseClaudeSession } from "../src/sources/claude.ts";
 import { parseCodexSession } from "../src/sources/codex.ts";
 
@@ -145,6 +146,37 @@ describe("server routes", () => {
     const touchIcon = await route(config, "/apple-touch-icon.png");
     expect(touchIcon.status).toBe(200);
     expect(touchIcon.contentType).toBe("image/png");
+  });
+
+  test("serves a lightweight visible non-archived session search index", async () => {
+    const config = freshConfig();
+    seed(config);
+    const db = openDb(config.dbPath);
+    const archived = db
+      .query(
+        `SELECT id
+         FROM session
+         WHERE tool = 'codex'
+         ORDER BY id
+         LIMIT 1`,
+      )
+      .get() as { id: number };
+    expect(setSessionUserState(db, archived.id, "archived")).toBe(true);
+    db.close();
+
+    const response = await route(config, "/api/sessions/search-index");
+    expect(response.status).toBe(200);
+    const rows = response.body as Array<Record<string, unknown>>;
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.some((row) => row.id === archived.id)).toBe(false);
+    expect(Object.keys(rows[0] ?? {}).sort()).toEqual([
+      "id",
+      "model",
+      "project",
+      "started_at",
+      "title",
+      "tool",
+    ]);
   });
 
   test("app routes fall back to the React shell and config is exposed locally", async () => {
@@ -522,6 +554,44 @@ describe("server routes", () => {
       total_is_capped: false,
       elapsed_ms: expect.any(Number),
     });
+    const fastSearch = await route(config, "/api/search", {
+      method: "POST",
+      body: JSON.stringify({ query: "auth", include_total: false, limit: 1 }),
+    });
+    expect(fastSearch).toMatchObject({
+      status: 200,
+      body: {
+        results: [expect.any(Object)],
+        total: null,
+        total_is_capped: false,
+        elapsed_ms: expect.any(Number),
+      },
+    });
+    const invalidSearchBodies: unknown[] = [
+      null,
+      { query: "auth", project: {} },
+      { query: "auth", tool: [] },
+      { query: "auth", from: 123 },
+      { query: "auth", include_subagents: "true" },
+      { query: "auth", include_total: null },
+      { query: "auth", limit: "1" },
+      { query: "auth", limit: 0 },
+      { query: "auth", limit: 101 },
+      { query: "auth", limit: 1.5 },
+      { query: "auth", offset: -4 },
+      { query: "auth", offset: 1.5 },
+    ];
+    for (const body of invalidSearchBodies) {
+      expect(
+        await route(config, "/api/search", {
+          method: "POST",
+          body: JSON.stringify(body),
+        }),
+      ).toMatchObject({
+        status: 400,
+        body: { code: "invalid_request" },
+      });
+    }
     const firstSearchPage = await route(config, "/api/search", {
       method: "POST",
       body: JSON.stringify({ query: "auth", limit: 1 }),

--- a/test/ui-command-palette.test.ts
+++ b/test/ui-command-palette.test.ts
@@ -5,6 +5,8 @@ import {
   flattenCommandPaletteItems,
   normalizeRecentSearches,
   paletteShortcutLabel,
+  pointerMovementChangesSelection,
+  reconcileCommandPaletteActiveIndex,
   reduceCommandPaletteKey,
   shouldOpenCommandPalette,
 } from "../src/ui/command-palette.ts";
@@ -137,6 +139,29 @@ describe("command palette key reducer", () => {
       effect: "none",
       handled: false,
     });
+  });
+});
+
+describe("command palette selection reconciliation", () => {
+  test("preserves the selected action when asynchronously loaded sessions prepend matches", () => {
+    expect(
+      reconcileCommandPaletteActiveIndex("content-search", [
+        item("session:1"),
+        item("session:2"),
+        item("content-search"),
+      ]),
+    ).toBe(2);
+  });
+
+  test("falls back to the first item only when the prior selection disappeared", () => {
+    expect(reconcileCommandPaletteActiveIndex("session:1", [item("session:2")])).toBe(0);
+    expect(reconcileCommandPaletteActiveIndex(null, [])).toBeNull();
+  });
+
+  test("ignores stationary pointer events caused by keyboard scrolling", () => {
+    expect(pointerMovementChangesSelection({ movementX: 0, movementY: 0 })).toBe(false);
+    expect(pointerMovementChangesSelection({ movementX: 1, movementY: 0 })).toBe(true);
+    expect(pointerMovementChangesSelection({ movementX: 0, movementY: -1 })).toBe(true);
   });
 });
 

--- a/test/ui-command-palette.test.ts
+++ b/test/ui-command-palette.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildCommandPaletteGroups,
+  type CommandPaletteItem,
+  flattenCommandPaletteItems,
+  normalizeRecentSearches,
+  paletteShortcutLabel,
+  reduceCommandPaletteKey,
+  shouldOpenCommandPalette,
+} from "../src/ui/command-palette.ts";
+
+const item = (id: string): CommandPaletteItem => ({ id, label: id });
+
+describe("command palette rendered order", () => {
+  test("uses fixed group order and shows recent searches only for a blank query", () => {
+    const groups = buildCommandPaletteGroups({
+      query: "   ",
+      recent: [item("recent-a")],
+      sessions: [item("session-a"), item("session-b")],
+      pages: [item("page-a")],
+      actions: [item("action-a")],
+      contentSearch: item("search-all"),
+    });
+
+    expect(groups.map((group) => group.id)).toEqual([
+      "recent",
+      "sessions",
+      "pages",
+      "actions",
+      "content-search",
+    ]);
+    expect(flattenCommandPaletteItems(groups).map((entry) => entry.id)).toEqual([
+      "recent-a",
+      "session-a",
+      "session-b",
+      "page-a",
+      "action-a",
+      "search-all",
+    ]);
+
+    expect(
+      buildCommandPaletteGroups({
+        query: "schema",
+        recent: [item("recent-a")],
+        sessions: [item("session-a")],
+        pages: [],
+        actions: [item("action-a")],
+        contentSearch: item("search-schema"),
+      }).map((group) => group.id),
+    ).toEqual(["sessions", "actions", "content-search"]);
+  });
+
+  test("omits empty groups while preserving caller item order", () => {
+    const groups = buildCommandPaletteGroups({
+      query: "",
+      recent: [],
+      sessions: [item("session-newest"), item("session-older")],
+      pages: [],
+      actions: [],
+      contentSearch: null,
+    });
+
+    expect(groups).toEqual([
+      {
+        id: "sessions",
+        label: "Sessions",
+        items: [item("session-newest"), item("session-older")],
+      },
+    ]);
+  });
+});
+
+describe("command palette key reducer", () => {
+  test("walks the flattened cross-group order and wraps at both ends", () => {
+    expect(
+      reduceCommandPaletteKey({ activeIndex: null }, { key: "ArrowDown", itemCount: 5 }),
+    ).toEqual({ activeIndex: 0, effect: "none", handled: true });
+    expect(reduceCommandPaletteKey({ activeIndex: 1 }, { key: "ArrowDown", itemCount: 5 })).toEqual(
+      { activeIndex: 2, effect: "none", handled: true },
+    );
+    expect(reduceCommandPaletteKey({ activeIndex: 4 }, { key: "ArrowDown", itemCount: 5 })).toEqual(
+      { activeIndex: 0, effect: "none", handled: true },
+    );
+    expect(reduceCommandPaletteKey({ activeIndex: 0 }, { key: "ArrowUp", itemCount: 5 })).toEqual({
+      activeIndex: 4,
+      effect: "none",
+      handled: true,
+    });
+  });
+
+  test("supports Home, End, Enter, and Escape semantics", () => {
+    expect(reduceCommandPaletteKey({ activeIndex: 3 }, { key: "Home", itemCount: 5 })).toEqual({
+      activeIndex: 0,
+      effect: "none",
+      handled: true,
+    });
+    expect(reduceCommandPaletteKey({ activeIndex: 1 }, { key: "End", itemCount: 5 })).toEqual({
+      activeIndex: 4,
+      effect: "none",
+      handled: true,
+    });
+    expect(reduceCommandPaletteKey({ activeIndex: 2 }, { key: "Enter", itemCount: 5 })).toEqual({
+      activeIndex: 2,
+      effect: "activate",
+      handled: true,
+    });
+    expect(reduceCommandPaletteKey({ activeIndex: 2 }, { key: "Escape", itemCount: 5 })).toEqual({
+      activeIndex: 2,
+      effect: "close",
+      handled: true,
+    });
+  });
+
+  test("does not claim unrelated, empty, stale, or composing key events", () => {
+    expect(reduceCommandPaletteKey({ activeIndex: null }, { key: "Enter", itemCount: 0 })).toEqual({
+      activeIndex: null,
+      effect: "none",
+      handled: false,
+    });
+    expect(reduceCommandPaletteKey({ activeIndex: 8 }, { key: "Enter", itemCount: 2 })).toEqual({
+      activeIndex: null,
+      effect: "none",
+      handled: false,
+    });
+    expect(reduceCommandPaletteKey({ activeIndex: 1 }, { key: "Tab", itemCount: 2 })).toEqual({
+      activeIndex: 1,
+      effect: "none",
+      handled: false,
+    });
+    expect(
+      reduceCommandPaletteKey(
+        { activeIndex: 1 },
+        { key: "ArrowDown", itemCount: 2, isComposing: true },
+      ),
+    ).toEqual({
+      activeIndex: 1,
+      effect: "none",
+      handled: false,
+    });
+  });
+});
+
+describe("command palette global shortcut", () => {
+  test("modifier-K wins over focused interactive targets", () => {
+    for (const modifiers of [
+      { metaKey: true, ctrlKey: false },
+      { metaKey: false, ctrlKey: true },
+    ]) {
+      expect(
+        shouldOpenCommandPalette({
+          key: "k",
+          ...modifiers,
+          altKey: false,
+          shiftKey: false,
+          interactiveTarget: true,
+          modalOpen: false,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  test("bare slash defers to interactive targets and every shortcut defers to an open modal", () => {
+    expect(
+      shouldOpenCommandPalette({
+        key: "/",
+        metaKey: false,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+        interactiveTarget: false,
+        modalOpen: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldOpenCommandPalette({
+        key: "/",
+        metaKey: false,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+        interactiveTarget: true,
+        modalOpen: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldOpenCommandPalette({
+        key: "k",
+        metaKey: true,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+        interactiveTarget: false,
+        modalOpen: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("uses a non-deprecated user-agent hint for the primary modifier", () => {
+    expect(paletteShortcutLabel("Mozilla/5.0 (Macintosh; Intel Mac OS X)")).toBe("⌘K");
+    expect(paletteShortcutLabel("Mozilla/5.0 (Windows NT 10.0; Win64; x64)")).toBe("Ctrl K");
+  });
+});
+
+describe("command palette recent searches", () => {
+  test("trims, deduplicates, bounds, and rejects malformed storage values", () => {
+    expect(normalizeRecentSearches({ nope: true })).toEqual([]);
+    expect(normalizeRecentSearches([" cache ", "", "cache", 4, "tools"], " new query ")).toEqual([
+      "new query",
+      "cache",
+      "tools",
+    ]);
+    expect(normalizeRecentSearches(Array.from({ length: 12 }, (_, index) => `q${index}`))).toEqual(
+      Array.from({ length: 8 }, (_, index) => `q${index}`),
+    );
+    expect(normalizeRecentSearches(["x".repeat(300)])[0]).toHaveLength(160);
+  });
+});

--- a/test/ui-fuzzy.test.ts
+++ b/test/ui-fuzzy.test.ts
@@ -1,0 +1,448 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createSessionSearchIndex,
+  SESSION_FUZZY_RANK_LIMIT,
+  type SessionSearchIndexRow,
+} from "../src/ui/fuzzy.ts";
+
+const sessions: SessionSearchIndexRow[] = [
+  {
+    id: 41,
+    title: "Fix schema migration",
+    project: "/workspace/decant",
+    tool: "codex",
+    model: "gpt-5.6",
+    started_at: "2026-07-29T12:00:00Z",
+  },
+  {
+    id: 42,
+    title: "Investigate analytics regression",
+    project: "/workspace/decant",
+    tool: "claude_code",
+    model: "claude-opus-4-1",
+    started_at: "2026-07-29T11:00:00Z",
+  },
+  {
+    id: 43,
+    title: "Archive session state",
+    project: "/workspace/other",
+    tool: "codex",
+    model: "gpt-5.6",
+    started_at: "2026-07-28T18:00:00Z",
+  },
+];
+
+describe("session fuzzy search", () => {
+  test("returns ranked session ids and field-local highlight ranges", () => {
+    const index = createSessionSearchIndex(sessions);
+
+    expect(index.search("schema")).toEqual([
+      {
+        id: 41,
+        highlights: {
+          title: [[4, 10]],
+        },
+      },
+    ]);
+    expect(index.search("workspace other")).toEqual([
+      {
+        id: 43,
+        highlights: {
+          project: [
+            [1, 10],
+            [11, 16],
+          ],
+        },
+      },
+    ]);
+  });
+
+  test("tolerates one internal typo and keeps ranges safe for React text slicing", () => {
+    const index = createSessionSearchIndex(sessions);
+    const [match] = index.search("schma");
+
+    expect(match).toEqual({
+      id: 41,
+      highlights: {
+        title: [[4, 10]],
+      },
+    });
+    for (const [field, ranges] of Object.entries(match?.highlights ?? {})) {
+      const value = sessions[0]?.[field as keyof SessionSearchIndexRow];
+      expect(typeof value).toBe("string");
+      for (const [start, end] of ranges ?? []) {
+        expect(start).toBeGreaterThanOrEqual(0);
+        expect(end).toBeGreaterThan(start);
+        expect(end).toBeLessThanOrEqual((value as string).length);
+      }
+    }
+  });
+
+  test("reuses an index across narrowing, replacement, blank, and limited searches", () => {
+    const index = createSessionSearchIndex(sessions);
+
+    expect(index.size).toBe(3);
+    expect(index.search("decant").map((match) => match.id)).toEqual([41, 42]);
+    expect(index.search("analytics decant").map((match) => match.id)).toEqual([42]);
+    expect(index.search("archive").map((match) => match.id)).toEqual([43]);
+    expect(index.search("   ")).toEqual([]);
+    expect(index.search("codex", 1)).toHaveLength(1);
+    expect(index.search("codex", 0)).toEqual([]);
+    expect(
+      index
+        .search("codex gpt")
+        .map((match) => match.id)
+        .sort(),
+    ).toEqual([41, 43]);
+  });
+
+  test("handles nullable fields without indexing placeholder markup", () => {
+    const index = createSessionSearchIndex([
+      {
+        id: 99,
+        title: null,
+        project: null,
+        tool: "codex",
+        model: null,
+        started_at: null,
+      },
+    ]);
+
+    expect(index.search("codex")).toEqual([
+      {
+        id: 99,
+        highlights: {
+          tool: [[0, 5]],
+        },
+      },
+    ]);
+    expect(index.search("null")).toEqual([]);
+  });
+
+  test("uses endpoint order as the deterministic tiebreaker", () => {
+    const tied = {
+      title: "Same exact title",
+      project: "/workspace/decant",
+      tool: "codex",
+      model: "gpt-5.6",
+      started_at: "2026-07-29T12:00:00Z",
+    };
+    const index = createSessionSearchIndex([
+      { ...tied, id: 71 },
+      { ...tied, id: 72 },
+    ]);
+
+    expect(index.search("same exact").map((match) => match.id)).toEqual([71, 72]);
+  });
+
+  test("does not reuse a narrower typo candidate set for a longer non-monotonic match", () => {
+    const index = createSessionSearchIndex([
+      {
+        id: 1,
+        title: "cache",
+        project: null,
+        tool: "codex",
+        model: null,
+        started_at: null,
+      },
+    ]);
+
+    expect(index.search("cah")).toEqual([]);
+    expect(index.search("cahe").map((match) => match.id)).toEqual([1]);
+  });
+
+  test("bounds expensive ranking work for broad matches while keeping newest endpoint order", () => {
+    const rows = Array.from(
+      { length: SESSION_FUZZY_RANK_LIMIT + 200 },
+      (_, index): SessionSearchIndexRow => ({
+        id: index,
+        title: `Codex session ${index}`,
+        project: "/workspace/decant",
+        tool: "codex",
+        model: "gpt-5.6",
+        started_at: "2026-07-29T12:00:00Z",
+      }),
+    );
+
+    expect(
+      createSessionSearchIndex(rows)
+        .search("codex", 10)
+        .map((match) => match.id),
+    ).toEqual(Array.from({ length: 10 }, (_, index) => index));
+  });
+
+  test("keeps the globally strongest match when it falls beyond the work cap", () => {
+    const typoRows = Array.from(
+      { length: SESSION_FUZZY_RANK_LIMIT },
+      (_, index): SessionSearchIndexRow => ({
+        id: index,
+        title: "schma",
+        project: null,
+        tool: "codex",
+        model: null,
+        started_at: null,
+      }),
+    );
+    const exact = {
+      id: SESSION_FUZZY_RANK_LIMIT,
+      title: "schema",
+      project: null,
+      tool: "codex",
+      model: null,
+      started_at: null,
+    } satisfies SessionSearchIndexRow;
+
+    expect(createSessionSearchIndex([...typoRows, exact]).search("schema", 3)[0]?.id).toBe(
+      exact.id,
+    );
+  });
+
+  test("elevates dense phrase matches before bounding out-of-order ranking", () => {
+    const noisyRows = Array.from(
+      { length: 100 },
+      (_, index): SessionSearchIndexRow => ({
+        id: index,
+        title: `alpha ${"noise ".repeat(20)}beta`,
+        project: null,
+        tool: "codex",
+        model: null,
+        started_at: null,
+      }),
+    );
+    const dense = {
+      id: 100,
+      title: "alpha beta",
+      project: null,
+      tool: "codex",
+      model: null,
+      started_at: null,
+    } satisfies SessionSearchIndexRow;
+
+    expect(createSessionSearchIndex([...noisyRows, dense]).search("alpha beta", 10)[0]?.id).toBe(
+      dense.id,
+    );
+  });
+
+  test("preserves whole-token quality before bounding single-term ranking", () => {
+    const embeddedRows = Array.from(
+      { length: 100 },
+      (_, index): SessionSearchIndexRow => ({
+        id: index,
+        title: "xschma",
+        project: null,
+        tool: "codex",
+        model: null,
+        started_at: null,
+      }),
+    );
+    const bounded = {
+      id: 100,
+      title: "schma x",
+      project: null,
+      tool: "codex",
+      model: null,
+      started_at: null,
+    } satisfies SessionSearchIndexRow;
+
+    expect(createSessionSearchIndex([...embeddedRows, bounded]).search("schma", 3)[0]?.id).toBe(
+      bounded.id,
+    );
+
+    const embeddedMultiTermRows = embeddedRows.map((row) => ({
+      ...row,
+      title: "xbeta alpha",
+    }));
+    expect(
+      createSessionSearchIndex([
+        ...embeddedMultiTermRows,
+        { ...bounded, title: "beta alpha x" },
+      ]).search("alpha beta", 3)[0]?.id,
+    ).toBe(bounded.id);
+
+    const letterPrefixed = embeddedRows.map((row) => ({ ...row, title: "xalpha" }));
+    expect(
+      createSessionSearchIndex([...letterPrefixed, { ...bounded, title: "—alpha" }]).search(
+        "alpha",
+        3,
+      )[0]?.id,
+    ).toBe(bounded.id);
+  });
+
+  test("does not drop a fuzzy multi-term match when exact candidates cross the work cap", () => {
+    const unrelated = (count: number): SessionSearchIndexRow[] =>
+      Array.from({ length: count }, (_, index) => ({
+        id: index,
+        title: `migration unrelated-${index}`,
+        project: null,
+        tool: "codex",
+        model: null,
+        started_at: null,
+      }));
+    const typoMatch = {
+      id: 100,
+      title: "migrtion schema",
+      project: null,
+      tool: "codex",
+      model: null,
+      started_at: null,
+    } satisfies SessionSearchIndexRow;
+
+    expect(
+      createSessionSearchIndex([...unrelated(39), typoMatch]).search("migration schema", 10)[0]?.id,
+    ).toBe(typoMatch.id);
+    expect(
+      createSessionSearchIndex([...unrelated(40), typoMatch]).search("migration schema", 10)[0]?.id,
+    ).toBe(typoMatch.id);
+  });
+
+  test("matches multiple terms independently of field or query order", () => {
+    const index = createSessionSearchIndex([
+      {
+        id: 1,
+        title: "Archive session state",
+        project: "/workspace/decant",
+        tool: "codex",
+        model: "gpt-5.6",
+        started_at: "2026-07-29T12:00:00Z",
+      },
+    ]);
+
+    expect(index.search("archive codex").map((match) => match.id)).toEqual([1]);
+    expect(index.search("codex archive").map((match) => match.id)).toEqual([1]);
+  });
+
+  test("matches and highlights Unicode titles without HTML conversion", () => {
+    const index = createSessionSearchIndex([
+      {
+        id: 1,
+        title: "認証フローを修正",
+        project: null,
+        tool: "codex",
+        model: null,
+        started_at: null,
+      },
+      {
+        id: 2,
+        title: "Исправить поиск",
+        project: null,
+        tool: "codex",
+        model: null,
+        started_at: null,
+      },
+      {
+        id: 3,
+        title: "Café diagnostics",
+        project: null,
+        tool: "codex",
+        model: null,
+        started_at: null,
+      },
+    ]);
+
+    expect(index.search("認証")).toEqual([{ id: 1, highlights: { title: [[0, 2]] } }]);
+    expect(index.search("поиск")).toEqual([{ id: 2, highlights: { title: [[10, 15]] } }]);
+    expect(index.search("Café")).toEqual([{ id: 3, highlights: { title: [[0, 4]] } }]);
+  });
+
+  test("matches canonically equivalent Unicode while preserving original UTF-16 offsets", () => {
+    const index = createSessionSearchIndex([
+      {
+        id: 1,
+        title: "Cafe\u0301 diagnostics",
+        project: null,
+        tool: "codex",
+        model: null,
+        started_at: null,
+      },
+      {
+        id: 2,
+        title: "Café diagnostics",
+        project: null,
+        tool: "codex",
+        model: null,
+        started_at: null,
+      },
+    ]);
+
+    expect(index.search("Café")).toEqual([
+      { id: 1, highlights: { title: [[0, 5]] } },
+      { id: 2, highlights: { title: [[0, 4]] } },
+    ]);
+    expect(index.search("Cafe\u0301")).toEqual([
+      { id: 1, highlights: { title: [[0, 5]] } },
+      { id: 2, highlights: { title: [[0, 4]] } },
+    ]);
+  });
+
+  test("keeps a realistic repetitive 5,000-row query within an interactive budget", () => {
+    const rows = Array.from(
+      { length: 5_000 },
+      (_, index): SessionSearchIndexRow => ({
+        id: index,
+        title: `Review feature branch ${index}`,
+        project: "/workspace/decant",
+        tool: "codex",
+        model: "gpt-5.6",
+        started_at: "2026-07-29T12:00:00Z",
+      }),
+    );
+    const index = createSessionSearchIndex(rows);
+    const startedAt = performance.now();
+
+    expect(index.search("review feature branch 499", 10).length).toBeGreaterThan(0);
+    expect(performance.now() - startedAt).toBeLessThan(250);
+  });
+
+  test("bounds out-of-order permutations before ranking a repetitive 5,000-row corpus", () => {
+    const rows = Array.from(
+      { length: 5_000 },
+      (_, index): SessionSearchIndexRow => ({
+        id: index,
+        title: `Review feature branch ${index}`,
+        project: "/workspace/decant",
+        tool: "codex",
+        model: "gpt-5.6",
+        started_at: "2026-07-29T12:00:00Z",
+      }),
+    );
+    const index = createSessionSearchIndex(rows);
+    const startedAt = performance.now();
+
+    expect(index.search("branch review feature", 10).map((match) => match.id)).toEqual(
+      Array.from({ length: 10 }, (_, rowIndex) => rowIndex),
+    );
+    expect(performance.now() - startedAt).toBeLessThan(250);
+  });
+
+  test("avoids factorial ranking and preserves highlights for long reversed queries", () => {
+    const rows = Array.from(
+      { length: 5_000 },
+      (_, index): SessionSearchIndexRow => ({
+        id: index,
+        title: `one two three four five six session ${index}`,
+        project: "/workspace/decant",
+        tool: "codex",
+        model: "gpt-5.6",
+        started_at: "2026-07-29T12:00:00Z",
+      }),
+    );
+    const index = createSessionSearchIndex(rows);
+    const startedAt = performance.now();
+    const matches = index.search("six five four three two one", 10);
+
+    expect(matches[0]).toEqual({
+      id: 0,
+      highlights: {
+        title: [
+          [0, 3],
+          [4, 7],
+          [8, 13],
+          [14, 18],
+          [19, 23],
+          [24, 27],
+        ],
+      },
+    });
+    expect(performance.now() - startedAt).toBeLessThan(250);
+  });
+});

--- a/test/ui-interaction-contracts.test.ts
+++ b/test/ui-interaction-contracts.test.ts
@@ -35,6 +35,56 @@ describe("UI interaction contracts", () => {
     expect(search).toContain("aria-selected={index === activeIndex}");
   });
 
+  test("keeps fast transcript search scoped and settles totals without replacing results", () => {
+    const search = sourceBetween("function SearchView(", "function groupSearchHits(");
+    const fastRequest = search.slice(
+      search.indexOf("include_total: false"),
+      search.indexOf("include_total: true"),
+    );
+
+    expect(search).toContain("searchRequestScope(path, { from: rangeFrom, to: rangeTo })");
+    expect(search).toContain("include_total: false");
+    expect(search).toContain("include_total: true");
+    expect(search).toContain("setTotal(response.total)");
+    expect(fastRequest).not.toContain("setTotal(response.total)");
+    expect(fastRequest).not.toContain("setTotalIsCapped(response.total_is_capped)");
+    expect(search).toContain("A count is supplementary");
+    expect(search).toContain("total == null");
+  });
+
+  test("opens one focus-managed palette from desktop, mobile, and global shortcuts", () => {
+    const app = sourceBetween("function App()", "function renderView(");
+    const palette = sourceBetween(
+      "function CommandPalette(",
+      "function commandPaletteTextMatches(",
+    );
+
+    expect(app).toContain("shouldOpenCommandPalette({");
+    expect(app).toContain("setCommandPaletteOpen(true)");
+    expect(app).not.toContain("getClientRects().length === 0");
+    expect(app).toContain('className="topbar-search"');
+    expect(app).toContain('className="icon-button topbar-search-mobile"');
+    expect(palette).toContain("createPortal(");
+    expect(palette).toContain("useDialogFocusTrap(open, dialogRef, requestClose)");
+    expect(palette).toContain('aria-modal="true"');
+    expect(palette).toContain('role="dialog"');
+    expect(palette).toContain('role="combobox"');
+    expect(palette).toContain('role="listbox"');
+    expect(palette).toContain('role="option"');
+    expect(palette).toContain("<fieldset");
+    expect(palette).toContain("<legend");
+    expect(palette).toContain('group.label ?? "Transcript search"');
+    expect(palette).toContain("aria-activedescendant={activeDescendant}");
+    expect(palette).toContain("flattenCommandPaletteItems(groups)");
+    expect(palette).toContain("onPointerMove");
+    expect(palette).toContain("setActiveIndex(index)");
+    expect(palette).toContain("setActiveIndex(0)");
+    expect(palette).toContain("item.highlights?.started_at");
+    expect(palette).not.toContain("dangerouslySetInnerHTML");
+    expect(app).toContain('aria-haspopup="dialog"');
+    expect(app).toContain("aria-expanded={commandPaletteOpen}");
+  });
+
   test("exposes tool-call details as a focus-managed modal with a keyboard entry point", () => {
     const detail = sourceBetween("function ToolCallDetail(", "function ToolsView(");
     const tools = sourceBetween("function ToolsView(", "function FilesView(");

--- a/test/ui-interaction-contracts.test.ts
+++ b/test/ui-interaction-contracts.test.ts
@@ -50,7 +50,10 @@ describe("UI interaction contracts", () => {
     expect(fastRequest).not.toContain("setTotal(response.total)");
     expect(fastRequest).not.toContain("setTotalIsCapped(response.total_is_capped)");
     expect(search).toContain("A count is supplementary");
-    expect(search).toContain("total == null");
+    expect(search).toContain("searchPageMayHaveMore");
+    expect(search).toContain("total: totalRef.current");
+    expect(search).toContain("exactSearchRemaining(total, hits.length, totalIsCapped)");
+    expect(search).not.toContain("total == null || hits.length >= total");
   });
 
   test("opens one focus-managed palette from desktop, mobile, and global shortcuts", () => {
@@ -88,11 +91,13 @@ describe("UI interaction contracts", () => {
     expect(palette).toContain("searchRouteHref(normalizedQuery, locationPath())");
     expect(palette).toContain("dialogRef.current");
     expect(palette).not.toContain("document\n      .querySelector<HTMLElement>");
-    expect(paletteGroups).toContain("onPointerEnter");
-    expect(paletteGroups).not.toContain("onPointerMove");
+    expect(paletteGroups).not.toContain("onPointerEnter");
+    expect(paletteGroups).toContain("onPointerMove");
+    expect(paletteGroups).toContain("pointerMovementChangesSelection(event)");
     expect(paletteGroups).not.toContain("onKeyDown");
-    expect(palette).toContain("setActiveIndex(index)");
-    expect(palette).toContain("setActiveIndex(0)");
+    expect(palette).toContain("selectPaletteIndex(index)");
+    expect(palette).toContain("reconcileCommandPaletteActiveIndex");
+    expect(palette).toContain("useLayoutEffect(() =>");
     expect(palette).toContain("item.highlights?.started_at");
     expect(palette).not.toContain("dangerouslySetInnerHTML");
     expect(styles).toContain(".command-palette-group-label {");

--- a/test/ui-interaction-contracts.test.ts
+++ b/test/ui-interaction-contracts.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const main = readFileSync(join(import.meta.dir, "..", "src", "ui", "main.tsx"), "utf8");
+const styles = readFileSync(join(import.meta.dir, "..", "src", "ui", "styles.css"), "utf8");
 
 function sourceBetween(start: string, end: string): string {
   const startIndex = main.indexOf(start);
@@ -58,6 +59,10 @@ describe("UI interaction contracts", () => {
       "function CommandPalette(",
       "function commandPaletteTextMatches(",
     );
+    const paletteGroups = palette.slice(
+      palette.indexOf("{groups.map("),
+      palette.indexOf('<footer className="command-palette-footer">'),
+    );
 
     expect(app).toContain("shouldOpenCommandPalette({");
     expect(app).toContain("setCommandPaletteOpen(true)");
@@ -71,16 +76,27 @@ describe("UI interaction contracts", () => {
     expect(palette).toContain('role="combobox"');
     expect(palette).toContain('role="listbox"');
     expect(palette).toContain('role="option"');
-    expect(palette).toContain("<fieldset");
-    expect(palette).toContain("<legend");
+    expect(paletteGroups).toContain('role="group"');
+    expect(paletteGroups).toContain("aria-labelledby={labelId}");
+    expect(paletteGroups).toContain('"command-palette-group-label"');
+    expect(paletteGroups).not.toContain("<fieldset");
+    expect(paletteGroups).not.toContain("<legend");
     expect(palette).toContain('group.label ?? "Transcript search"');
     expect(palette).toContain("aria-activedescendant={activeDescendant}");
     expect(palette).toContain("flattenCommandPaletteItems(groups)");
-    expect(palette).toContain("onPointerMove");
+    expect(palette).toContain("searchRouteHref(recent, locationPath())");
+    expect(palette).toContain("searchRouteHref(normalizedQuery, locationPath())");
+    expect(palette).toContain("dialogRef.current");
+    expect(palette).not.toContain("document\n      .querySelector<HTMLElement>");
+    expect(paletteGroups).toContain("onPointerEnter");
+    expect(paletteGroups).not.toContain("onPointerMove");
+    expect(paletteGroups).not.toContain("onKeyDown");
     expect(palette).toContain("setActiveIndex(index)");
     expect(palette).toContain("setActiveIndex(0)");
     expect(palette).toContain("item.highlights?.started_at");
     expect(palette).not.toContain("dangerouslySetInnerHTML");
+    expect(styles).toContain(".command-palette-group-label {");
+    expect(styles).not.toContain(".command-palette-group legend {");
     expect(app).toContain('aria-haspopup="dialog"');
     expect(app).toContain("aria-expanded={commandPaletteOpen}");
   });

--- a/test/ui-responsive-styles.test.ts
+++ b/test/ui-responsive-styles.test.ts
@@ -56,6 +56,25 @@ describe("responsive session detail styles", () => {
   });
 });
 
+describe("responsive command palette", () => {
+  test("keeps one desktop trigger and exposes the mobile trigger below the breakpoint", () => {
+    expect(rule(".icon-button.topbar-search-mobile")).toContain("display: none");
+    const mobileStart = styles.indexOf("@media (max-width: 767px)");
+    const mobileEnd = styles.indexOf("@media (max-width: 640px)", mobileStart);
+    const mobileRules = styles.slice(mobileStart, mobileEnd);
+    expect(mobileRules).toContain(".topbar-search");
+    expect(mobileRules).toContain("display: none");
+    expect(mobileRules).toContain(".icon-button.topbar-search-mobile");
+    expect(mobileRules).toContain("display: inline-grid");
+  });
+
+  test("bounds the modal to the dynamic viewport and scrolls its results independently", () => {
+    expect(rule(".command-palette")).toContain("100dvh");
+    expect(rule(".command-palette")).toContain("overflow: hidden");
+    expect(rule(".command-palette-results")).toContain("overflow-y: auto");
+  });
+});
+
 describe("responsive Dosu surfaces", () => {
   test("aligns sidebar metadata and attribution to the same icon column", () => {
     expect(rule(".sidebar-stat")).toContain("grid-template-columns: 18px minmax(0, 1fr)");

--- a/test/ui-search-pagination.test.ts
+++ b/test/ui-search-pagination.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { exactSearchRemaining, searchPageMayHaveMore } from "../src/ui/search-pagination.ts";
+
+describe("search pagination availability", () => {
+  test("uses a known total when the supplementary count succeeds", () => {
+    expect(searchPageMayHaveMore({ lastPageSize: 25, loaded: 25, pageSize: 25, total: 26 })).toBe(
+      true,
+    );
+    expect(searchPageMayHaveMore({ lastPageSize: 25, loaded: 25, pageSize: 25, total: 25 })).toBe(
+      false,
+    );
+  });
+
+  test("keeps pagination available from a full page when the count is unavailable", () => {
+    expect(searchPageMayHaveMore({ lastPageSize: 25, loaded: 25, pageSize: 25, total: null })).toBe(
+      true,
+    );
+    expect(searchPageMayHaveMore({ lastPageSize: 7, loaded: 32, pageSize: 25, total: null })).toBe(
+      false,
+    );
+  });
+
+  test("continues past a capped total until a short page proves the end", () => {
+    expect(
+      searchPageMayHaveMore({
+        lastPageSize: 25,
+        loaded: 1_000,
+        pageSize: 25,
+        total: 1_000,
+        totalIsCapped: true,
+      }),
+    ).toBe(true);
+    expect(
+      searchPageMayHaveMore({
+        lastPageSize: 7,
+        loaded: 1_007,
+        pageSize: 25,
+        total: 1_000,
+        totalIsCapped: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("never presents a capped count as an exact remaining count", () => {
+    expect(exactSearchRemaining(1_000, 1_000, true)).toBeNull();
+    expect(exactSearchRemaining(1_000, 1_025, true)).toBeNull();
+    expect(exactSearchRemaining(30, 25, false)).toBe(5);
+  });
+});

--- a/test/ui-search-request.test.ts
+++ b/test/ui-search-request.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { searchRequestScope, searchRouteHref } from "../src/ui/search-request.ts";
+
+describe("search request scope", () => {
+  test("includes the active date range and supported URL filters", () => {
+    expect(
+      searchRequestScope("/search?q=cache&tool=codex&project=%2Fwork%2Fdecant", {
+        from: "2026-07-01",
+        to: "2026-07-29",
+      }),
+    ).toEqual({
+      from: "2026-07-01",
+      project: "/work/decant",
+      to: "2026-07-29",
+      tool: "codex",
+    });
+  });
+
+  test("omits blank filters and does not forward unrelated query parameters", () => {
+    expect(
+      searchRequestScope("/search?q=cache&tool=&project=&model=gpt-5", {
+        from: null,
+        to: null,
+      }),
+    ).toEqual({});
+  });
+
+  test("preserves search-page tool and project filters while the query changes", () => {
+    const path = "/search?q=old&tool=codex&project=%2Fwork%2Fdecant&ignored=yes";
+
+    expect(searchRouteHref("new query", path)).toBe(
+      "/search?tool=codex&project=%2Fwork%2Fdecant&q=new+query",
+    );
+    expect(searchRouteHref("", path)).toBe("/search?tool=codex&project=%2Fwork%2Fdecant");
+    expect(searchRouteHref("new query", "/sessions")).toBe("/search?q=new+query");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds one responsive, focus-managed command palette for keyboard, desktop, and mobile navigation, actions, recent searches, and session lookup.
- Adds a lightweight visibility-aware `/api/sessions/search-index` endpoint plus bounded uFuzzy matching with typo tolerance, order-independent terms, Unicode normalization, deterministic ranking, and field-local highlights.
- Keeps transcript search responsive by separating fast result retrieval from delayed totals while preserving tool, project, and date scope.

## Why

This is PR5 of the UX and API hardening plan. It makes navigation and local archive search fast from anywhere without weakening archive visibility rules or putting transcript contents into the session index.

Stacked on #77 because the index must respect durable archive visibility. Keep this PR in draft until the stack lands.

## Validation

- [x] `just check` passes: 718 tests, TypeScript, Biome, and distribution staging smoke.
- [x] New behavior has focused tests. No existing test was weakened or deleted to make this pass.
- [x] Three independent adversarial review passes are clean after reproducing and fixing ranking, performance, Unicode, request-validation, race, accessibility, and responsive-layout findings.
- [x] Rendered at 1440x1000 and mobile widths in light and dark themes; keyboard selection, focus restoration, named listbox groups, date highlights, responsive layout, and scoped fast/count requests were verified with zero console errors.
- [x] Ten fresh-process 5,000-row reversed-query runs completed in 30.8-61.0 ms.

## Archive schema

The baseline is `LATEST_SCHEMA_VERSION` in `src/db.ts`. Check one:

- [x] This change does not touch the archive schema.
- [ ] This change bumps the schema. It ships the migration, and the summary above says what happens to archives created before it.