### PR TITLE
feat: document and harden local API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,13 +13,16 @@ full-text-searchable SQLite archive (WAL + FTS5).
 The repo is now a single Bun + TypeScript app. The same `decant` CLI owns
 parsing, ingest, reads, distillation, recommendations, watch mode, and the local
 React web UI served by `decant serve`. There is no Rust daemon, Phoenix app,
-Swift menu bar app, bearer token, or cross-process OpenAPI contract on mainline.
-The pre-cutover tree is preserved in the signed `pre-typescript` tag.
+Swift menu bar app, bearer token, hosted service, or separate API process on
+mainline. The local serve API is documented with OpenAPI but remains part of the
+one Decant process. The pre-cutover tree is preserved in the signed
+`pre-typescript` tag.
 
 ## Layout
 
 Start from `src/cli.ts`; parsers live in `src/sources/` (the extension
-point). Docs: `docs/api/routes.md` (serve routes), `docs/distribution.md`
+point). Docs: `docs/api/openapi.yaml` (local API contract),
+`docs/api/routes.md` (serve semantics), `docs/distribution.md`
 (npm/installer/Docker/source), and `docs/releasing.md` (release operations).
 
 ## Setup
@@ -94,23 +97,27 @@ A change is ready when:
    background daemon, token/lock file, or second app that opens the DB behind a
    separate contract.
 3. **Local-first only.** No outbound network calls, no hosted service dependency,
-   and no LLM calls. The only networking is the loopback UI/API served by
-   `decant serve`.
+   and no LLM calls. The only networking is the local UI/API served by
+   `decant serve`, bound to loopback by default; non-loopback exposure requires
+   an explicit host bind and trusted-peer configuration.
 4. **Costs are computed at ingest** with `cost::estimateCost` and stored on the
    session row. Editing pricing does not rewrite historical rows; rebuild the
    archive to recompute.
-5. **The schema baseline is v19.** Pre-v8 archives are intentionally rebuild-only:
+5. **The schema baseline is v20.** Pre-v8 archives are intentionally rebuild-only:
    delete the archive and re-ingest from the source directories. Do not add
    broad forward migrations unless that product decision changes; the narrow
-   v8-to-v19 migrations preserve existing TypeScript-cutover archives. A
+   v8-to-v20 migrations preserve existing TypeScript-cutover archives. A
    migration is frozen as soon as it is committed to a branch because a
    dogfooding archive may already have run it. During review, put any schema
    adjustment in a new version; never edit a committed migration.
 6. **Parsers are the extension point.** A new source tool means
    `src/sources/<tool>.ts`, synthetic fixtures, parser tests, ingest/query tests,
    and golden updates.
-7. **Serve routes are internal app routes.** `docs/api/routes.md` is a reference,
-   not a versioned public contract.
+7. **Serve routes are a documented local API.** `docs/api/openapi.yaml` is the
+   reference contract and `/api/openapi.json` is its runtime representation.
+   Keep the spec, route behavior, and contract tests in sync. This remains a
+   local-first API inside the one Decant process, not a hosted service, daemon,
+   bearer-token boundary, or separate cross-process server.
 
 ## Security and data privacy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY package.json bun.lock tsconfig.json ./
 COPY npm ./npm
 COPY scripts ./scripts
 COPY src ./src
+COPY docs/api/openapi.yaml ./docs/api/openapi.yaml
 
 RUN bun install --frozen-lockfile
 

--- a/README.md
+++ b/README.md
@@ -169,11 +169,33 @@ means no gateway is derived.
 deliberately want other hosts in: the `Host` header check is not an access
 control for non-browser clients, which can send `Host: localhost` freely.
 
-Archives older than schema v8 are rebuild-only. v8 through v14 archives migrate
-forward to v15 on open; the next `decant sync` backfills persisted economics
+Archives older than schema v8 are rebuild-only. v8 through v19 archives migrate
+forward to v20 on open; the next `decant sync` backfills persisted economics
 vectors and context-window rollups for unchanged sessions. Older archives should
 be deleted and rebuilt with `decant sync`. Source logs remain the source of
 truth, so nothing is lost by rebuilding.
