### PR TITLE
fix: repair context_compaction_count drift with schema v21

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,10 +103,10 @@ A change is ready when:
 4. **Costs are computed at ingest** with `cost::estimateCost` and stored on the
    session row. Editing pricing does not rewrite historical rows; rebuild the
    archive to recompute.
-5. **The schema baseline is v20.** Pre-v8 archives are intentionally rebuild-only:
+5. **The schema baseline is v21.** Pre-v8 archives are intentionally rebuild-only:
    delete the archive and re-ingest from the source directories. Do not add
    broad forward migrations unless that product decision changes; the narrow
-   v8-to-v20 migrations preserve existing TypeScript-cutover archives. A
+   v8-to-v21 migrations preserve existing TypeScript-cutover archives. A
    migration is frozen as soon as it is committed to a branch because a
    dogfooding archive may already have run it. During review, put any schema
    adjustment in a new version; never edit a committed migration.

--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ means no gateway is derived.
 deliberately want other hosts in: the `Host` header check is not an access
 control for non-browser clients, which can send `Host: localhost` freely.
 
-Archives older than schema v8 are rebuild-only. v8 through v19 archives migrate
-forward to v20 on open; the next `decant sync` backfills persisted economics
+Archives older than schema v8 are rebuild-only. v8 through v20 archives migrate
+forward to v21 on open; the next `decant sync` backfills persisted economics
 vectors and context-window rollups for unchanged sessions. Older archives should
 be deleted and rebuilt with `decant sync`. Source logs remain the source of
 truth, so nothing is lost by rebuilding.

--- a/src/db.ts
+++ b/src/db.ts
@@ -21,7 +21,7 @@ import {
 /// effective DDL with migrations 1..LATEST_SCHEMA_VERSION already applied
 /// and is now the frozen baseline, so a fresh archive is created in one step
 /// and stamped with the full migration history.
-export const LATEST_SCHEMA_VERSION = 20;
+export const LATEST_SCHEMA_VERSION = 21;
 
 const logger = getDecantLogger("db");
 let expectedSchemaManifest: SchemaManifest | null = null;
@@ -705,6 +705,16 @@ function migrate(db: Database, current: number): void {
       `);
       db.query(
         "INSERT INTO schema_migrations (version, applied_at) VALUES (20, datetime('now'))",
+      ).run();
+    }
+    if (current < 21) {
+      // A never-merged variant of migration 11 left this column on dogfooding
+      // archives; no committed build reads or writes it.
+      if (hasColumn(db, "session", "context_compaction_count")) {
+        db.exec("ALTER TABLE session DROP COLUMN context_compaction_count");
+      }
+      db.query(
+        "INSERT INTO schema_migrations (version, applied_at) VALUES (21, datetime('now'))",
       ).run();
     }
     assertSchemaMatchesBaseline(db);

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1,7 +1,7 @@
--- decant:schema_version=20
--- Effective decant schema (migrations 1..20 applied), frozen as the current
--- baseline. v20 adds durable user archive/delete state keyed by source
--- identity so synchronization cannot resurrect a deleted session.
+-- decant:schema_version=21
+-- Effective decant schema (migrations 1..21 applied), frozen as the current
+-- baseline. v21 only drops the never-committed context_compaction_count
+-- column from drifted archives, so the baseline DDL is unchanged from v20.
 -- Do not edit without updating schema tests.
 CREATE TABLE schema_migrations(
             version INTEGER PRIMARY KEY,

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -99,7 +99,7 @@ function historicalArchive(path: string, version: 8 | 9 | 12 | 13 | 14): Databas
   return db;
 }
 
-// Inventory of the frozen v20 baseline. Shadow tables
+// Inventory of the frozen v21 baseline. Shadow tables
 // of block_fts are excluded; they are implementation details of FTS5.
 const BASELINE_TABLES = [
   "block",
@@ -485,7 +485,7 @@ describe("openDb", () => {
       INSERT INTO session(id, tool, source_session_id, title)
       VALUES (1, 'codex', 'preserved-v19', 'Preserved');
       DROP TABLE session_user_state;
-      DELETE FROM schema_migrations WHERE version = 20;
+      DELETE FROM schema_migrations WHERE version >= 20;
     `);
     old.close();
 
@@ -506,6 +506,45 @@ describe("openDb", () => {
       ).version,
     ).toBe(LATEST_SCHEMA_VERSION);
     migrated.close();
+  });
+
+  test("migrates archives that ran the never-committed context_compaction_count variant", () => {
+    const path = freshPath();
+    const old = openDb(path);
+    old.exec(`
+      INSERT INTO session(id, tool, source_session_id, title)
+      VALUES (1, 'claude_code', 'preserved-drift', 'Preserved');
+      ALTER TABLE session ADD COLUMN context_compaction_count INTEGER;
+      UPDATE session SET context_compaction_count = 1 WHERE id = 1;
+      DROP TABLE session_user_state;
+      DELETE FROM schema_migrations WHERE version >= 19;
+    `);
+    old.close();
+
+    const migrated = openDb(path);
+    const baseline = openDb(freshPath());
+    expect(buildSchemaManifest(migrated)).toEqual(buildSchemaManifest(baseline));
+    expect(
+      migrated
+        .query("SELECT 1 FROM pragma_table_info('session') WHERE name = 'context_compaction_count'")
+        .get(),
+    ).toBeNull();
+    expect(
+      migrated.query("SELECT tool, source_session_id, title FROM session WHERE id = 1").get(),
+    ).toEqual({
+      tool: "claude_code",
+      source_session_id: "preserved-drift",
+      title: "Preserved",
+    });
+    expect(
+      (
+        migrated.query("SELECT MAX(version) AS version FROM schema_migrations").get() as {
+          version: number;
+        }
+      ).version,
+    ).toBe(LATEST_SCHEMA_VERSION);
+    migrated.close();
+    baseline.close();
   });
 
   test("migrates v12 archives and invalidates stale Claude context-window rollups", () => {


### PR DESCRIPTION
## Summary

A never-merged variant of migration 11 left `session.context_compaction_count` on dogfooding archives (the column appears in zero commits on any branch). Since the schema fingerprint gate landed in #73, those archives fail to open: `migrate()` reaches v20, the baseline assert sees the extra column, and the whole transaction rolls back.

- Migration 21: `hasColumn`-guarded `ALTER TABLE session DROP COLUMN context_compaction_count`, so drifted archives converge on the baseline and clean archives no-op through it
- `LATEST_SCHEMA_VERSION` → 21; `schema.sql` header bumped, baseline DDL unchanged from v20
- Docs: AGENTS.md invariant 5 and the README migrate-on-open range now say v21

## Testing

- New test replays the drifted lineage and asserts the migrated manifest equals a fresh baseline, the column is gone, session rows survive, and the archive stamps v21
- Existing v19 test rewind changed to `version >= 20` to stay contiguous now that fresh archives stamp 21; it also covers migration 21's no-op path
- `just check` green (782 tests, tsc, biome, dist smoke)
- Verified against a copy of a real drifted 2.8 GB archive: opens cleanly, migrates 18→21, all 1531 sessions intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)