### PR TITLE
fix(distribution): embed worker entrypoints

### DIFF
--- a/scripts/dist-check.ts
+++ b/scripts/dist-check.ts
@@ -204,7 +204,7 @@ async function assertCompiledEconomics(port: number): Promise<void> {
       );
     }
     latest = await response.json();
-    const totals = (latest as { totals?: Record<string, unknown> }).totals;
+    const totals = (latest as { totals?: Record<string, unknown> } | null)?.totals;
     if (
       typeof totals?.generation_tokens === "number" &&
       totals.generation_tokens > 0 &&

--- a/scripts/dist-check.ts
+++ b/scripts/dist-check.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -36,7 +36,7 @@ if (target == null) {
 
 const binary = buildTarget(target, { outDir: binaryDir, version });
 assertVersion(binary, ["--version"], {}, version);
-await assertOpenApi(binary, version);
+await assertCompiledServe(binary, version);
 
 stageNpmPackages({
   outDir: npmDir,
@@ -98,8 +98,17 @@ function assertVersion(
   }
 }
 
-async function assertOpenApi(binary: string, expectedVersion: string): Promise<void> {
+async function assertCompiledServe(binary: string, expectedVersion: string): Promise<void> {
   const serveDir = mkdtempSync(join(outRoot, "serve-"));
+  const claudeDir = join(serveDir, "claude");
+  const codexDir = join(serveDir, "codex");
+  const codexSessionsDir = join(codexDir, "sessions");
+  mkdirSync(claudeDir, { recursive: true });
+  mkdirSync(codexSessionsDir, { recursive: true });
+  copyFileSync(
+    join(import.meta.dir, "..", "fixtures", "codex", "sample.jsonl"),
+    join(codexSessionsDir, "rollout-sample.jsonl"),
+  );
   const proc = Bun.spawn(
     [
       binary,
@@ -111,6 +120,10 @@ async function assertOpenApi(binary: string, expectedVersion: string): Promise<v
       "127.0.0.1",
       "--port",
       "0",
+      "--claude-dir",
+      claudeDir,
+      "--codex-dir",
+      codexDir,
     ],
     {
       env: {
@@ -150,6 +163,27 @@ async function assertOpenApi(binary: string, expectedVersion: string): Promise<v
     if (document.paths?.["/api/health"] == null) {
       throw new Error("compiled OpenAPI document is missing /api/health");
     }
+
+    const syncResponse = await fetch(`http://127.0.0.1:${port}/api/sync`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (!syncResponse.ok) {
+      throw new Error(
+        `compiled binary returned ${syncResponse.status} for /api/sync: ${await syncResponse.text()}`,
+      );
+    }
+    const report = (await syncResponse.json()) as {
+      scanned?: unknown;
+      ingested?: unknown;
+      failed?: unknown;
+    };
+    if (report.scanned !== 1 || report.ingested !== 1 || report.failed !== 0) {
+      throw new Error(`compiled sync returned an unexpected report: ${JSON.stringify(report)}`);
+    }
+
+    await assertCompiledEconomics(port);
   } finally {
     if (startupTimeout != null) {
       clearTimeout(startupTimeout);
@@ -157,6 +191,31 @@ async function assertOpenApi(binary: string, expectedVersion: string): Promise<v
     proc.kill();
     await proc.exited;
   }
+}
+
+async function assertCompiledEconomics(port: number): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  let latest: unknown = null;
+  while (Date.now() < deadline) {
+    const response = await fetch(`http://127.0.0.1:${port}/api/analytics/token-economics`);
+    if (!response.ok) {
+      throw new Error(
+        `compiled binary returned ${response.status} for token economics: ${await response.text()}`,
+      );
+    }
+    latest = await response.json();
+    const totals = (latest as { totals?: Record<string, unknown> }).totals;
+    if (
+      typeof totals?.generation_tokens === "number" &&
+      totals.generation_tokens > 0 &&
+      typeof totals.estimated_cost_usd === "number" &&
+      totals.estimated_cost_usd > 0
+    ) {
+      return;
+    }
+    await Bun.sleep(50);
+  }
+  throw new Error(`compiled token economics stayed empty: ${JSON.stringify(latest)}`);
 }
 
 async function readServePort(proc: Bun.Subprocess<"ignore", "ignore", "pipe">): Promise<number> {

--- a/scripts/distribution.ts
+++ b/scripts/distribution.ts
@@ -118,7 +118,10 @@ export function buildTargetArgs(
   if (version != null) {
     args.push("--env=DECANT_BUILD_VERSION*");
   }
-  args.push("src/cli.ts", "--outfile", outPath);
+  // Bun does not infer Worker entrypoints for standalone executables. Each
+  // worker must be listed explicitly so its module is embedded alongside the
+  // CLI entrypoint instead of being resolved from the runtime filesystem.
+  args.push("src/cli.ts", "src/sync-worker.ts", "src/stats-worker.ts", "--outfile", outPath);
   return args;
 }
 

--- a/src/economics-cache.ts
+++ b/src/economics-cache.ts
@@ -6,6 +6,7 @@ import {
   type SessionEconomicsVector,
   type TokenEconomics,
 } from "./token-economics.ts";
+import { workerError, workerUrl } from "./worker-runtime.ts";
 
 /**
  * Serves /api/analytics/token-economics from precomputed per-session vectors.
@@ -171,7 +172,7 @@ function computeVectorsInWorker(
       reject(new Error("aborted"));
       return;
     }
-    const worker = new Worker(new URL("./stats-worker.ts", import.meta.url), { type: "module" });
+    const worker = new Worker(workerUrl("stats-worker.ts"), { type: "module" });
     const cancelBuffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
     const cancelView = new Int32Array(cancelBuffer);
     let promiseSettled = false;
@@ -205,7 +206,7 @@ function computeVectorsInWorker(
         return;
       }
       promiseSettled = true;
-      reject(event.error instanceof Error ? event.error : new Error(String(event.error)));
+      reject(workerError(event, "token economics worker failed"));
     });
     worker.postMessage({ dbPath, cancelBuffer });
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -71,6 +71,7 @@ import {
   type WatchEvent,
   type WatchHandle,
 } from "./watch.ts";
+import { workerError, workerUrl } from "./worker-runtime.ts";
 
 export const DEFAULT_SERVE_HOST = "127.0.0.1";
 export const DEFAULT_SERVE_PORT = 3000;
@@ -810,7 +811,7 @@ function runSyncWorker(
   onProgress?: (progress: SyncProgress) => void,
 ): Promise<ReturnType<typeof ingestSync>> {
   return new Promise((resolve, reject) => {
-    const worker = new Worker(new URL("./sync-worker.ts", import.meta.url), { type: "module" });
+    const worker = new Worker(workerUrl("sync-worker.ts"), { type: "module" });
     const cancelBuffer =
       cancel == null ? null : new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
     const cancelView = cancelBuffer == null ? null : new Int32Array(cancelBuffer);
@@ -839,7 +840,7 @@ function runSyncWorker(
     });
     worker.addEventListener("error", (event) => {
       settle();
-      reject(event.error instanceof Error ? event.error : new Error(String(event.error)));
+      reject(workerError(event, "sync worker failed"));
     });
     if (cancel != null) {
       // Share cancellation with the worker so it can stop between files and

--- a/src/worker-runtime.ts
+++ b/src/worker-runtime.ts
@@ -1,0 +1,30 @@
+interface WorkerErrorEventLike {
+  error: unknown;
+  message?: string;
+}
+
+/** Bun emits compiled TypeScript entrypoints with `.js` names inside the
+ * standalone module graph, while source execution loads the adjacent `.ts`. */
+export function workerUrl(sourceName: string): URL {
+  const embedded = import.meta.url.startsWith("file:///$bunfs/");
+  const entryName = embedded ? sourceName.replace(/\.ts$/, ".js") : sourceName;
+  return new URL(`./${entryName}`, import.meta.url);
+}
+
+/** Preserve a worker's real exception when Bun provides one, but fall back to
+ * ErrorEvent.message and then any non-null payload before using a stable label.
+ * Resolution failures in a compiled executable can emit an ErrorEvent whose
+ * `error` field is null. */
+export function workerError(event: WorkerErrorEventLike, fallback: string): Error {
+  if (event.error instanceof Error) {
+    return event.error;
+  }
+  const message = event.message?.trim();
+  if (message != null && message !== "") {
+    return new Error(message);
+  }
+  if (event.error != null) {
+    return new Error(String(event.error));
+  }
+  return new Error(fallback);
+}

--- a/test/distribution.test.ts
+++ b/test/distribution.test.ts
@@ -74,7 +74,7 @@ describe("distribution helpers", () => {
     expect(parseDistributionArgs(["--version", "1.2.3"]).version).toBe("1.2.3");
   });
 
-  test("passes release version through Bun env inlining for compiled binaries", () => {
+  test("includes worker entrypoints and optional release version in compiled binaries", () => {
     const target = selectTargets("linux-x64")[0];
     if (target == null) {
       throw new Error("missing linux-x64 target");
@@ -85,6 +85,8 @@ describe("distribution helpers", () => {
       "--target",
       "bun-linux-x64",
       "src/cli.ts",
+      "src/sync-worker.ts",
+      "src/stats-worker.ts",
       "--outfile",
       "/tmp/decant",
     ]);
@@ -95,6 +97,8 @@ describe("distribution helpers", () => {
       "bun-linux-x64",
       "--env=DECANT_BUILD_VERSION*",
       "src/cli.ts",
+      "src/sync-worker.ts",
+      "src/stats-worker.ts",
       "--outfile",
       "/tmp/decant",
     ]);

--- a/test/worker-runtime.test.ts
+++ b/test/worker-runtime.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { workerError, workerUrl } from "../src/worker-runtime.ts";
+
+test("workerUrl keeps TypeScript worker names during source execution", () => {
+  expect(workerUrl("sync-worker.ts").pathname).toEndWith("/src/sync-worker.ts");
+});
+
+describe("workerError", () => {
+  test("preserves a concrete worker exception", () => {
+    const cause = new Error("worker exploded");
+    expect(workerError({ error: cause, message: "ignored" }, "worker failed")).toBe(cause);
+  });
+
+  test("uses the ErrorEvent message when the exception is missing", () => {
+    expect(workerError({ error: null, message: "module not found" }, "worker failed").message).toBe(
+      "module not found",
+    );
+  });
+
+  test("retains a non-Error exception payload when no message is available", () => {
+    expect(workerError({ error: "worker exploded" }, "worker failed").message).toBe(
+      "worker exploded",
+    );
+  });
+
+  test("uses a stable fallback instead of stringifying null", () => {
+    expect(workerError({ error: null, message: "" }, "worker failed").message).toBe(
+      "worker failed",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Embed the sync and token-economics worker entrypoints in standalone Bun binaries, resolve their emitted `.js` URLs at runtime, and preserve useful worker failure details. Extend the native distribution smoke to perform a synthetic sync and verify nonzero token economics.

## Why

Release builds compiled only `src/cli.ts`. Bun did not infer the two `Worker` entrypoints, so packaged binaries attempted to load modules that were not embedded. That caused startup and manual sync to fail with HTTP 500 while worker-backed analytics remained empty; null worker payloads also obscured the cause as `Error: null`.

## Validation

- [x] `just check` passes (`bun test`, `bunx tsc --noEmit`, `bunx biome check .`, distribution staging smoke).
- [x] New behavior has focused tests. No existing test was weakened or deleted to make this pass.

`just check` passed with 788 tests plus the native compiled sync and token-economics smoke.

## Archive schema

The baseline is `LATEST_SCHEMA_VERSION` in `src/db.ts`. Check one:

- [x] This change does not touch the archive schema.
- [ ] This change bumps the schema. It ships the migration, and the summary above says what happens to archives created before it.