+
+## Integrating with Decant
+
+`decant serve` exposes a documented local API at
+`http://127.0.0.1:3000/api`. It has no authentication on the default loopback
+listener, so any local process can read or mutate the archive. Keep the listener
+on loopback unless you have deliberately configured the trusted-peer boundary
+described under [Configuration](#configuration).
+
+The source OpenAPI 3.1 contract is
+[docs/api/openapi.yaml](docs/api/openapi.yaml). A running server exposes the
+same contract as JSON at `http://127.0.0.1:3000/api/openapi.json`.
+
+For example, read the archive summary:
+
+```bash
+curl --fail --silent --show-error \
+  http://127.0.0.1:3000/api/stats/summary
+```
+
+See [docs/api/routes.md](docs/api/routes.md) for local access-control semantics,
+write-request requirements, and Server-Sent Event names.
 
 ## How It Works
 
@@ -188,11 +210,13 @@ truth, so nothing is lost by rebuilding.
         +--> local React UI + JSON routes + SSE
 ```
 
-There is no background daemon and no cross-process API contract. The old
+There is no background daemon or separate service process. The old
 Rust/Phoenix/Swift implementation is preserved in the signed `pre-typescript`
 tag.
 
-Route reference for the local UI lives in [docs/api/routes.md](docs/api/routes.md).
+The local API contract lives in
+[docs/api/openapi.yaml](docs/api/openapi.yaml), with operational semantics in
+[docs/api/routes.md](docs/api/routes.md).
 Operational log fields and privacy rules live in [docs/logging.md](docs/logging.md).
 Distribution notes live in [docs/distribution.md](docs/distribution.md), and the
 tag-driven release pipeline is documented in

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,2832 @@
+openapi: 3.1.0
+jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
+info:
+  title: Decant Local API
+  version: 0.0.0-dev
+  description: |
+    The local API served by `decant serve`. Decant does not provide a hosted
+    service and this API has no authentication layer: any process or trusted
+    peer that can reach the listener can read or mutate the local archive.
+
+    The default listener is loopback-only. When Decant is bound to a
+    non-loopback host, requests are admitted only from loopback or from peers
+    selected by the trusted-peer precedence documented in `docs/api/routes.md`.
+    Browser-origin checks protect mutating routes from cross-site requests but
+    are not authentication for non-browser clients.
+servers:
+  - url: http://127.0.0.1:3000
+    description: Default loopback listener
+security: []
+x-access-control:
+  authentication: none
+  default_bind: 127.0.0.1
+  trusted_peer_precedence:
+    - serve --trusted-peer
+    - DECANT_TRUSTED_PEERS
+    - DECANT_TRUST_DEFAULT_GATEWAY=1
+  precedence_mode: replace
+  host_header: The request URL hostname must be loopback, even on a non-loopback bind.
+  non_loopback_writes: |
+    A trusted non-loopback peer must also send a loopback Origin or acceptable
+    Sec-Fetch-Site value; writes with neither header are rejected.
+  cidr_support: IPv4 CIDRs and exact IPv4 or IPv6 peer addresses.
+  warning: Any admitted client can read or mutate the entire local archive.
+tags:
+  - name: System
+  - name: Settings
+  - name: Launch
+  - name: Sync
+  - name: Sessions
+  - name: Search
+  - name: Statistics
+  - name: Analytics
+  - name: Reports
+  - name: Files
+  - name: Tools
+  - name: Recommendations
+
+paths:
+  /api/health:
+    get:
+      tags: [System]
+      operationId: getHealth
+      summary: Check whether the local HTTP handler is available
+      responses:
+        "200":
+          description: Healthy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Health"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/events:
+    get:
+      tags: [System]
+      operationId: streamEvents
+      summary: Stream archive, watcher, and sync events
+      description: |
+        Server-Sent Events. Each frame uses its event name in the `event:`
+        field and a JSON object matching the corresponding schema in `data:`.
+        The connection begins with `hello`; `ping` is normally emitted every
+        five seconds.
+      x-sse-events:
+        hello:
+          $ref: "#/components/schemas/HelloEvent"
+        ping:
+          $ref: "#/components/schemas/PingEvent"
+        ready:
+          $ref: "#/components/schemas/WatchReadyEvent"
+        sync_progress:
+          $ref: "#/components/schemas/SyncProgressEvent"
+        sync:
+          $ref: "#/components/schemas/SyncEvent"
+        archive_updated:
+          $ref: "#/components/schemas/ArchiveUpdatedEvent"
+        error:
+          $ref: "#/components/schemas/SyncErrorEvent"
+        stopped:
+          $ref: "#/components/schemas/WatchStoppedEvent"
+      responses:
+        "200":
+          description: Open SSE stream
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+              example: no-cache
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/openapi.json:
+    get:
+      tags: [System]
+      operationId: getOpenApiDocument
+      summary: Read this API description as JSON
+      responses:
+        "200":
+          description: OpenAPI 3.1 document with the running Decant version
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpenApiDocument"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/config:
+    get:
+      tags: [System]
+      operationId: getConfig
+      summary: Read resolved local archive and source paths
+      description: The returned paths are local filesystem metadata and may be sensitive.
+      responses:
+        "200":
+          description: Resolved runtime configuration
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Config"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/settings:
+    get:
+      tags: [Settings]
+      operationId: getSettings
+      summary: Read sanitized user settings and available choices
+      responses:
+        "200":
+          description: Settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SettingsResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+    post:
+      tags: [Settings]
+      operationId: updateSettings
+      summary: Persist recognized user settings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserSettingsPatch"
+      responses:
+        "200":
+          description: Saved settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SettingsSavedResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/launch/agent:
+    post:
+      tags: [Launch]
+      operationId: launchAgent
+      summary: Open a configured terminal agent with a prompt
+      description: Launching is supported only on macOS; failures include a copyable command when possible.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AgentLaunchRequest"
+      responses:
+        "200":
+          description: Launch accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LaunchResult"
+        "400":
+          description: Invalid request, unsupported platform, or launch failure
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LaunchError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/launch/ide:
+    post:
+      tags: [Launch]
+      operationId: launchIde
+      summary: Open a local project directory in the configured IDE
+      description: Launching is supported only on macOS.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IdeLaunchRequest"
+      responses:
+        "200":
+          description: Launch accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LaunchResult"
+        "400":
+          description: Invalid request, unsupported platform, missing directory, or launch failure
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LaunchError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/sync-status:
+    get:
+      tags: [Sync]
+      operationId: getSyncStatus
+      summary: Read current sync status
+      responses:
+        "200":
+          description: Sync status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SyncStatusResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/metadata/sync-status:
+    get:
+      tags: [Sync]
+      operationId: getMetadataSyncStatus
+      summary: Read current sync status through the metadata alias
+      responses:
+        "200":
+          description: Sync status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SyncStatusResponse"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/sync:
+    post:
+      tags: [Sync]
+      operationId: runSync
+      summary: Scan configured sources and ingest changes
+      description: "Works even when the server was started with `--no-sync`."
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+      responses:
+        "200":
+          description: Completed or joined sync report
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SyncReport"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/sessions:
+    get:
+      tags: [Sessions]
+      operationId: listSessions
+      summary: List visible sessions newest first
+      parameters:
+        - $ref: "#/components/parameters/FromDate"
+        - $ref: "#/components/parameters/ToDate"
+        - $ref: "#/components/parameters/Tool"
+        - $ref: "#/components/parameters/Model"
+        - $ref: "#/components/parameters/Project"
+        - $ref: "#/components/parameters/IncludeSubagents"
+        - $ref: "#/components/parameters/WithSubagents"
+        - $ref: "#/components/parameters/IncludeArchived"
+        - $ref: "#/components/parameters/SessionLimit"
+        - $ref: "#/components/parameters/Offset"
+      responses:
+        "200":
+          description: Session summaries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SessionSummary"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/sessions/search-index:
+    get:
+      tags: [Sessions]
+      operationId: getSessionSearchIndex
+      summary: Read lightweight metadata for client-side fuzzy search
+      description: Returns every visible non-archived session, including subagents, without message data.
+      responses:
+        "200":
+          description: Stable newest-first search index
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SessionSearchIndexRow"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/sessions/{id}:
+    parameters:
+      - $ref: "#/components/parameters/SessionId"
+    get:
+      tags: [Sessions]
+      operationId: getSession
+      summary: Read one session, transcript page, and nested subagent structure
+      parameters:
+        - $ref: "#/components/parameters/MessageLimit"
+        - $ref: "#/components/parameters/MessageOffset"
+      responses:
+        "200":
+          description: Session detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionDetail"
+        "400":
+          $ref: "#/components/responses/InvalidSessionId"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/SessionNotFound"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/sessions/{id}/state:
+    parameters:
+      - $ref: "#/components/parameters/SessionId"
+    post:
+      tags: [Sessions]
+      operationId: updateSessionState
+      summary: Archive, delete, or restore one session identity
+      description: |
+        `deleted` persists a tombstone so future syncs cannot resurrect the
+        session. `visible` clears a direct archived/deleted override.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SessionStateRequest"
+      responses:
+        "200":
+          description: Updated session state
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionStateResponse"
+        "400":
+          description: Invalid session id or state
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/SessionNotFound"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/sessions/{id}/outline:
+    parameters:
+      - $ref: "#/components/parameters/SessionId"
+    get:
+      tags: [Sessions]
+      operationId: getSessionOutline
+      summary: Read lightweight prompt and verified Dosu-call anchors
+      responses:
+        "200":
+          description: Ordered outline
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SessionOutlineItem"
+        "400":
+          $ref: "#/components/responses/InvalidSessionId"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/SessionNotFound"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/sessions/{id}/issues:
+    parameters:
+      - $ref: "#/components/parameters/SessionId"
+    get:
+      tags: [Sessions]
+      operationId: getSessionIssues
+      summary: Read ingest diagnostics for a session source
+      description: "`raw_line` may contain private transcript content and must remain local."
+      responses:
+        "200":
+          description: Ingest diagnostics
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SessionIngestIssue"
+        "400":
+          $ref: "#/components/responses/InvalidSessionId"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/SessionNotFound"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/sessions/{id}/token-economics:
+    parameters:
+      - $ref: "#/components/parameters/SessionId"
+    get:
+      tags: [Sessions]
+      operationId: getSessionTokenEconomics
+      summary: Read token, cost, and activity economics for one session
+      responses:
+        "200":
+          description: Session economics
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenEconomics"
+        "400":
+          $ref: "#/components/responses/InvalidSessionId"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/SessionNotFound"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/sessions/{id}/context-window:
+    parameters:
+      - $ref: "#/components/parameters/SessionId"
+    get:
+      tags: [Sessions]
+      operationId: getSessionContextWindow
+      summary: Read context occupancy and compaction events for one session
+      responses:
+        "200":
+          description: Context-window timeline
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ContextWindowTimeline"
+        "400":
+          $ref: "#/components/responses/InvalidSessionId"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/SessionNotFound"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/projects:
+    get:
+      tags: [Sessions]
+      operationId: listProjects
+      summary: List project and worktree rollups
+      responses:
+        "200":
+          description: Projects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProjectSummary"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/search:
+    post:
+      tags: [Search]
+      operationId: searchTranscriptContent
+      summary: Search message and tool-call content with SQLite FTS
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SearchRequest"
+      responses:
+        "200":
+          description: Ranked search page
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchPage"
+        "400":
+          description: Missing query, malformed JSON, or invalid field type/range
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/stats/summary:
+    get:
+      tags: [Statistics]
+      operationId: getStatsSummary
+      summary: Read archive totals
+      parameters:
+        - $ref: "#/components/parameters/FromDate"
+        - $ref: "#/components/parameters/ToDate"
+        - $ref: "#/components/parameters/Project"
+        - $ref: "#/components/parameters/Tool"
+        - $ref: "#/components/parameters/IncludeArchived"
+      responses:
+        "200":
+          description: Totals
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Totals"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/stats/by-dimension:
+    get:
+      tags: [Statistics]
+      operationId: getStatsByDimension
+      summary: Group archive totals by one dimension
+      parameters:
+        - $ref: "#/components/parameters/Dimension"
+        - $ref: "#/components/parameters/FromDate"
+        - $ref: "#/components/parameters/ToDate"
+        - $ref: "#/components/parameters/Project"
+        - $ref: "#/components/parameters/Tool"
+        - $ref: "#/components/parameters/IncludeArchived"
+      responses:
+        "200":
+          description: Dimension rows
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DimensionRow"
+        "400":
+          description: Unknown dimension
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/analytics/activity:
+    get:
+      tags: [Analytics]
+      operationId: getActivityAnalytics
+      summary: Read local-time activity distributions
+      parameters:
+        - $ref: "#/components/parameters/FromDate"
+        - $ref: "#/components/parameters/ToDate"
+      responses:
+        "200":
+          description: Activity distribution
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Activity"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/analytics/model-sparklines:
+    get:
+      tags: [Analytics]
+      operationId: getModelSparklines
+      summary: Read daily session counts by model
+      parameters:
+        - $ref: "#/components/parameters/FromDate"
+        - $ref: "#/components/parameters/ToDate"
+      responses:
+        "200":
+          description: Model sparkline series
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ModelSparklines"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/analytics/token-economics:
+    get:
+      tags: [Analytics]
+      operationId: getTokenEconomics
+      summary: Read archive token, cost, and activity economics
+      parameters:
+        - $ref: "#/components/parameters/FromDate"
+        - $ref: "#/components/parameters/ToDate"
+      responses:
+        "200":
+          description: Archive economics
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenEconomics"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/analytics/now:
+    get:
+      tags: [Analytics]
+      operationId: getNowAnalytics
+      summary: Read today's totals and live sync state
+      responses:
+        "200":
+          description: Current local activity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NowAnalytics"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/reports/analytics.html:
+    get:
+      tags: [Reports]
+      operationId: downloadAnalyticsReport
+      summary: Download a self-contained analytics report
+      parameters:
+        - $ref: "#/components/parameters/FromDate"
+        - $ref: "#/components/parameters/ToDate"
+      responses:
+        "200":
+          description: Zero-JavaScript HTML report with inline styles and SVG
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+              example: attachment; filename="decant-analytics-report.html"
+          content:
+            text/html:
+              schema:
+                type: string
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/reports/session/{id}.html:
+    parameters:
+      - $ref: "#/components/parameters/SessionId"
+    get:
+      tags: [Reports]
+      operationId: downloadSessionReport
+      summary: Download a self-contained session report without transcript content
+      responses:
+        "200":
+          description: Zero-JavaScript HTML report with inline styles and SVG
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+          content:
+            text/html:
+              schema:
+                type: string
+        "400":
+          $ref: "#/components/responses/InvalidSessionId"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/SessionNotFound"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/date-bounds:
+    get:
+      tags: [Statistics]
+      operationId: getDateBounds
+      summary: Read the first and last visible session dates
+      responses:
+        "200":
+          description: Archive date bounds
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DateBounds"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/metadata/date-bounds:
+    get:
+      tags: [Statistics]
+      operationId: getMetadataDateBounds
+      summary: Read archive date bounds through the metadata alias
+      responses:
+        "200":
+          description: Archive date bounds
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DateBounds"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/files:
+    get:
+      tags: [Files]
+      operationId: listFileHotspots
+      summary: List file activity grouped by path or extension
+      parameters:
+        - $ref: "#/components/parameters/FileGroup"
+        - $ref: "#/components/parameters/FileOperation"
+        - $ref: "#/components/parameters/FromDate"
+        - $ref: "#/components/parameters/ToDate"
+        - $ref: "#/components/parameters/FileLimit"
+      responses:
+        "200":
+          description: File activity
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/FileStatRow"
+        "400":
+          description: Invalid group or operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/tools/calls:
+    get:
+      tags: [Tools]
+      operationId: listToolCalls
+      summary: Browse individual tool calls newest first
+      parameters:
+        - $ref: "#/components/parameters/Tool"
+        - $ref: "#/components/parameters/McpServer"
+        - $ref: "#/components/parameters/ErrorsOnly"
+        - $ref: "#/components/parameters/ToolCallSession"
+        - $ref: "#/components/parameters/Project"
+        - $ref: "#/components/parameters/FromDate"
+        - $ref: "#/components/parameters/ToDate"
+        - $ref: "#/components/parameters/MinimumDuration"
+        - $ref: "#/components/parameters/ToolCallLimit"
+        - $ref: "#/components/parameters/Offset"
+      responses:
+        "200":
+          description: Tool-call page; summary is present only on the first page
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolCallPage"
+        "400":
+          description: Invalid session, duration, or boolean filter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/tools/usage:
+    get:
+      tags: [Tools]
+      operationId: getToolUsage
+      summary: Aggregate tool usage and latency by tool identity
+      parameters:
+        - $ref: "#/components/parameters/ErrorsOnly"
+        - $ref: "#/components/parameters/FromDate"
+        - $ref: "#/components/parameters/ToDate"
+        - $ref: "#/components/parameters/UsageLimit"
+      responses:
+        "200":
+          description: Tool usage rows
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ToolStatRow"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/tools/mcp-usage:
+    get:
+      tags: [Tools]
+      operationId: getMcpUsage
+      summary: Aggregate MCP usage and latency by server
+      parameters:
+        - $ref: "#/components/parameters/FromDate"
+        - $ref: "#/components/parameters/ToDate"
+        - $ref: "#/components/parameters/UsageLimit"
+      responses:
+        "200":
+          description: MCP server usage rows
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/McpStatRow"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/recommendations:
+    get:
+      tags: [Recommendations]
+      operationId: listRecommendations
+      summary: List open, implemented, or all recommendations
+      parameters:
+        - $ref: "#/components/parameters/RecommendationStatus"
+      responses:
+        "200":
+          description: Recommendations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Recommendation"
+        "400":
+          description: Unknown status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /api/recommendations/mark:
+    post:
+      tags: [Recommendations]
+      operationId: markRecommendationImplemented
+      summary: Mark a recommendation implemented
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RecommendationMarkRequest"
+      responses:
+        "200":
+          description: Recommendation updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RecommendationMarkResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Recommendation key not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RecommendationNotFoundError"
+        "409":
+          $ref: "#/components/responses/SchemaConflict"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+components:
+  parameters:
+    SessionId:
+      name: id
+      in: path
+      required: true
+      description: Positive, JavaScript-safe session row id
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 9007199254740991
+    FromDate:
+      name: from
+      in: query
+      description: Inclusive UTC calendar date; invalid dates are ignored.
+      schema:
+        type: string
+        format: date
+    ToDate:
+      name: to
+      in: query
+      description: Inclusive UTC calendar date; invalid dates are ignored.
+      schema:
+        type: string
+        format: date
+    Tool:
+      name: tool
+      in: query
+      description: Exact tool or tool-name filter, depending on the route
+      schema:
+        type: string
+    Model:
+      name: model
+      in: query
+      description: Exact session model filter
+      schema:
+        type: string
+    Project:
+      name: project
+      in: query
+      description: Exact project path filter
+      schema:
+        type: string
+    IncludeSubagents:
+      name: include_subagents
+      in: query
+      description: Include subagents as top-level list rows
+      schema:
+        type: boolean
+        default: false
+    WithSubagents:
+      name: with_subagents
+      in: query
+      description: Attach nested subagent summaries to returned rows
+      schema:
+        type: boolean
+        default: false
+    IncludeArchived:
+      name: include_archived
+      in: query
+      description: Include user-archived sessions; deleted sessions remain excluded
+      schema:
+        type: boolean
+        default: false
+    SessionLimit:
+      name: limit
+      in: query
+      description: Page size; defaults to 50 and is capped by the server at 100.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 50
+    Offset:
+      name: offset
+      in: query
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    MessageLimit:
+      name: message_limit
+      in: query
+      description: Number of messages to return; zero or omission loads the complete transcript.
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    MessageOffset:
+      name: message_offset
+      in: query
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    Dimension:
+      name: dim
+      in: query
+      required: true
+      schema:
+        type: string
+        enum: [tool, model, project, day]
+    FileGroup:
+      name: group
+      in: query
+      schema:
+        type: string
+        enum: [path, ext]
+        default: path
+    FileOperation:
+      name: op
+      in: query
+      schema:
+        type: string
+        enum: [read, edit, write, delete]
+    FileLimit:
+      name: limit
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        default: 25
+    McpServer:
+      name: server
+      in: query
+      description: Exact MCP server filter
+      schema:
+        type: string
+    ErrorsOnly:
+      name: errors_only
+      in: query
+      schema:
+        type: boolean
+        default: false
+    ToolCallSession:
+      name: session
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 9007199254740991
+    MinimumDuration:
+      name: min_ms
+      in: query
+      schema:
+        type: integer
+        minimum: 0
+    ToolCallLimit:
+      name: limit
+      in: query
+      description: Page size, capped by the server at 100
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 50
+    UsageLimit:
+      name: limit
+      in: query
+      description: Maximum aggregate rows; defaults to 50
+      schema:
+        type: integer
+        minimum: 1
+        default: 50
+    RecommendationStatus:
+      name: status
+      in: query
+      schema:
+        type: string
+        enum: [open, implemented, all]
+        default: open
+
+  responses:
+    BadRequest:
+      description: Invalid request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+    InvalidSessionId:
+      description: Session id is not a positive safe integer
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+    SessionNotFound:
+      description: Session does not exist in the archive
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SessionNotFoundError"
+    Forbidden:
+      description: Host, peer, or browser-origin guard rejected the request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+    SchemaConflict:
+      description: Archive schema is newer, older, or structurally different from this build
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+    UnsupportedMediaType:
+      description: Mutating requests require Content-Type application/json
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+    InternalError:
+      description: Unexpected error; private details are retained only in local structured logs
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+    ServiceUnavailable:
+      description: Service is starting or the SQLite archive is temporarily busy
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+
+  schemas:
+    ErrorCode:
+      type: string
+      enum:
+        - archive_locked
+        - cross_origin_write
+        - forbidden_host
+        - forbidden_remote
+        - internal_error
+        - invalid_files_query
+        - invalid_request
+        - invalid_session_id
+        - launch_failed
+        - launch_unsupported_platform
+        - malformed_body
+        - not_found
+        - query_required
+        - recommendation_not_found
+        - schema_drift
+        - schema_too_new
+        - schema_too_old
+        - service_starting
+        - session_not_found
+        - unknown_dimension
+        - unknown_status
+        - unsupported_media_type
+    ApiError:
+      type: object
+      required: [error, code]
+      properties:
+        error:
+          type: string
+        code:
+          $ref: "#/components/schemas/ErrorCode"
+        retryable:
+          type: boolean
+        archive_empty:
+          type: boolean
+        allowed:
+          type: array
+          items:
+            type: string
+        ok:
+          type: boolean
+        key:
+          type: string
+        command:
+          type: string
+      additionalProperties: true
+    SessionNotFoundError:
+      allOf:
+        - $ref: "#/components/schemas/ApiError"
+        - type: object
+          required: [archive_empty]
+          properties:
+            code:
+              const: session_not_found
+            archive_empty:
+              type: boolean
+    RecommendationNotFoundError:
+      allOf:
+        - $ref: "#/components/schemas/ApiError"
+        - type: object
+          required: [ok, key]
+          properties:
+            code:
+              const: recommendation_not_found
+            ok:
+              const: false
+            key:
+              type: string
+    Health:
+      type: object
+      required: [ok]
+      properties:
+        ok:
+          const: true
+      additionalProperties: false
+    OpenApiDocument:
+      type: object
+      required: [openapi, info, paths]
+      properties:
+        openapi:
+          type: string
+          pattern: '^3\.1(?:\.\d+)?$'
+        info:
+          type: object
+          required: [title, version]
+          properties:
+            title:
+              type: string
+            version:
+              type: string
+          additionalProperties: true
+        paths:
+          type: object
+          additionalProperties: true
+      additionalProperties: true
+    Config:
+      type: object
+      required: [dbPath, claudeDir, codexDir, version]
+      properties:
+        dbPath:
+          type: string
+        claudeDir:
+          type: string
+        codexDir:
+          type: string
+        version:
+          type: string
+      additionalProperties: false
+    UserSettings:
+      type: object
+      required: [agent, terminal, ide]
+      properties:
+        agent:
+          type: string
+          enum: [claude, codex]
+        terminal:
+          type: string
+          enum: [terminal, iterm, ghostty, warp, wezterm, kitty, alacritty]
+        ide:
+          type: string
+          enum: [vscode, cursor, zed, sublime, intellij]
+        dosuSuggestions:
+          type: string
+          enum: [show, hide]
+          deprecated: true
+          description: Deprecated transitional field; clients should not depend on it.
+      additionalProperties: false
+    UserSettingsPatch:
+      type: object
+      properties:
+        agent:
+          type: string
+          enum: [claude, codex]
+        terminal:
+          type: string
+          enum: [terminal, iterm, ghostty, warp, wezterm, kitty, alacritty]
+        ide:
+          type: string
+          enum: [vscode, cursor, zed, sublime, intellij]
+        dosuSuggestions:
+          type: string
+          enum: [show, hide]
+          deprecated: true
+          description: Deprecated transitional input; clients should omit it.
+      additionalProperties: false
+    LabeledOption:
+      type: array
+      minItems: 2
+      maxItems: 2
+      prefixItems:
+        - type: string
+        - type: string
+    SettingsResponse:
+      type: object
+      required: [settings, path, can_launch, options]
+      properties:
+        settings:
+          $ref: "#/components/schemas/UserSettings"
+        path:
+          type: string
+        can_launch:
+          type: boolean
+        saved:
+          type: boolean
+        options:
+          type: object
+          required: [agents, terminals, ides]
+          properties:
+            agents:
+              type: array
+              items:
+                $ref: "#/components/schemas/LabeledOption"
+            terminals:
+              type: array
+              items:
+                $ref: "#/components/schemas/LabeledOption"
+            ides:
+              type: array
+              items:
+                $ref: "#/components/schemas/LabeledOption"
+            dosuSuggestions:
+              type: array
+              deprecated: true
+              description: Deprecated transitional option list.
+              items:
+                $ref: "#/components/schemas/LabeledOption"
+          additionalProperties: false
+      additionalProperties: false
+    SettingsSavedResponse:
+      allOf:
+        - $ref: "#/components/schemas/SettingsResponse"
+        - type: object
+          required: [saved]
+          properties:
+            saved:
+              const: true
+    AgentLaunchRequest:
+      type: object
+      required: [agent, prompt]
+      properties:
+        agent:
+          type: string
+          enum: [claude, codex]
+        prompt:
+          type: string
+          minLength: 1
+        key:
+          type: string
+      additionalProperties: false
+    IdeLaunchRequest:
+      type: object
+      required: [dir]
+      properties:
+        dir:
+          type: string
+          minLength: 1
+      additionalProperties: false
+    LaunchResult:
+      type: object
+      required: [ok]
+      properties:
+        ok:
+          type: boolean
+        error:
+          type: string
+        command:
+          type: string
+      additionalProperties: false
+    LaunchError:
+      allOf:
+        - $ref: "#/components/schemas/ApiError"
+        - type: object
+          required: [ok]
+          properties:
+            ok:
+              const: false
+    SyncReport:
+      type: object
+      required: [scanned, ingested, skipped, issues, issuesByCode, failed, cancelled]
+      properties:
+        scanned:
+          type: integer
+          minimum: 0
+        ingested:
+          type: integer
+          minimum: 0
+        skipped:
+          type: integer
+          minimum: 0
+        issues:
+          type: integer
+          minimum: 0
+        issuesByCode:
+          type: object
+          additionalProperties:
+            type: integer
+            minimum: 0
+        failed:
+          type: integer
+          minimum: 0
+        cancelled:
+          type: boolean
+      additionalProperties: false
+    SyncProgress:
+      type: object
+      required: [scanned, ingested, skipped, failed, total]
+      properties:
+        scanned:
+          type: integer
+          minimum: 0
+        ingested:
+          type: integer
+          minimum: 0
+        skipped:
+          type: integer
+          minimum: 0
+        failed:
+          type: integer
+          minimum: 0
+        total:
+          type: integer
+          minimum: 0
+      additionalProperties: false
+    SyncStatus:
+      type: object
+      required: [last_sync_at, in_progress, last_report, last_error, ingested_count]
+      properties:
+        last_sync_at:
+          type: [string, "null"]
+        in_progress:
+          type: boolean
+        last_report:
+          type: [string, "null"]
+        last_error:
+          type: [string, "null"]
+        ingested_count:
+          type: [integer, "null"]
+          minimum: 0
+        runs:
+          type: integer
+          minimum: 0
+        timestamp:
+          type: string
+      additionalProperties: false
+    SyncStatusResponse:
+      allOf:
+        - $ref: "#/components/schemas/SyncStatus"
+        - type: object
+          required: [timestamp]
+          properties:
+            timestamp:
+              type: string
+    SyncReason:
+      type: string
+      enum: [startup, watch, sweep, manual]
+    HelloEvent:
+      type: object
+      required: [type, timestamp]
+      properties:
+        type:
+          const: hello
+        timestamp:
+          type: string
+      additionalProperties: false
+    PingEvent:
+      type: object
+      required: [type, timestamp]
+      properties:
+        type:
+          const: ping
+        timestamp:
+          type: string
+      additionalProperties: false
+    WatchReadyEvent:
+      type: object
+      required: [type, dirs, status]
+      properties:
+        type:
+          const: ready
+        dirs:
+          type: array
+          items:
+            type: string
+        status:
+          $ref: "#/components/schemas/SyncStatus"
+      additionalProperties: false
+    SyncProgressEvent:
+      type: object
+      required: [type, reason, progress, status]
+      properties:
+        type:
+          const: sync_progress
+        reason:
+          $ref: "#/components/schemas/SyncReason"
+        progress:
+          $ref: "#/components/schemas/SyncProgress"
+        status:
+          $ref: "#/components/schemas/SyncStatus"
+      additionalProperties: false
+    SyncEvent:
+      type: object
+      required: [type, reason, report, status]
+      properties:
+        type:
+          const: sync
+        reason:
+          $ref: "#/components/schemas/SyncReason"
+        report:
+          $ref: "#/components/schemas/SyncReport"
+        status:
+          $ref: "#/components/schemas/SyncStatus"
+      additionalProperties: false
+    ArchiveUpdatedEvent:
+      type: object
+      required: [type]
+      properties:
+        type:
+          const: archive_updated
+        reason:
+          type: string
+          enum: [stats, session_state]
+        ingested:
+          type: integer
+          minimum: 0
+        last_sync_at:
+          type: [string, "null"]
+      additionalProperties: true
+    SyncErrorEvent:
+      type: object
+      required: [type, reason, error, status]
+      properties:
+        type:
+          const: error
+        reason:
+          type: string
+          enum: [startup, watch, sweep, manual]
+        error:
+          type: string
+        status:
+          $ref: "#/components/schemas/SyncStatus"
+      additionalProperties: false
+    WatchStoppedEvent:
+      type: object
+      required: [type, status]
+      properties:
+        type:
+          const: stopped
+        status:
+          $ref: "#/components/schemas/SyncStatus"
+      additionalProperties: false
+    SessionSummary:
+      type: object
+      required:
+        - id
+        - tool
+        - source_session_id
+        - title
+        - project_path
+        - model
+        - reasoning_effort
+        - reasoning_effort_levels
+        - started_at
+        - ended_at
+        - message_count
+        - total_input_tokens
+        - total_output_tokens
+        - estimated_cost_usd
+        - user_state
+        - is_user_archived
+        - is_archived
+        - is_subagent
+        - parent_session_id
+        - spawn_tool_use_id
+        - agent_id
+        - agent_type
+        - spawn_depth
+        - context_window_tokens
+        - peak_context_tokens
+        - compaction_count
+        - subagent_count
+        - subagent_estimated_cost_usd
+        - ingest_issue_count
+        - informational_ingest_issue_count
+        - dosu_mcp_direct_calls
+        - dosu_mcp_tree_calls
+      properties:
+        id:
+          type: integer
+          minimum: 1
+        tool:
+          type: string
+        source_session_id:
+          type: string
+        title:
+          type: [string, "null"]
+        project_path:
+          type: [string, "null"]
+        model:
+          type: [string, "null"]
+        reasoning_effort:
+          type: [string, "null"]
+        reasoning_effort_levels:
+          type: array
+          items:
+            type: string
+        started_at:
+          type: [string, "null"]
+        ended_at:
+          type: [string, "null"]
+        message_count:
+          type: integer
+          minimum: 0
+        total_input_tokens:
+          type: integer
+          minimum: 0
+        total_output_tokens:
+          type: integer
+          minimum: 0
+        estimated_cost_usd:
+          type: number
+          minimum: 0
+        user_state:
+          type: [string, "null"]
+          enum: [archived, deleted, null]
+        is_user_archived:
+          type: boolean
+        is_archived:
+          type: boolean
+        is_subagent:
+          type: boolean
+        parent_session_id:
+          type: [integer, "null"]
+          minimum: 1
+        spawn_tool_use_id:
+          type: [string, "null"]
+        agent_id:
+          type: [string, "null"]
+        agent_type:
+          type: [string, "null"]
+        spawn_depth:
+          type: [integer, "null"]
+          minimum: 0
+        context_window_tokens:
+          type: [integer, "null"]
+          minimum: 0
+        peak_context_tokens:
+          type: [integer, "null"]
+          minimum: 0
+        compaction_count:
+          type: integer
+          minimum: 0
+        subagent_count:
+          type: integer
+          minimum: 0
+        subagent_estimated_cost_usd:
+          type: number
+          minimum: 0
+        ingest_issue_count:
+          type: integer
+          minimum: 0
+        informational_ingest_issue_count:
+          type: integer
+          minimum: 0
+        dosu_mcp_direct_calls:
+          type: integer
+          minimum: 0
+        dosu_mcp_tree_calls:
+          type: integer
+          minimum: 0
+        subagents:
+          type: array
+          items:
+            $ref: "#/components/schemas/SessionSummary"
+      additionalProperties: true
+    SessionSearchIndexRow:
+      type: object
+      required: [id, title, project, tool, model, started_at]
+      properties:
+        id:
+          type: integer
+          minimum: 1
+        title:
+          type: [string, "null"]
+        project:
+          type: [string, "null"]
+        tool:
+          type: string
+        model:
+          type: [string, "null"]
+        started_at:
+          type: [string, "null"]
+      additionalProperties: false
+    SessionStateRequest:
+      type: object
+      required: [state]
+      properties:
+        state:
+          type: string
+          enum: [archived, deleted, visible]
+      additionalProperties: false
+    SessionStateResponse:
+      type: object
+      required: [ok, id, state]
+      properties:
+        ok:
+          const: true
+        id:
+          type: integer
+          minimum: 1
+        state:
+          type: string
+          enum: [archived, deleted, visible]
+        user_state:
+          type: [string, "null"]
+          enum: [archived, deleted, null]
+        is_user_archived:
+          type: boolean
+      additionalProperties: false
+    SessionBlock:
+      type: object
+      required: [ordinal, block_type, text, tool_name, tool_use_id, tool_input, tool_result]
+      properties:
+        ordinal:
+          type: integer
+          minimum: 0
+        block_type:
+          type: string
+        text:
+          type: [string, "null"]
+        tool_name:
+          type: [string, "null"]
+        tool_use_id:
+          type: [string, "null"]
+        tool_input:
+          type: [string, "null"]
+        tool_result:
+          type: [string, "null"]
+      additionalProperties: true
+    SessionMessage:
+      type: object
+      required:
+        - seq
+        - role
+        - timestamp
+        - model
+        - context_tokens
+        - output_tokens
+        - is_sidechain
+        - is_compact_boundary
+        - compact_trigger
+        - compact_pre_tokens
+        - is_compact_summary
+        - blocks
+      properties:
+        seq:
+          type: integer
+          minimum: 0
+        role:
+          type: string
+        timestamp:
+          type: [string, "null"]
+        model:
+          type: [string, "null"]
+        context_tokens:
+          type: [integer, "null"]
+          minimum: 0
+        output_tokens:
+          type: [integer, "null"]
+          minimum: 0
+        is_sidechain:
+          type: boolean
+        is_compact_boundary:
+          type: boolean
+        compact_trigger:
+          type: [string, "null"]
+        compact_pre_tokens:
+          type: [integer, "null"]
+          minimum: 0
+        is_compact_summary:
+          type: boolean
+        blocks:
+          type: array
+          items:
+            $ref: "#/components/schemas/SessionBlock"
+      additionalProperties: true
+    SessionTotals:
+      type: object
+      required: [reply_count, tool_call_count]
+      properties:
+        reply_count:
+          type: integer
+          minimum: 0
+        tool_call_count:
+          type: integer
+          minimum: 0
+      additionalProperties: false
+    SubagentDetail:
+      type: object
+      required:
+        - summary
+        - messages
+        - subagents
+        - spawn_tool_use_id
+        - agent_id
+        - agent_type
+        - spawn_depth
+      properties:
+        summary:
+          $ref: "#/components/schemas/SessionSummary"
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/SessionMessage"
+        subagents:
+          type: array
+          items:
+            $ref: "#/components/schemas/SubagentDetail"
+        spawn_tool_use_id:
+          type: [string, "null"]
+        agent_id:
+          type: [string, "null"]
+        agent_type:
+          type: [string, "null"]
+        spawn_depth:
+          type: [integer, "null"]
+          minimum: 0
+      additionalProperties: true
+    SessionDetail:
+      type: object
+      required: [summary, messages, subagents, totals, message_limit]
+      properties:
+        summary:
+          $ref: "#/components/schemas/SessionSummary"
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/SessionMessage"
+        subagents:
+          type: array
+          items:
+            $ref: "#/components/schemas/SubagentDetail"
+        totals:
+          $ref: "#/components/schemas/SessionTotals"
+        message_offset:
+          type: integer
+          minimum: 0
+        message_limit:
+          type: [integer, "null"]
+          minimum: 1
+        has_more_messages:
+          type: boolean
+      additionalProperties: true
+    SessionOutlineItem:
+      type: object
+      required: [seq, text, kind, ordinal]
+      properties:
+        seq:
+          type: integer
+          minimum: 0
+        text:
+          type: string
+        kind:
+          type: string
+          enum: [prompt, dosu]
+        ordinal:
+          type: integer
+          minimum: -1
+      additionalProperties: false
+    SessionIngestIssue:
+      type: object
+      required: [code, line_no, error, raw_line, created_at]
+      properties:
+        code:
+          type: string
+        line_no:
+          type: [integer, "null"]
+          minimum: 1
+        error:
+          type: string
+        raw_line:
+          type: [string, "null"]
+        created_at:
+          type: [string, "null"]
+      additionalProperties: false
+    ProjectSummary:
+      type: object
+      required:
+        - id
+        - path
+        - name
+        - sessions
+        - estimated_cost_usd
+        - last_seen_at
+        - is_worktree
+        - root_path
+        - worktree_label
+        - worktree_tool
+        - root_source
+        - worktree_count
+        - session_tools
+      properties:
+        id:
+          type: integer
+          minimum: 1
+        path:
+          type: string
+        name:
+          type: [string, "null"]
+        sessions:
+          type: integer
+          minimum: 0
+        estimated_cost_usd:
+          type: number
+          minimum: 0
+        last_seen_at:
+          type: [string, "null"]
+        is_worktree:
+          type: boolean
+        root_path:
+          type: [string, "null"]
+        worktree_label:
+          type: [string, "null"]
+        worktree_tool:
+          type: [string, "null"]
+        root_source:
+          type: [string, "null"]
+        worktree_count:
+          type: integer
+          minimum: 0
+        session_tools:
+          type: array
+          items:
+            type: string
+      additionalProperties: true
+    SearchRequest:
+      type: object
+      required: [query]
+      properties:
+        query:
+          type: string
+          minLength: 1
+        tool:
+          type: [string, "null"]
+        project:
+          type: [string, "null"]
+        include_subagents:
+          type: boolean
+          default: false
+        include_total:
+          type: boolean
+          default: true
+          description: "When false, `total` is null and the capped count query is skipped."
+        from:
+          type: [string, "null"]
+          format: date
+        to:
+          type: [string, "null"]
+          format: date
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 30
+        offset:
+          type: integer
+          minimum: 0
+          default: 0
+      additionalProperties: false
+    SearchHit:
+      type: object
+      required:
+        - session_id
+        - session_title
+        - tool
+        - block_id
+        - snippet
+        - message_seq
+        - timestamp
+        - project
+        - role
+        - block_type
+        - href
+      properties:
+        session_id:
+          type: integer
+          minimum: 1
+        session_title:
+          type: [string, "null"]
+        tool:
+          type: string
+        block_id:
+          type: integer
+          minimum: 1
+        snippet:
+          type: string
+        message_seq:
+          type: integer
+          minimum: 0
+        timestamp:
+          type: [string, "null"]
+        project:
+          type: [string, "null"]
+        role:
+          type: string
+        block_type:
+          type: string
+        href:
+          type: string
+      additionalProperties: false
+    SearchPage:
+      type: object
+      required: [results, total, total_is_capped, elapsed_ms]
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/SearchHit"
+        total:
+          type: [integer, "null"]
+          minimum: 0
+          maximum: 1000
+        total_is_capped:
+          type: boolean
+        elapsed_ms:
+          type: number
+          minimum: 0
+      additionalProperties: false
+    Totals:
+      type: object
+      required:
+        - sessions
+        - messages
+        - tool_calls
+        - input_tokens
+        - output_tokens
+        - cache_read_tokens
+        - cache_creation_tokens
+        - reasoning_tokens
+        - est_reasoning_tokens
+        - estimated_cost_usd
+      properties:
+        sessions:
+          type: integer
+          minimum: 0
+        messages:
+          type: integer
+          minimum: 0
+        tool_calls:
+          type: integer
+          minimum: 0
+        input_tokens:
+          type: integer
+          minimum: 0
+        output_tokens:
+          type: integer
+          minimum: 0
+        cache_read_tokens:
+          type: integer
+          minimum: 0
+        cache_creation_tokens:
+          type: integer
+          minimum: 0
+        reasoning_tokens:
+          type: integer
+          minimum: 0
+        est_reasoning_tokens:
+          type: integer
+          minimum: 0
+        estimated_cost_usd:
+          type: number
+          minimum: 0
+      additionalProperties: false
+    DimensionRow:
+      type: object
+      required:
+        - key
+        - sessions
+        - input_tokens
+        - output_tokens
+        - reasoning_tokens
+        - est_reasoning_tokens
+        - estimated_cost_usd
+      properties:
+        key:
+          type: string
+        sessions:
+          type: integer
+          minimum: 0
+        input_tokens:
+          type: integer
+          minimum: 0
+        output_tokens:
+          type: integer
+          minimum: 0
+        reasoning_tokens:
+          type: integer
+          minimum: 0
+        est_reasoning_tokens:
+          type: integer
+          minimum: 0
+        estimated_cost_usd:
+          type: number
+          minimum: 0
+      additionalProperties: false
+    Activity:
+      type: object
+      required: [by_hour, by_weekday, timezone, peak_hour, peak_weekday]
+      properties:
+        by_hour:
+          type: array
+          minItems: 24
+          maxItems: 24
+          items:
+            type: integer
+            minimum: 0
+        by_weekday:
+          type: array
+          minItems: 7
+          maxItems: 7
+          items:
+            type: integer
+            minimum: 0
+        timezone:
+          type: string
+        peak_hour:
+          type: [integer, "null"]
+          minimum: 0
+          maximum: 23
+        peak_weekday:
+          type: [integer, "null"]
+          minimum: 0
+          maximum: 6
+      additionalProperties: false
+    ModelSparklines:
+      type: object
+      required: [models, days]
+      properties:
+        models:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: integer
+              minimum: 0
+        days:
+          type: array
+          items:
+            type: string
+            format: date
+      additionalProperties: false
+    PhaseAmounts:
+      type: object
+      required: [generation_tokens, context_window_tokens, estimated_cost_usd, active_ms]
+      properties:
+        generation_tokens:
+          type: number
+          minimum: 0
+        context_window_tokens:
+          type: number
+          minimum: 0
+        estimated_cost_usd:
+          type: number
+          minimum: 0
+        active_ms:
+          type: number
+          minimum: 0
+      additionalProperties: false
+    PhaseMap:
+      type: object
+      properties:
+        orientation:
+          $ref: "#/components/schemas/PhaseAmounts"
+        implementation:
+          $ref: "#/components/schemas/PhaseAmounts"
+      additionalProperties: false
+    TokenEconomicsBucket:
+      type: object
+      required:
+        - bucket
+        - generation_tokens
+        - context_window_tokens
+        - estimated_cost_usd
+        - tool_calls
+        - sessions
+        - cost_share
+        - active_ms
+      properties:
+        bucket:
+          type: string
+        generation_tokens:
+          type: number
+          minimum: 0
+        context_window_tokens:
+          type: number
+          minimum: 0
+        estimated_cost_usd:
+          type: number
+          minimum: 0
+        tool_calls:
+          type: integer
+          minimum: 0
+        sessions:
+          type: integer
+          minimum: 0
+        cost_share:
+          type: number
+          minimum: 0
+        active_ms:
+          type: number
+          minimum: 0
+        phases:
+          $ref: "#/components/schemas/PhaseMap"
+      additionalProperties: true
+    TokenEconomics:
+      type: object
+      required: [buckets, totals]
+      properties:
+        buckets:
+          type: array
+          items:
+            $ref: "#/components/schemas/TokenEconomicsBucket"
+        totals:
+          type: object
+          required:
+            - generation_tokens
+            - context_window_tokens
+            - estimated_cost_usd
+            - input_cost_usd
+            - output_cost_usd
+            - active_ms
+            - waiting_on_user_ms
+            - attributed_ms
+          properties:
+            generation_tokens:
+              type: number
+              minimum: 0
+            context_window_tokens:
+              type: number
+              minimum: 0
+            estimated_cost_usd:
+              type: number
+              minimum: 0
+            input_cost_usd:
+              type: number
+              minimum: 0
+            output_cost_usd:
+              type: number
+              minimum: 0
+            active_ms:
+              type: number
+              minimum: 0
+            waiting_on_user_ms:
+              type: number
+              minimum: 0
+            attributed_ms:
+              type: number
+              minimum: 0
+            phases:
+              $ref: "#/components/schemas/PhaseMap"
+          additionalProperties: true
+      additionalProperties: true
+    NowAnalytics:
+      type: object
+      required: [today, active_sessions, last_sync_at, sync_in_progress]
+      properties:
+        today:
+          $ref: "#/components/schemas/Totals"
+        active_sessions:
+          type: array
+          items:
+            $ref: "#/components/schemas/SessionSummary"
+        last_sync_at:
+          type: [string, "null"]
+        sync_in_progress:
+          type: boolean
+      additionalProperties: true
+    ContextWindowPoint:
+      type: object
+      required:
+        - seq
+        - timestamp
+        - turn
+        - context_tokens
+        - input_tokens
+        - cache_read_tokens
+        - cache_creation_tokens
+        - output_tokens
+      properties:
+        seq:
+          type: integer
+          minimum: 0
+        timestamp:
+          type: [string, "null"]
+        turn:
+          type: integer
+          minimum: 0
+        context_tokens:
+          type: integer
+          minimum: 0
+        input_tokens:
+          type: integer
+          minimum: 0
+        cache_read_tokens:
+          type: integer
+          minimum: 0
+        cache_creation_tokens:
+          type: integer
+          minimum: 0
+        output_tokens:
+          type: integer
+          minimum: 0
+      additionalProperties: false
+    ContextWindowCompaction:
+      type: object
+      required: [seq, timestamp, trigger, pre_tokens, post_tokens]
+      properties:
+        seq:
+          type: integer
+          minimum: 0
+        timestamp:
+          type: [string, "null"]
+        trigger:
+          type: [string, "null"]
+        pre_tokens:
+          type: [integer, "null"]
+          minimum: 0
+        post_tokens:
+          type: [integer, "null"]
+          minimum: 0
+      additionalProperties: false
+    ContextWindowTimeline:
+      type: object
+      required:
+        - session_id
+        - tool
+        - window_tokens
+        - window_inferred
+        - peak_tokens
+        - peak_pct
+        - turn_count
+        - points
+        - compactions
+      properties:
+        session_id:
+          type: integer
+          minimum: 1
+        tool:
+          type: string
+        window_tokens:
+          type: [integer, "null"]
+          minimum: 0
+        window_inferred:
+          type: boolean
+        peak_tokens:
+          type: integer
+          minimum: 0
+        peak_pct:
+          type: [number, "null"]
+          minimum: 0
+        turn_count:
+          type: integer
+          minimum: 0
+        points:
+          type: array
+          items:
+            $ref: "#/components/schemas/ContextWindowPoint"
+        compactions:
+          type: array
+          items:
+            $ref: "#/components/schemas/ContextWindowCompaction"
+      additionalProperties: true
+    DateBounds:
+      type: object
+      required: [min, max]
+      properties:
+        min:
+          type: [string, "null"]
+          format: date
+        max:
+          type: [string, "null"]
+          format: date
+      additionalProperties: false
+    FileStatRow:
+      type: object
+      required: [key, project, reads, edits, writes, deletes, sessions, last_touched_at]
+      properties:
+        key:
+          type: string
+        project:
+          type: [string, "null"]
+        reads:
+          type: integer
+          minimum: 0
+        edits:
+          type: integer
+          minimum: 0
+        writes:
+          type: integer
+          minimum: 0
+        deletes:
+          type: integer
+          minimum: 0
+        sessions:
+          type: integer
+          minimum: 0
+        last_touched_at:
+          type: [string, "null"]
+      additionalProperties: false
+    ToolCallRow:
+      type: object
+      required:
+        - id
+        - session_id
+        - session_title
+        - project
+        - tool_name
+        - tool_kind
+        - mcp_server
+        - input_preview
+        - input_bytes
+        - output_preview
+        - output_bytes
+        - is_error
+        - has_result
+        - duration_ms
+        - timestamp
+        - seq
+      properties:
+        id:
+          type: integer
+          minimum: 1
+        session_id:
+          type: integer
+          minimum: 1
+        session_title:
+          type: [string, "null"]
+        project:
+          type: [string, "null"]
+        tool_name:
+          type: [string, "null"]
+        tool_kind:
+          type: [string, "null"]
+        mcp_server:
+          type: [string, "null"]
+        input_preview:
+          type: [string, "null"]
+        input_bytes:
+          type: [integer, "null"]
+          minimum: 0
+        output_preview:
+          type: [string, "null"]
+        output_bytes:
+          type: [integer, "null"]
+          minimum: 0
+        is_error:
+          type: [boolean, "null"]
+        has_result:
+          type: [boolean, "null"]
+        duration_ms:
+          type: [integer, "null"]
+          minimum: 0
+        timestamp:
+          type: [string, "null"]
+        seq:
+          type: [integer, "null"]
+          minimum: 0
+      additionalProperties: false
+    ToolCallSummary:
+      type: object
+      required: [calls, errors, p50_ms, p95_ms]
+      properties:
+        calls:
+          type: integer
+          minimum: 0
+        errors:
+          type: integer
+          minimum: 0
+        p50_ms:
+          type: [integer, "null"]
+          minimum: 0
+        p95_ms:
+          type: [integer, "null"]
+          minimum: 0
+      additionalProperties: false
+    ToolCallPage:
+      type: object
+      required: [calls, total, limit, offset, summary]
+      properties:
+        calls:
+          type: array
+          items:
+            $ref: "#/components/schemas/ToolCallRow"
+        total:
+          type: integer
+          minimum: 0
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+        offset:
+          type: integer
+          minimum: 0
+        summary:
+          oneOf:
+            - $ref: "#/components/schemas/ToolCallSummary"
+            - type: "null"
+      additionalProperties: false
+    ToolStatRow:
+      type: object
+      required:
+        - tool_name
+        - tool_kind
+        - mcp_server
+        - calls
+        - errors
+        - p50_ms
+        - p95_ms
+        - last_used_at
+      properties:
+        tool_name:
+          type: string
+        tool_kind:
+          type: string
+        mcp_server:
+          type: [string, "null"]
+        calls:
+          type: integer
+          minimum: 0
+        errors:
+          type: integer
+          minimum: 0
+        p50_ms:
+          type: [integer, "null"]
+          minimum: 0
+        p95_ms:
+          type: [integer, "null"]
+          minimum: 0
+        last_used_at:
+          type: [string, "null"]
+      additionalProperties: false
+    McpStatRow:
+      type: object
+      required: [mcp_server, tools, calls, errors, p50_ms, p95_ms, last_used_at]
+      properties:
+        mcp_server:
+          type: string
+        tools:
+          type: integer
+          minimum: 0
+        calls:
+          type: integer
+          minimum: 0
+        errors:
+          type: integer
+          minimum: 0
+        p50_ms:
+          type: [integer, "null"]
+          minimum: 0
+        p95_ms:
+          type: [integer, "null"]
+          minimum: 0
+        last_used_at:
+          type: [string, "null"]
+      additionalProperties: false
+    Recommendation:
+      type: object
+      required:
+        - key
+        - kind
+        - category
+        - title
+        - detail
+        - suggestion
+        - prompt
+        - url
+        - link_label
+        - icon
+        - tone
+        - impact_label
+        - score
+        - status
+        - status_source
+        - note
+        - first_seen_at
+        - updated_at
+        - implemented_at
+        - memory_layer
+        - promotion_target
+        - trigger
+        - evidence
+        - action
+        - success_metric
+      properties:
+        key:
+          type: string
+        kind:
+          type: string
+          enum: [signal, catalog]
+        category:
+          type: [string, "null"]
+        title:
+          type: string
+        detail:
+          type: [string, "null"]
+        suggestion:
+          type: [string, "null"]
+        prompt:
+          type: [string, "null"]
+        url:
+          type: [string, "null"]
+        link_label:
+          type: [string, "null"]
+        icon:
+          type: [string, "null"]
+        tone:
+          type: [string, "null"]
+        impact_label:
+          type: [string, "null"]
+        score:
+          type: [number, "null"]
+        status:
+          type: string
+        status_source:
+          type: [string, "null"]
+        note:
+          type: [string, "null"]
+        first_seen_at:
+          type: [string, "null"]
+        updated_at:
+          type: [string, "null"]
+        implemented_at:
+          type: [string, "null"]
+        memory_layer:
+          type: [string, "null"]
+        promotion_target:
+          type: [string, "null"]
+        trigger:
+          type: [string, "null"]
+        evidence:
+          type: [string, "null"]
+        action:
+          type: [string, "null"]
+        success_metric:
+          type: [string, "null"]
+      additionalProperties: true
+    RecommendationMarkRequest:
+      type: object
+      required: [key]
+      properties:
+        key:
+          type: string
+          minLength: 1
+        source:
+          type: string
+          default: agent
+        note:
+          type: string
+      additionalProperties: false
+    RecommendationMarkResponse:
+      type: object
+      required: [ok, key, status]
+      properties:
+        ok:
+          const: true
+        key:
+          type: string
+        status:
+          const: implemented
+      additionalProperties: false

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -326,6 +326,11 @@ paths:
       tags: [Sessions]
       operationId: listSessions
       summary: List visible sessions newest first
+      description: >-
+        Returns a bare newest-first array with no total or continuation token.
+        Advance offset by the number of rows received. The effective page size
+        defaults to 50 and never exceeds 100. A final short or empty page marks
+        the end; an exact multiple requires one empty request to confirm it.
       parameters:
         - $ref: "#/components/parameters/FromDate"
         - $ref: "#/components/parameters/ToDate"
@@ -360,7 +365,7 @@ paths:
       tags: [Sessions]
       operationId: getSessionSearchIndex
       summary: Read lightweight metadata for client-side fuzzy search
-      description: Returns every visible non-archived session, including subagents, without message data.
+      description: Returns every visible non-archived top-level session without message data.
       responses:
         "200":
           description: Stable newest-first search index

--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -1,188 +1,89 @@
-# Local Serve Routes
+# Local Serve API
 
-`decant serve` runs the CLI, watcher, JSON routes, SSE stream, and React UI in
-one Bun process. These routes are internal app routes, not a versioned public
-contract. By default, the server listens on `http://127.0.0.1:3000`.
+`decant serve` runs the archive owner, source watcher, local HTTP API,
+Server-Sent Events stream, and React UI in one Bun process. It listens on
+`http://127.0.0.1:3000` by default.
+
+The reference contract is [openapi.yaml](openapi.yaml). It describes every
+`/api/*` operation, parameter, request body, response schema, and stable error
+code. A running server exposes the same OpenAPI 3.1 document as JSON at
+`GET /api/openapi.json`; its `info.version` is the running Decant version.
+
+This page records the operational semantics around that contract.
 
 ## Access control
 
-Every route is unauthenticated: anything that reaches the port and passes the
-guard reads or writes the whole archive.
+The API has no authentication. Any request that reaches the listener and passes
+the local guard can read or mutate the whole archive.
 
-- Bound to loopback (the default), only local processes can connect.
-- Bound to a non-loopback host (`--host 0.0.0.0`, as the container image does),
-  the peer's source address is the boundary. Loopback peers pass, and so do the
-  trusted peers resolved at startup. Everything else gets `403 forbidden
-  remote`.
-- Trusted peers come from exactly one source, highest first, each replacing the
-  ones below rather than adding to them: `--trusted-peer`, then
-  `DECANT_TRUSTED_PEERS` whenever that variable is set at all, then
-  `DECANT_TRUST_DEFAULT_GATEWAY=1`. All are unset by default outside the
-  container image, so nothing beyond loopback is trusted until an operator opts
-  in.
-- `DECANT_TRUST_DEFAULT_GATEWAY=1` contributes a single address, the container's
-  own bridge gateway, and only when the default route is a container veth
-  pointing at an on-link gateway inside `172.16.0.0/12`; see
-  `docs/distribution.md`. Every other shape, including `--network host` and
-  macvlan, contributes nothing.
-- The `Host` check that returns `403 forbidden host` is not an access control
-  for non-browser clients: `curl -H 'Host: localhost'` satisfies it. Neither are
-  the `Origin`/`Sec-Fetch-Site` checks on mutating routes, which only stop a
-  browser on another site from driving this API.
+- The default loopback bind admits local processes only.
+- On a non-loopback bind, loopback source addresses and the trusted peers
+  resolved at startup are admitted; every other source receives
+  `403 forbidden_remote`.
+- Trusted-peer sources use replacement precedence, not a union. The first
+  present source wins: `--trusted-peer`, then `DECANT_TRUSTED_PEERS` whenever
+  the variable is set, then `DECANT_TRUST_DEFAULT_GATEWAY=1`.
+  `DECANT_TRUSTED_PEERS=` therefore means “trust nobody,” not “fall through.”
+- The gateway option contributes one address only when Decant proves the
+  default route is a container veth to an on-link gateway inside
+  `172.16.0.0/12`. It fails closed for host networking, macvlan/ipvlan,
+  multi-homed hosts, and other unproven shapes. See
+  [distribution.md](../distribution.md#docker).
+- The `Host` check is not authentication: a non-browser client can send
+  `Host: localhost`. The `Origin` and `Sec-Fetch-Site` checks on writes are
+  browser-drive protections, not credentials.
 
-## UI
+On a loopback bind, a command-line write may omit `Origin`. On a non-loopback
+bind, a write that supplies neither `Origin` nor `Sec-Fetch-Site` is rejected
+even when the source is trusted. Supply a loopback `Origin` for an explicit
+command-line write; for example:
 
-- `GET /` (Analytics; the sidebar groups this under Overview)
-- `GET /projects`
-- `GET /sessions`
-- `GET /sessions/:id`
-- `GET /search`
-- `GET /analytics`
-- `GET /insights`
-- `GET /tools`
-- `GET /files`
-- `GET /settings`
-- `GET /reports/analytics?from=YYYY-MM-DD&to=YYYY-MM-DD`
-- `GET /reports/session/:id`
+```bash
+curl --fail --silent --show-error \
+  --request POST \
+  --header 'Content-Type: application/json' \
+  --header 'Origin: http://127.0.0.1:3000' \
+  --data '{}' \
+  http://127.0.0.1:3000/api/sync
+```
 
-The report UI routes render a light, print-ready preview with Back, Download
-HTML, and Save as PDF controls. They read the same local-only report endpoints
-listed below; the session preview intentionally omits transcript content.
+If the client connects to a non-loopback address directly, it must also send a
+loopback `Host` header. Admission still depends on the actual source address;
+changing `Host` or `Origin` never makes an untrusted peer trusted.
 
-## JSON
+## Response and archive semantics
 
-- `GET /api/health`
-- `GET /api/config`
-- `GET /api/settings`
-- `POST /api/settings`
-- `GET /api/sync-status`
-- `GET /api/metadata/sync-status`
-- `POST /api/sync` (works even under `--no-sync`, which only stops the watcher)
-- `GET /api/sessions?from=YYYY-MM-DD&to=YYYY-MM-DD`
-- `GET /api/sessions/search-index` — lightweight, top-level, visible,
-  non-archived session metadata for the local command palette
-- `GET /api/sessions/:id`
-- `GET /api/sessions/:id/outline`
-- `GET /api/sessions/:id/issues` — ingest diagnostics recorded for the session's
-  source file
-- `GET /api/sessions/:id/token-economics`
-- `GET /api/sessions/:id/context-window`
-- `GET /api/projects`
-- `POST /api/search`
-- `GET /api/stats/summary?from=YYYY-MM-DD&to=YYYY-MM-DD`
-- `GET /api/stats/by-dimension?dim=tool|model|project|day&from=YYYY-MM-DD&to=YYYY-MM-DD`
-- `GET /api/analytics/activity?from=YYYY-MM-DD&to=YYYY-MM-DD`
-- `GET /api/analytics/model-sparklines?from=YYYY-MM-DD&to=YYYY-MM-DD`
-- `GET /api/analytics/token-economics?from=YYYY-MM-DD&to=YYYY-MM-DD`
-- `GET /api/analytics/now`
-- `GET /api/reports/analytics.html?from=YYYY-MM-DD&to=YYYY-MM-DD`
-- `GET /api/reports/session/:id.html`
-- `GET /api/date-bounds`
-- `GET /api/metadata/date-bounds`
-- `GET /api/files?group=path|ext&op=read|edit|write|delete&from=YYYY-MM-DD&to=YYYY-MM-DD`
-- `GET /api/tools/calls?tool=&server=&errors_only=&session=&project=&from=&to=&min_ms=&limit=&offset=`
-- `GET /api/tools/usage?from=YYYY-MM-DD&to=YYYY-MM-DD`
-- `GET /api/tools/mcp-usage?from=YYYY-MM-DD&to=YYYY-MM-DD`
-- `GET /api/recommendations?status=open|implemented|all`
-- `POST /api/recommendations/mark`
-- `POST /api/launch/agent`
-- `POST /api/launch/ide`
+JSON errors use the stable envelope `{ "error": string, "code": string, ... }`.
+Expected recovery cases retain specific codes, including `archive_locked`,
+`schema_drift`, `schema_too_new`, `schema_too_old`, `session_not_found`, and
+validation failures. Unexpected failures return generic `internal_error` prose;
+the structured stderr log retains the diagnostic.
 
-Report routes download self-contained, zero-JavaScript HTML documents with
-inline styles and SVG charts. Analytics reports honor the inclusive date
-filter. Session reports omit transcript content by design and return the same
-coded `session_not_found` response as session detail when the id is absent.
+`DECANT_NO_SYNC` and `--no-sync` suppress Decant-initiated startup, watch, and
+sweep syncs. They do not disable `POST /api/sync`.
 
-Errors use stable codes so the UI can offer recovery without exposing private
-exception text. In particular, an unexpected `500` returns `internal_error`
-with generic prose while the structured server log retains the diagnostic.
-`archive_locked` is retryable, schema conflicts distinguish `schema_too_new`
-from `schema_too_old`, and missing sessions include `archive_empty`.
+Session archive/delete state is local metadata. Archiving hides a session from
+default lists, searches, and aggregate statistics. The `include_archived`
+parameter on session-list and statistics operations opts it back into those
+operations; full-text and command-palette search remain limited to visible
+sessions. Deletion creates a tombstone keyed to source identity, so a later sync
+does not restore the session. Neither operation modifies the source JSONL file.
 
-Session and archive token-economics routes aggregate versioned per-session
-vectors persisted during ingest. The first sync after a schema upgrade
-backfills vectors for unchanged sessions.
+Report operations return self-contained, zero-JavaScript HTML. Session reports
+omit transcript content by design.
 
-The tool-call browse route returns
-`{ calls: ToolCallRow[], total, limit, offset, summary }`, ordered newest first.
-On the first page, `summary` reports calls, confirmed errors, and nearest-rank
-`p50_ms`/`p95_ms` over the complete filtered result, not only the current page;
-later pages return `summary: null` to avoid repeating the percentile scan.
-`limit` defaults to 50 and is capped at 100. `tool`, `server`, `session`, and `project` are
-exact-match filters; `errors_only=true` includes only confirmed errors; `from`
-and `to` filter call timestamps by inclusive UTC date; and `min_ms` filters
-measured durations. A legacy or provider-opaque value stays JSON `null`: in
-particular, `is_error: null` means the archive cannot determine whether the
-call failed, not success. The per-tool and per-MCP-server usage routes also
-return nearest-rank `p50_ms`/`p95_ms` plus `last_used_at`; each is `null` when
-the underlying rows do not contain the relevant source metadata.
+## Server-Sent Events
 
-Session detail accepts `message_limit` and `message_offset` for transcript
-pagination. The outline route returns lightweight entries for each human/prompt
-turn and verified Dosu MCP call: sequence number, kind, ordinal, and either a
-short prompt excerpt or normalized tool name. This lets sticky thread
-navigation cover the whole session and point to Dosu optimizations without
-loading every rich transcript block up front.
+`GET /api/events` returns `text/event-stream`. The current event names are:
 
-Session detail also returns `totals`, holding `reply_count` and
-`tool_call_count` aggregated across the whole session rather than the requested
-page, so a client can report them without loading every message. A reply is an
-assistant message carrying at least one renderable block, matching what the UI
-draws. The nested `subagents` entries carry structure and a summary but no
-messages, so they omit `totals` along with the paging fields.
+- `hello` — connection acknowledgement
+- `ping` — heartbeat, normally every five seconds
+- `ready` — source watcher initialized
+- `sync_progress` — bounded progress snapshot for a running sync
+- `sync` — terminal successful sync report
+- `archive_updated` — archive-derived UI data changed
+- `error` — watcher or sync failure
+- `stopped` — source watcher stopped
 
-Session summaries returned by the list and detail routes include
-`reasoning_effort` and `reasoning_effort_levels`. The first is the normalized
-provider effort label, `mixed` when the setting changes between turns, or
-`null` when the source did not record one. The levels array preserves the
-unique labels represented by `mixed`. Provider labels retain their meaning
-after whitespace trimming and canonicalization of known labels: Claude Code's
-`max` remains `max`, while Codex's distinct `max` and `ultra` values also
-remain unchanged. The current known values are:
-
-- Claude Code: `low`, `medium`, `high`, `xhigh`, and `max`. Its `auto`
-  selector resolves to the model default, while `ultracode` reports `xhigh`
-  because it is workflow orchestration layered on that effort level. Numeric
-  Agent SDK per-agent token budgets are preserved and displayed as token
-  budgets.
-- Codex: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, and
-  `ultra`. Unknown future custom values preserve their original spelling
-  rather than being discarded or rewritten.
-
-Availability remains model-dependent for both providers.
-
-Claude Code began recording the active effort on every assistant transcript
-message in v2.1.219. Earlier transcripts do not contain enough information to
-distinguish the model default from a session override, so the UI keeps the
-placeholder `-` and explains the missing source data in a tooltip instead of
-guessing a historical effort level.
-
-The context-window route derives per-API-call window occupancy and compaction
-events at read time from persisted per-message token columns and raw records.
-Claude logs do not state the size, so it is inferred from the recorded model:
-Opus 5, Opus 4.6-4.8, Sonnet 5, Sonnet 4.6, Fable 5, and Mythos 5/Preview use
-1M; other Claude models use 200k unless observed usage proves a historical 1M
-session. Codex rollouts carry an explicit `model_context_window`, persisted on
-the session's `raw_meta`, and that runtime value takes precedence over a
-model's general API limit. Session rows also carry materialized rollups
-(`context_window_tokens`, `peak_context_tokens`, plus the existing
-`compaction_count`) computed at ingest; the first sync after a schema upgrade
-backfills them, like the economics vectors.
-Codex sessions ingested by older Decant builds, as well as source rollouts
-predating `last_token_usage`, return empty `points` until the source changes
-and is re-ingested or the archive is rebuilt.
-
-## Events
-
-- `GET /api/events` returns an SSE stream.
-
-Current event names:
-
-- `hello`
-- `ping` (heartbeat, emitted every 5 seconds)
-- `ready`
-- `sync_progress`
-- `sync`
-- `archive_updated`
-- `error`
-- `stopped`
+Each `data` field is JSON and includes a matching `type`. The OpenAPI operation's
+`x-sse-events` extension defines the payload schema for each name.

--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -11,6 +11,25 @@ code. A running server exposes the same OpenAPI 3.1 document as JSON at
 
 This page records the operational semantics around that contract.
 
+## UI routes
+
+- `GET /` (Analytics; grouped under Overview in the sidebar)
+- `GET /projects`
+- `GET /sessions`
+- `GET /sessions/:id`
+- `GET /search`
+- `GET /analytics`
+- `GET /insights`
+- `GET /tools`
+- `GET /files`
+- `GET /settings`
+- `GET /reports/analytics?from=YYYY-MM-DD&to=YYYY-MM-DD`
+- `GET /reports/session/:id`
+
+The report UI routes render a light, print-ready preview with Back, Download
+HTML, and Save as PDF controls. They read the local-only report operations;
+the session preview intentionally omits transcript content.
+
 ## Access control
 
 The API has no authentication. Any request that reaches the listener and passes
@@ -71,6 +90,18 @@ does not restore the session. Neither operation modifies the source JSONL file.
 
 Report operations return self-contained, zero-JavaScript HTML. Session reports
 omit transcript content by design.
+
+### Session listing and command-palette index
+
+`GET /api/sessions` returns a bare newest-first array, not an envelope with a
+total or continuation token. Its `limit` defaults to 50 and has an effective
+maximum of 100. Increment `offset` by the number of rows received; a final short
+or empty page marks the end. When the result count is an exact multiple of the
+page size, one empty request is required to confirm the end.
+
+`GET /api/sessions/search-index` returns lightweight metadata for every visible,
+non-archived top-level session. It is the command palette's local fuzzy-search
+haystack and intentionally omits transcript content.
 
 ## Server-Sent Events
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -26,14 +26,16 @@ The current event names are:
 | `decant.server.stopped` | Local HTTP server stopped. |
 | `http.server.request` | HTTP request completed with method, route, status, and duration. |
 | `http.server.request.exception` | Request handling raised an exception. |
+| `http.server.request.rejected` | Request handling mapped a rejected operation to a non-5xx API response. |
 
 Set `DECANT_LOG_LEVEL` to `trace`, `debug`, `info`, `warn` (or `warning`),
 `error`, `fatal`, or `off` (or `silent`). The default is `info`. HTTP 4xx
 outcomes use `WARN`; 5xx outcomes and exceptions use `ERROR`.
 
-Logging is local and has no network transport. Request logs use route templates
-and deliberately omit query strings, headers, bodies, source-directory paths,
-and transcript content. Exception records include the runtime error message and
-stack trace, which can contain local code or database paths. Redirect or pipe
-stderr to an external processor if retention, rotation, or shipping is needed;
-those policies stay outside the application process.
+Logging is local and has no network transport. Completed `http.server.request`
+records use route templates. Rejection and exception diagnostics use the URL
+path, but no request record includes query strings, headers, bodies,
+source-directory paths, or transcript content. Exception records include the
+runtime error message and stack trace, which can contain local code or database
+paths. Redirect or pipe stderr to an external processor if retention, rotation,
+or shipping is needed; those policies stay outside the application process.

--- a/scripts/dist-check.ts
+++ b/scripts/dist-check.ts
@@ -36,6 +36,7 @@ if (target == null) {
 
 const binary = buildTarget(target, { outDir: binaryDir, version });
 assertVersion(binary, ["--version"], {}, version);
+await assertOpenApi(binary, version);
 
 stageNpmPackages({
   outDir: npmDir,
@@ -94,6 +95,84 @@ function assertVersion(
   const result = runCommand(command, args, { env });
   if (!result.stdout.includes(expected)) {
     throw new Error(`expected ${expected} in version output, got: ${result.stdout.trim()}`);
+  }
+}
+
+async function assertOpenApi(binary: string, expectedVersion: string): Promise<void> {
+  const serveDir = mkdtempSync(join(outRoot, "serve-"));
+  const proc = Bun.spawn(
+    [
+      binary,
+      "--db",
+      join(serveDir, "decant.db"),
+      "--no-sync",
+      "serve",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      "0",
+    ],
+    {
+      env: {
+        ...process.env,
+        DECANT_CONFIG_DIR: join(serveDir, "config"),
+        DECANT_LOG_LEVEL: "info",
+      },
+      stderr: "pipe",
+      stdout: "ignore",
+    },
+  );
+  let startupTimeout: ReturnType<typeof setTimeout> | null = null;
+  try {
+    const port = await Promise.race([
+      readServePort(proc),
+      new Promise<never>(
+        (_resolve, reject) =>
+          (startupTimeout = setTimeout(
+            () => reject(new Error("compiled binary did not start within 10s")),
+            10_000,
+          )),
+      ),
+    ]);
+    const response = await fetch(`http://127.0.0.1:${port}/api/openapi.json`);
+    if (!response.ok) {
+      throw new Error(`compiled binary returned ${response.status} for /api/openapi.json`);
+    }
+    const document = (await response.json()) as {
+      info?: { version?: unknown };
+      paths?: Record<string, unknown>;
+    };
+    if (document.info?.version !== expectedVersion) {
+      throw new Error(
+        `compiled OpenAPI version was ${String(document.info?.version)}, expected ${expectedVersion}`,
+      );
+    }
+    if (document.paths?.["/api/health"] == null) {
+      throw new Error("compiled OpenAPI document is missing /api/health");
+    }
+  } finally {
+    if (startupTimeout != null) {
+      clearTimeout(startupTimeout);
+    }
+    proc.kill();
+    await proc.exited;
+  }
+}
+
+async function readServePort(proc: Bun.Subprocess<"ignore", "ignore", "pipe">): Promise<number> {
+  const reader = proc.stderr.getReader();
+  const decoder = new TextDecoder();
+  let log = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) {
+      throw new Error(`compiled binary stopped before reporting a port: ${log.slice(0, 500)}`);
+    }
+    log += decoder.decode(value, { stream: true });
+    const match = log.match(/"server\.port":\s*(\d+)/);
+    if (match?.[1] != null) {
+      return Number(match[1]);
+    }
   }
 }
 

--- a/src/api-limits.ts
+++ b/src/api-limits.ts
@@ -1,0 +1,1 @@
+export const SESSION_LIST_MAX_LIMIT = 100;

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -144,14 +144,23 @@ export function exceptionAttributes(error: unknown): Record<string, string> {
 }
 
 function httpRoute(pathname: string): string {
-  if (/^\/api\/sessions\/\d+\/token-economics$/.test(pathname)) {
-    return "/api/sessions/{id}/token-economics";
+  const sessionDetail = pathname.match(
+    /^\/api\/sessions\/[^/]+\/(token-economics|context-window|outline|issues|state)$/,
+  );
+  if (sessionDetail != null) {
+    return `/api/sessions/{id}/${sessionDetail[1]}`;
   }
-  if (/^\/api\/sessions\/\d+$/.test(pathname)) {
+  if (pathname !== "/api/sessions/search-index" && /^\/api\/sessions\/[^/]+$/.test(pathname)) {
     return "/api/sessions/{id}";
+  }
+  if (/^\/api\/reports\/session\/[^/]+\.html$/.test(pathname)) {
+    return "/api/reports/session/{id}.html";
   }
   if (/^\/sessions\/[^/]+$/.test(pathname)) {
     return "/sessions/{id}";
+  }
+  if (/^\/reports\/session\/[^/]+$/.test(pathname)) {
+    return "/reports/session/{id}";
   }
   if (pathname.startsWith("/src/ui/")) {
     return "/src/ui/*";

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1,0 +1,26 @@
+import openApiSource from "../docs/api/openapi.yaml";
+
+interface OpenApiDocument {
+  info: {
+    version: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+/**
+ * Return the embedded local API contract with the running build's version.
+ *
+ * Bun resolves the YAML import at build time, so native binaries and packaged
+ * launchers do not depend on a repository checkout or runtime docs directory.
+ */
+export function openApiDocument(version: string): OpenApiDocument {
+  const source = openApiSource as OpenApiDocument;
+  return {
+    ...source,
+    info: {
+      ...source.info,
+      version,
+    },
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1082,12 +1082,7 @@ export function serve(options: ServeOptions): ReturnType<typeof Bun.serve> {
       const activeDb = db;
       const activeEconomics = economics;
       if (activeDb == null || activeEconomics == null) {
-        return errorResponse(
-          "service_starting",
-          "Decant is still starting. Please try again.",
-          { retryable: true },
-          503,
-        );
+        return serviceStartingResponse();
       }
       try {
         const response = await handleRequest(request, options.config, {
@@ -1274,6 +1269,16 @@ export function errorResponse(
   status = 400,
 ): Response {
   return json({ error: message, code, ...extras }, status);
+}
+
+/** Stable startup response shared by the live guard and contract tests. */
+export function serviceStartingResponse(): Response {
+  return errorResponse(
+    "service_starting",
+    "Decant is still starting. Please try again.",
+    { retryable: true },
+    503,
+  );
 }
 
 function responseForError(error: unknown): Response {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { SESSION_LIST_MAX_LIMIT } from "./api-limits.ts";
 import type { Config } from "./config.ts";
 import { contextWindowForSession } from "./context-window.ts";
 import { dateFilterFromSearch } from "./date-filter.ts";
@@ -11,6 +12,7 @@ import type { Operation } from "./enrich.ts";
 import type { sync as ingestSync, SyncProgress, SyncReport } from "./ingest.ts";
 import { canLaunch, launchAgent, command as launchCommand, openIde } from "./launcher.ts";
 import { exceptionAttributes, logHttpRequest, type StructuredLogger } from "./logging.ts";
+import { openApiDocument } from "./openapi.ts";
 import {
   getSession,
   getSessionOutline,
@@ -62,6 +64,7 @@ import appleTouchIconPath from "./ui/assets/apple-touch-icon.png" with { type: "
 import faviconPath from "./ui/assets/favicon.ico" with { type: "file" };
 import uiBundle from "./ui/index.html";
 import {
+  type SyncRunnerFailure,
   type SyncRunnerResult,
   type SyncStatusStore,
   startWatch,
@@ -220,6 +223,9 @@ export async function handleRequest(
     if (request.method === "GET" && url.pathname === "/api/health") {
       return json({ ok: true });
     }
+    if (request.method === "GET" && url.pathname === "/api/openapi.json") {
+      return json(openApiDocument(DECANT_VERSION));
+    }
     if (request.method === "GET" && url.pathname === "/api/events") {
       return eventStream();
     }
@@ -247,8 +253,19 @@ export async function handleRequest(
       if (contentTypeFailure != null) {
         return contentTypeFailure;
       }
-      const body = await readJson<{ agent?: string; prompt?: string; key?: string }>(request);
-      if (body.agent == null || body.prompt == null || body.prompt.trim() === "") {
+      const body = await readJson<unknown>(request);
+      if (!isJsonObject(body)) {
+        return errorResponse("invalid_request", "request body must be a JSON object", {
+          ok: false,
+        });
+      }
+      const { agent, prompt, key } = body;
+      if (
+        typeof agent !== "string" ||
+        agent.trim() === "" ||
+        typeof prompt !== "string" ||
+        prompt.trim() === ""
+      ) {
         return errorResponse(
           "invalid_request",
           "agent and prompt are required",
@@ -256,13 +273,16 @@ export async function handleRequest(
           400,
         );
       }
-      const result = launchAgent(body.agent, body.prompt, body.key ?? null, getSettings(), {
+      if (key != null && typeof key !== "string") {
+        return errorResponse("invalid_request", "key must be a string or null", { ok: false }, 400);
+      }
+      const result = launchAgent(agent, prompt, key ?? null, getSettings(), {
         platform: context.launchPlatform,
       });
       if (result.ok) {
         return json(result);
       }
-      const command = result.command ?? launchCommand(body.agent, body.prompt);
+      const command = result.command ?? launchCommand(agent, prompt);
       return errorResponse(
         isUnsupportedLaunchError(result.error) ? "launch_unsupported_platform" : "launch_failed",
         result.error ?? "launch failed",
@@ -275,11 +295,17 @@ export async function handleRequest(
       if (contentTypeFailure != null) {
         return contentTypeFailure;
       }
-      const body = await readJson<{ dir?: string }>(request);
-      if (body.dir == null || body.dir.trim() === "") {
+      const body = await readJson<unknown>(request);
+      if (!isJsonObject(body)) {
+        return errorResponse("invalid_request", "request body must be a JSON object", {
+          ok: false,
+        });
+      }
+      const { dir } = body;
+      if (typeof dir !== "string" || dir.trim() === "") {
         return errorResponse("invalid_request", "dir is required", { ok: false }, 400);
       }
-      const result = openIde(body.dir, getSettings(), { platform: context.launchPlatform });
+      const result = openIde(dir, getSettings(), { platform: context.launchPlatform });
       return result.ok
         ? json(result)
         : errorResponse(
@@ -305,6 +331,10 @@ export async function handleRequest(
       if (contentTypeFailure != null) {
         return contentTypeFailure;
       }
+      const body = await readJson<unknown>(request);
+      if (!isJsonObject(body)) {
+        return errorResponse("invalid_request", "request body must be a JSON object", {}, 400);
+      }
       return await syncNow(
         config,
         context.economics,
@@ -322,7 +352,7 @@ export async function handleRequest(
             includeSubagents: url.searchParams.get("include_subagents") === "true",
             includeNestedSubagents: url.searchParams.get("with_subagents") === "true",
             includeArchived: url.searchParams.get("include_archived") === "true",
-            limit: integerParam(url, "limit", 50),
+            limit: Math.min(integerParam(url, "limit", 50), SESSION_LIST_MAX_LIMIT),
             offset: integerParam(url, "offset", 0, true),
             ...dateFilter,
           }),
@@ -652,18 +682,28 @@ export async function handleRequest(
       if (contentTypeFailure != null) {
         return contentTypeFailure;
       }
-      const body = await readJson<{ key?: string; source?: string; note?: string }>(request);
-      if (body.key == null || body.key.trim() === "") {
+      const body = await readJson<unknown>(request);
+      if (!isJsonObject(body)) {
+        return errorResponse("invalid_request", "request body must be a JSON object", {}, 400);
+      }
+      const { key, source, note } = body;
+      if (typeof key !== "string" || key.trim() === "") {
         return errorResponse("invalid_request", "key is required", {}, 400);
       }
+      if (source != null && typeof source !== "string") {
+        return errorResponse("invalid_request", "source must be a string or null", {}, 400);
+      }
+      if (note != null && typeof note !== "string") {
+        return errorResponse("invalid_request", "note must be a string or null", {}, 400);
+      }
       return withDb(config, context, (db) => {
-        const ok = markImplemented(db, body.key as string, body.source ?? "agent", body.note);
+        const ok = markImplemented(db, key, source ?? "agent", note);
         return ok
-          ? json({ ok: true, key: body.key, status: "implemented" })
+          ? json({ ok: true, key, status: "implemented" })
           : errorResponse(
               "recommendation_not_found",
               "recommendation not found",
-              { ok: false, key: body.key },
+              { ok: false, key },
               404,
             );
       });
@@ -753,6 +793,12 @@ async function syncNow(
       syncStatus.in_progress = false;
       syncStatus.last_sync_at = new Date().toISOString();
       syncStatus.last_error = error instanceof Error ? error.message : String(error);
+      publishServerEvent({
+        type: "error",
+        reason: "manual",
+        error: syncStatus.last_error,
+        status: { ...syncStatus },
+      });
     }
     throw error;
   }
@@ -1157,7 +1203,7 @@ export function serve(options: ServeOptions): ReturnType<typeof Bun.serve> {
 
 /** Runs one watcher-triggered sync in a worker thread, keeping request
  * handling responsive while multi-second ingests run. */
-async function workerSyncRunner(
+export async function workerSyncRunner(
   config: Config,
   status: SyncStatusStore,
   cancel: { aborted: boolean },
@@ -1166,16 +1212,16 @@ async function workerSyncRunner(
     promise: runSyncWorker(workerConfig, workerCancel, workerProgress),
     owned: true,
   }),
-): Promise<SyncRunnerResult> {
+): Promise<SyncRunnerResult | SyncRunnerFailure> {
   status.start();
+  const handle = runSync(config, cancel, onProgress);
   try {
-    const handle = runSync(config, cancel, onProgress);
     const report = await handle.promise;
     status.finishOk(report);
     return { report, emitTerminal: handle.owned };
   } catch (error) {
     status.finishErr(error instanceof Error ? error.message : String(error));
-    throw error;
+    return { error, emitTerminal: handle.owned };
   }
 }
 
@@ -1760,6 +1806,10 @@ async function readJson<T>(request: Request): Promise<T> {
   } catch {
     throw new RequestBodyError();
   }
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
 }
 
 function integerParam(url: URL, name: string, fallback: number, allowZero = false): number {

--- a/src/ui/loading-state.ts
+++ b/src/ui/loading-state.ts
@@ -1,3 +1,5 @@
+import { SESSION_LIST_MAX_LIMIT } from "../api-limits.ts";
+
 export type SessionLoadPlan = {
   limit: number;
   offset: number;
@@ -19,14 +21,13 @@ export function planSessionLoad({
 }): SessionLoadPlan | null {
   const refreshFirstPage = loadedRequestKey !== requestKey;
   const offset = refreshFirstPage ? 0 : loadedRows;
-  const desiredLimit = refreshFirstPage
-    ? Math.max(sessionLimit, pageSize)
-    : sessionLimit - loadedRows;
-  const limit = Math.max(0, desiredLimit);
+  const desiredRows = Math.max(sessionLimit, pageSize);
+  const remainingRows = desiredRows - offset;
+  const limit = Math.min(SESSION_LIST_MAX_LIMIT, Math.max(0, remainingRows));
   if (limit <= 0) {
     return null;
   }
-  return { limit, offset, replace: offset === 0 };
+  return { limit, offset, replace: refreshFirstPage };
 }
 
 export function shouldShowSessionSkeleton({

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -63,10 +63,16 @@ export type SyncRunner = (
   status: SyncStatusStore,
   cancel: { aborted: boolean },
   onProgress: (progress: SyncProgress) => void,
-) => Promise<SyncReport | SyncRunnerResult>;
+) => Promise<SyncReport | SyncRunnerResult | SyncRunnerFailure>;
 
 export interface SyncRunnerResult {
   report: SyncReport;
+  /** False when this watcher joined a run whose terminal events have another owner. */
+  emitTerminal: boolean;
+}
+
+export interface SyncRunnerFailure {
+  error: unknown;
   /** False when this watcher joined a run whose terminal events have another owner. */
   emitTerminal: boolean;
 }
@@ -249,10 +255,21 @@ export function startWatch(options: WatchOptions): WatchHandle {
           const result = await runner(options.config, status, cancel, (progress) => {
             emit({ type: "sync_progress", reason: current, progress, status: status.snapshot() });
           });
-          const { report, emitTerminal } =
-            "report" in result ? result : { report: result, emitTerminal: true };
-          if (emitTerminal) {
-            emit({ type: "sync", reason: current, report, status: status.snapshot() });
+          if ("error" in result) {
+            if (result.emitTerminal) {
+              emit({
+                type: "error",
+                reason: current,
+                error: result.error instanceof Error ? result.error.message : String(result.error),
+                status: status.snapshot(),
+              });
+            }
+          } else {
+            const { report, emitTerminal } =
+              "report" in result ? result : { report: result, emitTerminal: true };
+            if (emitTerminal) {
+              emit({ type: "sync", reason: current, report, status: status.snapshot() });
+            }
           }
         } catch (error) {
           emit({

--- a/test/api-contract.test.ts
+++ b/test/api-contract.test.ts
@@ -8,7 +8,7 @@ import { openDb } from "../src/db.ts";
 import { DECANT_VERSION } from "../src/distill.ts";
 import { upsertSession } from "../src/ingest.ts";
 import { regenerate } from "../src/recommendations.ts";
-import { serve } from "../src/server.ts";
+import { serve, serviceStartingResponse } from "../src/server.ts";
 import { parseClaudeSession } from "../src/sources/claude.ts";
 import { parseCodexSession } from "../src/sources/codex.ts";
 
@@ -20,8 +20,11 @@ interface ContractCase {
   url: string;
   status?: number;
   body?: unknown;
+  expectedCode?: string;
+  headers?: Record<string, string>;
   mediaType?: "application/json" | "text/event-stream" | "text/html";
   requestValid?: boolean;
+  response?: () => Response | Promise<Response>;
 }
 
 interface OpenApiOperation {
@@ -33,6 +36,7 @@ interface OpenApiOperation {
   responses: Record<
     string,
     {
+      $ref?: string;
       content?: Record<string, { schema?: Record<string, unknown> }>;
     }
   >;
@@ -245,6 +249,77 @@ describe("local API OpenAPI contract", () => {
           body: { key: recommendationKey, source: "api-contract", note: "fixture-only" },
         },
       ];
+      const errorCases: ContractCase[] = [
+        {
+          path: "/api/health",
+          method: "get",
+          url: "/api/health",
+          status: 503,
+          expectedCode: "service_starting",
+          response: serviceStartingResponse,
+        },
+        {
+          path: "/api/health",
+          method: "get",
+          url: "/api/health",
+          status: 403,
+          expectedCode: "forbidden_host",
+          headers: { host: "remote.invalid" },
+        },
+        {
+          path: "/api/sessions/{id}",
+          method: "get",
+          url: "/api/sessions/not-a-number",
+          status: 400,
+          expectedCode: "invalid_session_id",
+        },
+        {
+          path: "/api/sessions/{id}",
+          method: "get",
+          url: "/api/sessions/999999999",
+          status: 404,
+          expectedCode: "session_not_found",
+        },
+        {
+          path: "/api/search",
+          method: "post",
+          url: "/api/search",
+          body: {},
+          status: 400,
+          expectedCode: "query_required",
+          requestValid: false,
+        },
+        {
+          path: "/api/stats/by-dimension",
+          method: "get",
+          url: "/api/stats/by-dimension?dim=unknown",
+          status: 400,
+          expectedCode: "unknown_dimension",
+        },
+        {
+          path: "/api/files",
+          method: "get",
+          url: "/api/files?group=unknown",
+          status: 400,
+          expectedCode: "invalid_files_query",
+        },
+        {
+          path: "/api/recommendations",
+          method: "get",
+          url: "/api/recommendations?status=unknown",
+          status: 400,
+          expectedCode: "unknown_status",
+        },
+        {
+          path: "/api/settings",
+          method: "post",
+          url: "/api/settings",
+          body: {},
+          headers: { "content-type": "text/plain" },
+          status: 415,
+          expectedCode: "unsupported_media_type",
+        },
+      ];
 
       expect(operationKeys(document)).toEqual(
         cases.map((entry) => `${entry.method.toUpperCase()} ${entry.path}`).sort(),
@@ -286,6 +361,19 @@ describe("local API OpenAPI contract", () => {
       ]);
       expect(requestPropertyNames(document, "/api/search", "post")).toContain("include_total");
       expect(requestPropertyNames(document, "/api/sessions/{id}/state", "post")).toEqual(["state"]);
+      expect(operationDescription(document, "/api/sessions", "get")).toContain(
+        "A final short or empty page marks the end",
+      );
+      expect(operationDescription(document, "/api/sessions/search-index", "get")).toContain(
+        "top-level",
+      );
+      const routesDocumentation = readFileSync(
+        join(import.meta.dir, "..", "docs", "api", "routes.md"),
+        "utf8",
+      );
+      expect(routesDocumentation).toContain("## UI routes");
+      expect(routesDocumentation).toContain("GET /api/sessions/search-index");
+      expect(routesDocumentation).toMatch(/final short\s+or empty page/);
       expect(sseEventNames(document)).toEqual([
         "archive_updated",
         "error",
@@ -298,18 +386,24 @@ describe("local API OpenAPI contract", () => {
       ]);
       const validators = new Map<string, ValidateFunction>();
 
-      for (const contractCase of cases) {
+      for (const contractCase of [...cases, ...errorCases]) {
         const expectedStatus = contractCase.status ?? 200;
         const expectedMediaType = contractCase.mediaType ?? "application/json";
-        const response = await fetch(`${baseUrl}${contractCase.url}`, {
-          method: contractCase.method.toUpperCase(),
-          ...(contractCase.body === undefined
-            ? {}
-            : {
-                body: JSON.stringify(contractCase.body),
-                headers: { "content-type": "application/json" },
-              }),
-        });
+        const response =
+          contractCase.response == null
+            ? await fetch(`${baseUrl}${contractCase.url}`, {
+                method: contractCase.method.toUpperCase(),
+                ...(contractCase.body === undefined
+                  ? { headers: contractCase.headers }
+                  : {
+                      body: JSON.stringify(contractCase.body),
+                      headers: {
+                        "content-type": "application/json",
+                        ...contractCase.headers,
+                      },
+                    }),
+              })
+            : await contractCase.response();
         expect(response.status).toBe(expectedStatus);
         expect(response.headers.get("content-type")).toStartWith(expectedMediaType);
         if (contractCase.body !== undefined) {
@@ -327,6 +421,9 @@ describe("local API OpenAPI contract", () => {
             : expectedMediaType === "text/event-stream"
               ? await firstStreamChunk(response)
               : await response.text();
+        if (contractCase.expectedCode != null) {
+          expect(value).toMatchObject({ code: contractCase.expectedCode });
+        }
         if (expectedMediaType === "text/event-stream") {
           const frame = parseSseFrame(value as string);
           expect(frame.event).toBe("hello");
@@ -529,6 +626,12 @@ function requestPropertyNames(
   return Object.keys(resolved.properties ?? {}).sort();
 }
 
+function operationDescription(document: OpenApiDocument, path: string, method: HttpMethod): string {
+  return (
+    (document.paths[path]?.[method] as { description?: string } | undefined)?.description ?? ""
+  );
+}
+
 function sseEventNames(document: OpenApiDocument): string[] {
   return Object.keys(document.paths["/api/events"]?.get?.["x-sse-events"] ?? {}).sort();
 }
@@ -573,10 +676,22 @@ function compileResponseValidator(
   status: number,
   mediaType: string,
 ): ValidateFunction {
-  const operation = openApiFromAjv(ajv).paths?.[path]?.[method];
-  const schema = operation?.responses[String(status)]?.content?.[mediaType]?.schema;
+  const document = openApiFromAjv(ajv);
+  const operation = document.paths?.[path]?.[method];
+  const documentedResponse = operation?.responses[String(status)];
+  const response =
+    documentedResponse?.$ref == null
+      ? documentedResponse
+      : resolveLocalRef<OpenApiOperation["responses"][string]>(document, documentedResponse.$ref);
+  const schema = response?.content?.[mediaType]?.schema;
   if (schema == null) {
     throw new Error(`${method.toUpperCase()} ${path} does not document ${status} ${mediaType}`);
+  }
+  if (documentedResponse?.$ref != null) {
+    return ajv.compile({
+      $ref:
+        `decant-openapi${documentedResponse.$ref}/content/` + `${jsonPointer(mediaType)}/schema`,
+    });
   }
   return ajv.compile({
     $ref:

--- a/test/api-contract.test.ts
+++ b/test/api-contract.test.ts
@@ -1,0 +1,612 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Ajv2020, { type ValidateFunction } from "ajv/dist/2020.js";
+import type { Config } from "../src/config.ts";
+import { openDb } from "../src/db.ts";
+import { DECANT_VERSION } from "../src/distill.ts";
+import { upsertSession } from "../src/ingest.ts";
+import { regenerate } from "../src/recommendations.ts";
+import { serve } from "../src/server.ts";
+import { parseClaudeSession } from "../src/sources/claude.ts";
+import { parseCodexSession } from "../src/sources/codex.ts";
+
+type HttpMethod = "get" | "post";
+
+interface ContractCase {
+  path: string;
+  method: HttpMethod;
+  url: string;
+  status?: number;
+  body?: unknown;
+  mediaType?: "application/json" | "text/event-stream" | "text/html";
+  requestValid?: boolean;
+}
+
+interface OpenApiOperation {
+  operationId?: string;
+  parameters?: Array<{ $ref?: string; in?: string; name?: string }>;
+  requestBody?: {
+    content?: Record<string, { schema?: Record<string, unknown> }>;
+  };
+  responses: Record<
+    string,
+    {
+      content?: Record<string, { schema?: Record<string, unknown> }>;
+    }
+  >;
+  "x-sse-events"?: Record<string, { $ref: string }>;
+}
+
+interface OpenApiDocument {
+  info: { version: string };
+  paths: Record<string, Partial<Record<HttpMethod, OpenApiOperation>>>;
+}
+
+const HTTP_METHODS = new Set(["delete", "get", "head", "options", "patch", "post", "put", "trace"]);
+
+describe("local API OpenAPI contract", () => {
+  test("boots a fixture archive and validates every documented operation response", async () => {
+    const root = mkdtempSync(join(tmpdir(), "decant-api-contract-"));
+    const priorConfigDir = process.env.DECANT_CONFIG_DIR;
+    process.env.DECANT_CONFIG_DIR = join(root, "config");
+    const config = fixtureConfig(root);
+    seed(config);
+    const server = serve({
+      config,
+      hostname: "127.0.0.1",
+      port: 0,
+      syncRunner: async () => ({
+        scanned: 0,
+        ingested: 0,
+        skipped: 0,
+        issues: 0,
+        issuesByCode: {},
+        failed: 0,
+        cancelled: false,
+      }),
+    });
+
+    try {
+      const baseUrl = `http://127.0.0.1:${server.port}`;
+      const documentResponse = await fetch(`${baseUrl}/api/openapi.json`);
+      expect(documentResponse.status).toBe(200);
+      const document = (await documentResponse.json()) as OpenApiDocument;
+      expect(document.info.version).toBe(DECANT_VERSION);
+
+      const sessions = (await fetchJson(`${baseUrl}/api/sessions?limit=1`)) as {
+        id: number;
+      }[];
+      const sessionId = sessions[0]?.id;
+      if (sessionId == null) {
+        throw new Error("fixture archive must expose a session");
+      }
+      const recommendations = (await fetchJson(`${baseUrl}/api/recommendations?status=all`)) as {
+        key: string;
+      }[];
+      const recommendationKey = recommendations[0]?.key;
+      if (recommendationKey == null) {
+        throw new Error("fixture archive must expose a recommendation");
+      }
+
+      const cases: ContractCase[] = [
+        { path: "/api/health", method: "get", url: "/api/health" },
+        { path: "/api/openapi.json", method: "get", url: "/api/openapi.json" },
+        {
+          path: "/api/events",
+          method: "get",
+          url: "/api/events",
+          mediaType: "text/event-stream",
+        },
+        { path: "/api/config", method: "get", url: "/api/config" },
+        { path: "/api/settings", method: "get", url: "/api/settings" },
+        { path: "/api/settings", method: "post", url: "/api/settings", body: {} },
+        {
+          path: "/api/launch/agent",
+          method: "post",
+          url: "/api/launch/agent",
+          body: {},
+          status: 400,
+          requestValid: false,
+        },
+        {
+          path: "/api/launch/ide",
+          method: "post",
+          url: "/api/launch/ide",
+          body: {},
+          status: 400,
+          requestValid: false,
+        },
+        { path: "/api/sync-status", method: "get", url: "/api/sync-status" },
+        {
+          path: "/api/metadata/sync-status",
+          method: "get",
+          url: "/api/metadata/sync-status",
+        },
+        { path: "/api/sync", method: "post", url: "/api/sync", body: {} },
+        {
+          path: "/api/sessions",
+          method: "get",
+          url: "/api/sessions?limit=1&offset=0&tool=claude_code",
+        },
+        {
+          path: "/api/sessions/search-index",
+          method: "get",
+          url: "/api/sessions/search-index",
+        },
+        { path: "/api/projects", method: "get", url: "/api/projects" },
+        {
+          path: "/api/sessions/{id}/state",
+          method: "post",
+          url: `/api/sessions/${sessionId}/state`,
+          body: { state: "visible" },
+        },
+        {
+          path: "/api/sessions/{id}/token-economics",
+          method: "get",
+          url: `/api/sessions/${sessionId}/token-economics`,
+        },
+        {
+          path: "/api/sessions/{id}/context-window",
+          method: "get",
+          url: `/api/sessions/${sessionId}/context-window`,
+        },
+        {
+          path: "/api/sessions/{id}/outline",
+          method: "get",
+          url: `/api/sessions/${sessionId}/outline`,
+        },
+        {
+          path: "/api/sessions/{id}/issues",
+          method: "get",
+          url: `/api/sessions/${sessionId}/issues`,
+        },
+        {
+          path: "/api/sessions/{id}",
+          method: "get",
+          url: `/api/sessions/${sessionId}?message_limit=2&message_offset=0`,
+        },
+        {
+          path: "/api/search",
+          method: "post",
+          url: "/api/search",
+          body: { query: "auth", limit: 1, include_total: false },
+        },
+        { path: "/api/stats/summary", method: "get", url: "/api/stats/summary" },
+        {
+          path: "/api/stats/by-dimension",
+          method: "get",
+          url: "/api/stats/by-dimension?dim=tool",
+        },
+        {
+          path: "/api/analytics/activity",
+          method: "get",
+          url: "/api/analytics/activity",
+        },
+        {
+          path: "/api/analytics/model-sparklines",
+          method: "get",
+          url: "/api/analytics/model-sparklines",
+        },
+        {
+          path: "/api/analytics/token-economics",
+          method: "get",
+          url: "/api/analytics/token-economics",
+        },
+        { path: "/api/analytics/now", method: "get", url: "/api/analytics/now" },
+        {
+          path: "/api/reports/analytics.html",
+          method: "get",
+          url: "/api/reports/analytics.html",
+          mediaType: "text/html",
+        },
+        {
+          path: "/api/reports/session/{id}.html",
+          method: "get",
+          url: `/api/reports/session/${sessionId}.html`,
+          mediaType: "text/html",
+        },
+        { path: "/api/date-bounds", method: "get", url: "/api/date-bounds" },
+        {
+          path: "/api/metadata/date-bounds",
+          method: "get",
+          url: "/api/metadata/date-bounds",
+        },
+        {
+          path: "/api/files",
+          method: "get",
+          url: "/api/files?group=path&limit=10",
+        },
+        {
+          path: "/api/tools/calls",
+          method: "get",
+          url: "/api/tools/calls?limit=10&offset=0",
+        },
+        {
+          path: "/api/tools/usage",
+          method: "get",
+          url: "/api/tools/usage?limit=10",
+        },
+        {
+          path: "/api/tools/mcp-usage",
+          method: "get",
+          url: "/api/tools/mcp-usage?limit=10",
+        },
+        {
+          path: "/api/recommendations",
+          method: "get",
+          url: "/api/recommendations?status=all",
+        },
+        {
+          path: "/api/recommendations/mark",
+          method: "post",
+          url: "/api/recommendations/mark",
+          body: { key: recommendationKey, source: "api-contract", note: "fixture-only" },
+        },
+      ];
+
+      expect(operationKeys(document)).toEqual(
+        cases.map((entry) => `${entry.method.toUpperCase()} ${entry.path}`).sort(),
+      );
+
+      const ajv = new Ajv2020({
+        allErrors: true,
+        strict: false,
+        validateFormats: false,
+      });
+      ajv.addSchema(document, "decant-openapi");
+      expect(validateDocumentSchemas(ajv, document)).toBeGreaterThan(100);
+      expect(parameterNames(document, "/api/sessions", "get")).toEqual([
+        "from",
+        "include_archived",
+        "include_subagents",
+        "limit",
+        "model",
+        "offset",
+        "project",
+        "to",
+        "tool",
+        "with_subagents",
+      ]);
+      expect(parameterNames(document, "/api/stats/summary", "get")).toEqual([
+        "from",
+        "include_archived",
+        "project",
+        "to",
+        "tool",
+      ]);
+      expect(parameterNames(document, "/api/stats/by-dimension", "get")).toEqual([
+        "dim",
+        "from",
+        "include_archived",
+        "project",
+        "to",
+        "tool",
+      ]);
+      expect(requestPropertyNames(document, "/api/search", "post")).toContain("include_total");
+      expect(requestPropertyNames(document, "/api/sessions/{id}/state", "post")).toEqual(["state"]);
+      expect(sseEventNames(document)).toEqual([
+        "archive_updated",
+        "error",
+        "hello",
+        "ping",
+        "ready",
+        "stopped",
+        "sync",
+        "sync_progress",
+      ]);
+      const validators = new Map<string, ValidateFunction>();
+
+      for (const contractCase of cases) {
+        const expectedStatus = contractCase.status ?? 200;
+        const expectedMediaType = contractCase.mediaType ?? "application/json";
+        const response = await fetch(`${baseUrl}${contractCase.url}`, {
+          method: contractCase.method.toUpperCase(),
+          ...(contractCase.body === undefined
+            ? {}
+            : {
+                body: JSON.stringify(contractCase.body),
+                headers: { "content-type": "application/json" },
+              }),
+        });
+        expect(response.status).toBe(expectedStatus);
+        expect(response.headers.get("content-type")).toStartWith(expectedMediaType);
+        if (contractCase.body !== undefined) {
+          const validateRequest = compileRequestValidator(
+            ajv,
+            contractCase.path,
+            contractCase.method,
+          );
+          expect(validateRequest(contractCase.body)).toBe(contractCase.requestValid !== false);
+        }
+
+        const value =
+          expectedMediaType === "application/json"
+            ? await response.json()
+            : expectedMediaType === "text/event-stream"
+              ? await firstStreamChunk(response)
+              : await response.text();
+        if (expectedMediaType === "text/event-stream") {
+          const frame = parseSseFrame(value as string);
+          expect(frame.event).toBe("hello");
+          const validateEvent = compileSseEventValidator(ajv, frame.event);
+          if (!validateEvent(frame.data)) {
+            throw new Error(
+              `SSE ${frame.event} violated its schema: ` +
+                ajv.errorsText(validateEvent.errors, { separator: "\n" }),
+            );
+          }
+        }
+
+        const validatorKey = [
+          contractCase.path,
+          contractCase.method,
+          expectedStatus,
+          expectedMediaType,
+        ].join("|");
+        let validate = validators.get(validatorKey);
+        if (validate == null) {
+          validate = compileResponseValidator(
+            ajv,
+            contractCase.path,
+            contractCase.method,
+            expectedStatus,
+            expectedMediaType,
+          );
+          validators.set(validatorKey, validate);
+        }
+        if (!validate(value)) {
+          throw new Error(
+            `${contractCase.method.toUpperCase()} ${contractCase.path} violated its ` +
+              `${expectedStatus} schema: ${ajv.errorsText(validate.errors, { separator: "\n" })}`,
+          );
+        }
+      }
+    } finally {
+      await server.stop(true);
+      if (priorConfigDir == null) {
+        delete process.env.DECANT_CONFIG_DIR;
+      } else {
+        process.env.DECANT_CONFIG_DIR = priorConfigDir;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 30_000);
+});
+
+function fixtureConfig(root: string): Config {
+  const claudeDir = join(root, "claude");
+  const codexDir = join(root, "codex");
+  mkdirSync(claudeDir, { recursive: true });
+  mkdirSync(codexDir, { recursive: true });
+  return {
+    dbPath: join(root, "archive.db"),
+    claudeDir,
+    codexDir,
+  };
+}
+
+function seed(config: Config): void {
+  const db = openDb(config.dbPath);
+  const fixture = (tool: "claude" | "codex", name: string): string =>
+    readFileSync(join(import.meta.dir, "..", "fixtures", tool, name), "utf8");
+  upsertSession(
+    db,
+    parseClaudeSession("contract-claude", fixture("claude", "sample.jsonl")),
+    "/synthetic/claude.jsonl",
+    1,
+    2,
+    "contract-claude",
+  );
+  upsertSession(
+    db,
+    parseCodexSession("contract-codex", fixture("codex", "enriched.jsonl"), new Map()),
+    "/synthetic/codex.jsonl",
+    1,
+    2,
+    "contract-codex",
+  );
+  regenerate(db);
+  db.close();
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`${url} returned ${response.status}`);
+  }
+  return await response.json();
+}
+
+async function firstStreamChunk(response: Response): Promise<string> {
+  const reader = response.body?.getReader();
+  if (reader == null) {
+    throw new Error("SSE response did not expose a body");
+  }
+  try {
+    const { value, done } = await reader.read();
+    if (done || value == null) {
+      throw new Error("SSE response ended before its hello event");
+    }
+    return new TextDecoder().decode(value);
+  } finally {
+    await reader.cancel();
+  }
+}
+
+function operationKeys(document: OpenApiDocument): string[] {
+  return Object.entries(document.paths)
+    .flatMap(([path, item]) =>
+      Object.keys(item)
+        .filter((key): key is HttpMethod => HTTP_METHODS.has(key))
+        .map((method) => `${method.toUpperCase()} ${path}`),
+    )
+    .sort();
+}
+
+function validateDocumentSchemas(ajv: Ajv2020, document: OpenApiDocument): number {
+  const compiled = new Set<string>();
+  const compilePointer = (pointer: string): void => {
+    if (compiled.has(pointer)) {
+      return;
+    }
+    try {
+      ajv.compile({ $ref: `decant-openapi#${pointer}` });
+    } catch (error) {
+      throw new Error(
+        `invalid OpenAPI schema at ${pointer}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      );
+    }
+    compiled.add(pointer);
+  };
+  const walk = (value: unknown, segments: string[]): void => {
+    if (Array.isArray(value)) {
+      for (const [index, child] of value.entries()) {
+        walk(child, [...segments, String(index)]);
+      }
+      return;
+    }
+    if (value == null || typeof value !== "object") {
+      return;
+    }
+    for (const [key, child] of Object.entries(value)) {
+      const childSegments = [...segments, key];
+      if (key === "schema" && child != null && typeof child === "object") {
+        compilePointer(`/${childSegments.map(jsonPointer).join("/")}`);
+      }
+      if (key === "$ref" && typeof child === "string" && child.startsWith("#/")) {
+        try {
+          resolveLocalRef(document, child);
+        } catch (error) {
+          throw new Error(
+            `invalid OpenAPI reference at /${childSegments
+              .map(jsonPointer)
+              .join("/")}: ${error instanceof Error ? error.message : String(error)}`,
+            { cause: error },
+          );
+        }
+      }
+      walk(child, childSegments);
+    }
+  };
+
+  const schemas = resolveLocalRef<Record<string, unknown>>(document, "#/components/schemas");
+  for (const name of Object.keys(schemas)) {
+    compilePointer(`/components/schemas/${jsonPointer(name)}`);
+  }
+  walk(document, []);
+  return compiled.size;
+}
+
+function parameterNames(document: OpenApiDocument, path: string, method: HttpMethod): string[] {
+  return (document.paths[path]?.[method]?.parameters ?? [])
+    .map((parameter) =>
+      parameter.$ref == null
+        ? parameter.name
+        : resolveLocalRef<{ name?: string }>(document, parameter.$ref).name,
+    )
+    .filter((name): name is string => name != null)
+    .sort();
+}
+
+function requestPropertyNames(
+  document: OpenApiDocument,
+  path: string,
+  method: HttpMethod,
+): string[] {
+  const schema = document.paths[path]?.[method]?.requestBody?.content?.["application/json"]?.schema;
+  if (schema == null) {
+    throw new Error(`${method.toUpperCase()} ${path} does not document a JSON request body`);
+  }
+  const resolved =
+    typeof schema.$ref === "string"
+      ? resolveLocalRef<{ properties?: Record<string, unknown> }>(document, schema.$ref)
+      : (schema as { properties?: Record<string, unknown> });
+  return Object.keys(resolved.properties ?? {}).sort();
+}
+
+function sseEventNames(document: OpenApiDocument): string[] {
+  return Object.keys(document.paths["/api/events"]?.get?.["x-sse-events"] ?? {}).sort();
+}
+
+function compileRequestValidator(ajv: Ajv2020, path: string, method: HttpMethod): ValidateFunction {
+  const operation = openApiFromAjv(ajv).paths[path]?.[method];
+  if (operation?.requestBody?.content?.["application/json"]?.schema == null) {
+    throw new Error(`${method.toUpperCase()} ${path} does not document a JSON request body`);
+  }
+  return ajv.compile({
+    $ref:
+      `decant-openapi#/paths/${jsonPointer(path)}/${method}/requestBody/content/` +
+      `${jsonPointer("application/json")}/schema`,
+  });
+}
+
+function compileSseEventValidator(ajv: Ajv2020, event: string): ValidateFunction {
+  const events = openApiFromAjv(ajv).paths["/api/events"]?.get?.["x-sse-events"];
+  if (events?.[event] == null) {
+    throw new Error(`GET /api/events does not document the ${event} event`);
+  }
+  return ajv.compile({
+    $ref:
+      `decant-openapi#/paths/${jsonPointer("/api/events")}/get/` +
+      `${jsonPointer("x-sse-events")}/${jsonPointer(event)}`,
+  });
+}
+
+function parseSseFrame(value: string): { data: unknown; event: string } {
+  const event = value.match(/^event: ([^\r\n]+)$/m)?.[1];
+  const data = value.match(/^data: (.+)$/m)?.[1];
+  if (event == null || data == null) {
+    throw new Error(`invalid SSE frame: ${value.slice(0, 200)}`);
+  }
+  return { event, data: JSON.parse(data) };
+}
+
+function compileResponseValidator(
+  ajv: Ajv2020,
+  path: string,
+  method: HttpMethod,
+  status: number,
+  mediaType: string,
+): ValidateFunction {
+  const operation = openApiFromAjv(ajv).paths?.[path]?.[method];
+  const schema = operation?.responses[String(status)]?.content?.[mediaType]?.schema;
+  if (schema == null) {
+    throw new Error(`${method.toUpperCase()} ${path} does not document ${status} ${mediaType}`);
+  }
+  return ajv.compile({
+    $ref:
+      `decant-openapi#/paths/${jsonPointer(path)}/${method}/responses/${status}/content/` +
+      `${jsonPointer(mediaType)}/schema`,
+  });
+}
+
+function openApiFromAjv(ajv: Ajv2020): OpenApiDocument {
+  return (
+    (ajv.getSchema("decant-openapi")?.schema as OpenApiDocument | undefined) ??
+    ({} as OpenApiDocument)
+  );
+}
+
+function resolveLocalRef<T>(document: OpenApiDocument, ref: string): T {
+  if (!ref.startsWith("#/")) {
+    throw new Error(`only local OpenAPI refs are supported, got ${ref}`);
+  }
+  let value: unknown = document;
+  for (const rawSegment of ref.slice(2).split("/")) {
+    const segment = rawSegment.replaceAll("~1", "/").replaceAll("~0", "~");
+    if (value == null || typeof value !== "object" || !(segment in value)) {
+      throw new Error(`unresolved OpenAPI ref ${ref}`);
+    }
+    value = (value as Record<string, unknown>)[segment];
+  }
+  return value as T;
+}
+
+function jsonPointer(value: string): string {
+  return value.replaceAll("~", "~0").replaceAll("/", "~1");
+}

--- a/test/logging.test.ts
+++ b/test/logging.test.ts
@@ -139,6 +139,36 @@ describe("structured logging", () => {
     expect(lines.join("")).not.toContain("do-not-log");
   });
 
+  test("normalizes dynamic session and report routes", () => {
+    const lines: string[] = [];
+    configureLogging({
+      level: "info",
+      write: (line) => lines.push(line),
+    });
+    const logger = getDecantLogger("server");
+    const routes = [
+      ["/api/sessions/42", "/api/sessions/{id}"],
+      ["/api/sessions/42/token-economics", "/api/sessions/{id}/token-economics"],
+      ["/api/sessions/not-a-number/context-window", "/api/sessions/{id}/context-window"],
+      ["/api/sessions/42/outline", "/api/sessions/{id}/outline"],
+      ["/api/sessions/42/issues", "/api/sessions/{id}/issues"],
+      ["/api/sessions/42/state", "/api/sessions/{id}/state"],
+      ["/api/reports/session/not-a-number.html", "/api/reports/session/{id}.html"],
+      ["/sessions/not-a-number", "/sessions/{id}"],
+      ["/reports/session/not-a-number", "/reports/session/{id}"],
+      ["/api/sessions/search-index", "/api/sessions/search-index"],
+    ] as const;
+
+    for (const [pathname] of routes) {
+      logHttpRequest(logger, new Request(`http://127.0.0.1:3000${pathname}`), new Response(), 1);
+    }
+
+    const records = lines.map((line) => JSON.parse(line) as StructuredLogRecord);
+    expect(records.map((record) => record["http.route"])).toEqual(
+      routes.map(([, normalized]) => normalized),
+    );
+  });
+
   test("records standard ports when an HTTP URL omits an explicit port", () => {
     const lines: string[] = [];
     configureLogging({

--- a/test/server-sync.test.ts
+++ b/test/server-sync.test.ts
@@ -3,7 +3,13 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Config } from "../src/config.ts";
-import { createSyncCoordinator, handleRequest, type SyncWorkerRunner } from "../src/server.ts";
+import {
+  createSyncCoordinator,
+  handleRequest,
+  type SyncWorkerRunner,
+  workerSyncRunner,
+} from "../src/server.ts";
+import { SyncStatusStore } from "../src/watch.ts";
 
 const workDir = mkdtempSync(join(tmpdir(), "decant-server-sync-test-"));
 afterAll(() => rmSync(workDir, { recursive: true, force: true }));
@@ -161,6 +167,44 @@ describe("server sync coordination", () => {
     release.resolve();
 
     expect(await watcher.promise).toMatchObject({ ingested: 1 });
+    expect(calls).toBe(1);
+  });
+
+  test("watcher joining a failed manual-owned sync leaves terminal error ownership to manual", async () => {
+    const config = freshConfig();
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    let calls = 0;
+    const runner: SyncWorkerRunner = async () => {
+      calls += 1;
+      entered.resolve();
+      await release.promise;
+      throw new Error("fixture sync failed");
+    };
+    const coordinator = createSyncCoordinator(runner);
+    const manual = coordinator.runWithOwnership(config);
+    expect(manual.owned).toBe(true);
+    await entered.promise;
+
+    const status = new SyncStatusStore();
+    const watcher = workerSyncRunner(
+      config,
+      status,
+      { aborted: false },
+      () => {},
+      coordinator.runWithOwnership,
+    );
+    release.resolve();
+
+    await expect(manual.promise).rejects.toThrow("fixture sync failed");
+    const result = await watcher;
+    expect(result).toMatchObject({ emitTerminal: false });
+    expect("error" in result && result.error).toEqual(new Error("fixture sync failed"));
+    expect(status.snapshot()).toMatchObject({
+      in_progress: false,
+      last_error: "fixture sync failed",
+      runs: 1,
+    });
     expect(calls).toBe(1);
   });
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -14,6 +14,7 @@ import { dirname, join } from "node:path";
 import type { Config } from "../src/config.ts";
 import { openDb } from "../src/db.ts";
 import { upsertSession } from "../src/ingest.ts";
+import { listSessions } from "../src/query.ts";
 import { regenerate } from "../src/recommendations.ts";
 import {
   handleRequest,
@@ -179,6 +180,31 @@ describe("server routes", () => {
     ]);
   });
 
+  test("caps session-list API pages without limiting core list consumers", async () => {
+    const config = freshConfig();
+    const db = openDb(config.dbPath);
+    db.exec(`
+      WITH RECURSIVE numbered(value) AS (
+        SELECT 1
+        UNION ALL
+        SELECT value + 1 FROM numbered WHERE value < 110
+      )
+      INSERT INTO session(tool, source_session_id, title, started_at, is_subagent)
+      SELECT
+        'codex',
+        'limit-cap-' || value,
+        'Session ' || value,
+        '2026-07-29T12:00:00Z',
+        0
+      FROM numbered;
+    `);
+    expect(listSessions(db, { limit: 10_000 })).toHaveLength(110);
+    db.close();
+
+    expect((await route(config, "/api/sessions?limit=10000")).body).toBeArrayOfSize(100);
+    expect((await route(config, "/api/sessions?limit=10000&offset=100")).body).toBeArrayOfSize(10);
+  });
+
   test("app routes fall back to the React shell and config is exposed locally", async () => {
     const config = freshConfig();
 
@@ -233,6 +259,38 @@ describe("server routes", () => {
     expect(frame).toContain("event: sync_progress");
     expect(frame).toContain('"scanned":0');
     expect(frame).toContain('"total":0');
+  });
+
+  test("events route terminates a failed manual sync with an error event", async () => {
+    const config = freshConfig();
+    const stream = await handleRequest(new Request("http://127.0.0.1:3000/api/events"), config);
+    const reader = stream.body?.getReader();
+    if (reader == null) {
+      throw new Error("missing SSE body");
+    }
+    await reader.read();
+
+    const response = handleRequest(
+      new Request("http://127.0.0.1:3000/api/sync", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }),
+      config,
+      {
+        runSync: async () => {
+          throw new Error("fixture sync failed");
+        },
+      },
+    );
+    const update = await reader.read();
+    expect((await response).status).toBe(500);
+    await reader.cancel();
+
+    const frame = new TextDecoder().decode(update.value);
+    expect(frame).toContain("event: error");
+    expect(frame).toContain('"reason":"manual"');
+    expect(frame).toContain('"error":"fixture sync failed"');
   });
 
   test("rejects non-loopback API hosts", async () => {
@@ -358,6 +416,56 @@ describe("server routes", () => {
         code: "malformed_body",
       },
     });
+
+    const malformedSync = await route(config, "/api/sync", {
+      method: "POST",
+      body: "{",
+    });
+    expect(malformedSync).toMatchObject({
+      status: 400,
+      body: {
+        error: "request body must be valid JSON",
+        code: "malformed_body",
+      },
+    });
+
+    expect(
+      await route(config, "/api/sync", {
+        method: "POST",
+        body: "null",
+      }),
+    ).toMatchObject({
+      status: 400,
+      body: { code: "invalid_request" },
+    });
+  });
+
+  test("rejects well-formed JSON with invalid mutation bodies without server errors", async () => {
+    const config = freshConfig();
+    const cases = [
+      ["/api/launch/agent", null],
+      ["/api/launch/agent", { agent: "codex", prompt: {} }],
+      ["/api/launch/agent", { agent: {}, prompt: "review this session" }],
+      ["/api/launch/agent", { agent: "codex", prompt: "review this session", key: {} }],
+      ["/api/launch/ide", null],
+      ["/api/launch/ide", { dir: {} }],
+      ["/api/recommendations/mark", null],
+      ["/api/recommendations/mark", { key: {} }],
+      ["/api/recommendations/mark", { key: "catalog:agents-md", source: {} }],
+      ["/api/recommendations/mark", { key: "catalog:agents-md", note: {} }],
+    ] as const;
+
+    for (const [path, body] of cases) {
+      expect(
+        await route(config, path, {
+          method: "POST",
+          body: JSON.stringify(body),
+        }),
+      ).toMatchObject({
+        status: 400,
+        body: { code: "invalid_request" },
+      });
+    }
   });
 
   test("settings routes read options and persist sanitized choices", async () => {

--- a/test/ui-loading-state.test.ts
+++ b/test/ui-loading-state.test.ts
@@ -22,7 +22,7 @@ describe("session loading state", () => {
     ).toEqual({ limit: 100, offset: 0, replace: true });
   });
 
-  test("preserves expanded load depth when refreshing in the background", () => {
+  test("preserves expanded refresh depth through successive bounded pages", () => {
     expect(
       planSessionLoad({
         loadedRequestKey: "all:1",
@@ -31,7 +31,34 @@ describe("session loading state", () => {
         requestKey: "all:2",
         sessionLimit: 300,
       }),
-    ).toEqual({ limit: 300, offset: 0, replace: true });
+    ).toEqual({ limit: 100, offset: 0, replace: true });
+    expect(
+      planSessionLoad({
+        loadedRequestKey: "all:2",
+        loadedRows: 100,
+        pageSize: 100,
+        requestKey: "all:2",
+        sessionLimit: 300,
+      }),
+    ).toEqual({ limit: 100, offset: 100, replace: false });
+    expect(
+      planSessionLoad({
+        loadedRequestKey: "all:2",
+        loadedRows: 200,
+        pageSize: 100,
+        requestKey: "all:2",
+        sessionLimit: 300,
+      }),
+    ).toEqual({ limit: 100, offset: 200, replace: false });
+    expect(
+      planSessionLoad({
+        loadedRequestKey: "all:2",
+        loadedRows: 300,
+        pageSize: 100,
+        requestKey: "all:2",
+        sessionLimit: 300,
+      }),
+    ).toBeNull();
   });
 
   test("loads the next page only after the active request key is current", () => {

--- a/test/watch.test.ts
+++ b/test/watch.test.ts
@@ -204,6 +204,32 @@ describe("watch mode", () => {
     await handle.stop();
   });
 
+  test("a watcher that joins another owner does not emit duplicate terminal errors", async () => {
+    const config = freshConfig();
+    const events: WatchEvent[] = [];
+    const handle = startWatch({
+      config,
+      enableWatch: false,
+      intervalMs: 0,
+      syncOnStart: false,
+      onEvent: (event) => events.push(event),
+      runner: async (_runnerConfig, status) => {
+        status.start();
+        const error = new Error("owned elsewhere");
+        status.finishErr(error.message);
+        return { error, emitTerminal: false };
+      },
+    });
+
+    handle.trigger("watch");
+    for (let attempt = 0; attempt < 100 && handle.status.snapshot().runs === 0; attempt += 1) {
+      await Bun.sleep(2);
+    }
+    expect(handle.status.snapshot().runs).toBe(1);
+    expect(events.some((event) => event.type === "error")).toBe(false);
+    await handle.stop();
+  });
+
   test("periodic sweep is enough to ingest when native watch is disabled", async () => {
     const config = freshConfig();
     seedClaude(config);


### PR DESCRIPTION
## Summary

- Add a complete OpenAPI 3.1 description for Decant's local HTTP and SSE surface, embed it in compiled distributions, and serve the runtime-stamped document at `GET /api/openapi.json`.
- Add fixture-backed contract validation for every documented operation, response schema, request body, parameter reference, and SSE event shape.
- Harden mutation-body validation, bound HTTP session-list pages without limiting core/CLI consumers, preserve expanded UI refreshes through bounded paging, normalize dynamic route logs, and make sync terminal-event ownership deterministic on both success and failure.

This is the final draft in the UX/API hardening stack and is based on `teedole/command-palette-fuzzy-search` / #78.

## Why

The local API had grown beyond its prose route reference without one machine-readable source of truth or distribution-level proof that the compiled binary served the same contract. A few HTTP-only boundaries and concurrent sync failure paths were also implicit, which made independent clients and operational diagnosis harder than necessary.

## Validation

- [x] Final stacked-branch `just check` passes: 728 tests / 7,063 assertions, TypeScript, Biome, native binary compilation, runtime OpenAPI fetch/version check, and npm staging smoke.
- [x] Final seven-PR integration `just check` passes in one run: 758 tests / 7,552 assertions, TypeScript, Biome, native binary compilation, and npm staging smoke.
- [x] New behavior has focused tests. No existing test was weakened or deleted to make this pass.
- [x] Focused server, sync/watch, and OpenAPI contract suite passes: 58 tests / 402 assertions.
- [x] Adversarial and consumer review findings were reproduced, fixed where valid, and revalidated across the final stack.
- [x] Headed browser validation covered the final command palette at 1440×1000 and 390×844. It exposed exactly three labeled ARIA groups, keyboard selection advanced through `aria-activedescendant`, all observed API requests returned 200, and the console reported 0 errors / 0 warnings.
- [x] Earlier synthetic watcher/UI validation covered Analytics, Sessions, session actions, Tools, Search, Insights, Settings, and `/api/openapi.json`; all current-port requests returned 200 with no current-page console errors or warnings.
- [x] Synthetic watcher validation completed startup plus a 45-second sweep with 0 failures; CPU settled from 0.2% after startup to 0.0% after navigation/idle.

Operational note: old `~/.decant/daemon.lock` and `~/.decant/daemon.token` files from the retired daemon architecture still exist on the validating machine. This change does not read, recreate, or delete them; cleanup remains an explicit local operator action.

## Archive schema

The baseline is `LATEST_SCHEMA_VERSION` in `src/db.ts`. Check one:

- [x] This change does not touch the archive schema.
- [ ] This change bumps the schema. It ships the migration, and the summary above says what happens to archives created before it.
