### PR TITLE
docs: document Homebrew 6 tap trust in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,26 +249,13 @@ details and per-artifact verification.
    brew install dosu-ai/dosu/decant
    ```
 
-   The fully qualified name works on every Homebrew version: it taps the
-   repo if needed and, on Homebrew 6.0+, records trust for just the `decant`
-   formula. To work with tapped short names instead:
+   Or with the tap and short names:
 
    ```bash
    brew tap dosu-ai/dosu
    brew trust dosu-ai/dosu   # Homebrew 6.0+ only — skip on older versions
    brew install decant
    ```
-
-   **Homebrew 6.0+ only**
-   ([released 2026-06-11](https://brew.sh/2026/06/11/homebrew-6.0.0/)):
-   third-party taps start untrusted
-   ([tap trust](https://docs.brew.sh/Tap-Trust)), and short-name installs or
-   upgrades — including on machines that tapped `dosu-ai/dosu` before
-   upgrading Homebrew — fail with `Error: Refusing to load formula
-   dosu-ai/dosu/decant from untrusted tap dosu-ai/dosu` until a one-time
-   `brew trust dosu-ai/dosu` (or `brew trust --formula dosu-ai/dosu/decant`).
-   Homebrew 5 and earlier has no trust step and needs none. Code signing
-   plays no part here: this is Homebrew consent, not Gatekeeper.
 
 3. **Install script** — for machines without Node:
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ decant serve
 Install it with Homebrew:
 
 ```bash
-brew tap dosu-ai/dosu && brew install decant
+brew install dosu-ai/dosu/decant
 decant serve
 ```
 
@@ -246,9 +246,29 @@ details and per-artifact verification.
 2. **Homebrew** — via the `dosu-ai/dosu` tap:
 
    ```bash
-   brew tap dosu-ai/dosu && brew install decant
-   brew install dosu-ai/dosu/decant   # equivalent one-liner
+   brew install dosu-ai/dosu/decant
    ```
+
+   The fully qualified name works on every Homebrew version: it taps the
+   repo if needed and, on Homebrew 6.0+, records trust for just the `decant`
+   formula. To work with tapped short names instead:
+
+   ```bash
+   brew tap dosu-ai/dosu
+   brew trust dosu-ai/dosu   # Homebrew 6.0+ only — skip on older versions
+   brew install decant
+   ```
+
+   **Homebrew 6.0+ only**
+   ([released 2026-06-11](https://brew.sh/2026/06/11/homebrew-6.0.0/)):
+   third-party taps start untrusted
+   ([tap trust](https://docs.brew.sh/Tap-Trust)), and short-name installs or
+   upgrades — including on machines that tapped `dosu-ai/dosu` before
+   upgrading Homebrew — fail with `Error: Refusing to load formula
+   dosu-ai/dosu/decant from untrusted tap dosu-ai/dosu` until a one-time
+   `brew trust dosu-ai/dosu` (or `brew trust --formula dosu-ai/dosu/decant`).
+   Homebrew 5 and earlier has no trust step and needs none. Code signing
+   plays no part here: this is Homebrew consent, not Gatekeeper.
 
 3. **Install script** — for machines without Node:
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -118,7 +118,7 @@ The `dosu-ai/dosu` tap carries a formula that installs the same prebuilt
 release tarball as every other channel — there is no source build:
 
 ```sh
-brew install dosu-ai/dosu/decant   # fully qualified — works on every Homebrew version
+brew install dosu-ai/dosu/decant
 ```
 
 Or with the tap and short names:
@@ -128,19 +128,6 @@ brew tap dosu-ai/dosu
 brew trust dosu-ai/dosu   # Homebrew 6.0+ only — skip on older versions
 brew install decant
 ```
-
-Since [Homebrew 6.0](https://brew.sh/2026/06/11/homebrew-6.0.0/) (2026-06-11),
-third-party taps start untrusted and short-name installs or upgrades refuse
-with `Error: Refusing to load formula dosu-ai/dosu/decant from untrusted tap
-dosu-ai/dosu` — including on machines that tapped before upgrading to
-Homebrew 6 — until a one-time `brew trust dosu-ai/dosu` or
-`brew trust --formula dosu-ai/dosu/decant`
-([tap trust](https://docs.brew.sh/Tap-Trust)). The fully qualified install
-needs none of that: verified on 6.0.14, it taps the repo if needed, records
-trust for just the `decant` formula, and runs non-interactively; on Homebrew
-5 and earlier (no trust mechanism) it behaves as it always did. An Apple
-Developer signature would not change any of this — tap trust is Homebrew's
-own consent gate, unrelated to Gatekeeper.
 
 The formula is rendered from `packaging/homebrew/decant.rb.template` during the
 release run, smoke-tested on all four supported OS/architecture targets, and

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -118,9 +118,29 @@ The `dosu-ai/dosu` tap carries a formula that installs the same prebuilt
 release tarball as every other channel — there is no source build:
 
 ```sh
-brew tap dosu-ai/dosu && brew install decant
-brew install dosu-ai/dosu/decant   # equivalent one-liner, taps on the fly
+brew install dosu-ai/dosu/decant   # fully qualified — works on every Homebrew version
 ```
+
+Or with the tap and short names:
+
+```sh
+brew tap dosu-ai/dosu
+brew trust dosu-ai/dosu   # Homebrew 6.0+ only — skip on older versions
+brew install decant
+```
+
+Since [Homebrew 6.0](https://brew.sh/2026/06/11/homebrew-6.0.0/) (2026-06-11),
+third-party taps start untrusted and short-name installs or upgrades refuse
+with `Error: Refusing to load formula dosu-ai/dosu/decant from untrusted tap
+dosu-ai/dosu` — including on machines that tapped before upgrading to
+Homebrew 6 — until a one-time `brew trust dosu-ai/dosu` or
+`brew trust --formula dosu-ai/dosu/decant`
+([tap trust](https://docs.brew.sh/Tap-Trust)). The fully qualified install
+needs none of that: verified on 6.0.14, it taps the repo if needed, records
+trust for just the `decant` formula, and runs non-interactively; on Homebrew
+5 and earlier (no trust mechanism) it behaves as it always did. An Apple
+Developer signature would not change any of this — tap trust is Homebrew's
+own consent gate, unrelated to Gatekeeper.
 
 The formula is rendered from `packaging/homebrew/decant.rb.template` during the
 release run, smoke-tested on all four supported OS/architecture targets, and


### PR DESCRIPTION
## Summary

Document Homebrew 6's tap trust in the Homebrew install paths (README quick start + install matrix, `docs/distribution.md`). The fully qualified `brew install dosu-ai/dosu/decant` stays the primary instruction — it works on every Homebrew version — and the new `brew trust` step is scoped to the Homebrew 6.0+ tapped/short-name flow, following the pattern the Databricks and coveralls taps adopted.

## Why

Homebrew 6.0 (released 2026-06-11) introduced [tap trust](https://docs.brew.sh/Tap-Trust): third-party taps start untrusted, and short-name installs or upgrades fail with `Error: Refusing to load formula dosu-ai/dosu/decant from untrusted tap dosu-ai/dosu` — including on machines that tapped before upgrading Homebrew. The trust step is deliberately version-scoped: Homebrew 5 and earlier has no trust requirement, and `brew trust` itself only exists from 5.1.15, so unconditional instructions would error there. Tap trust is Homebrew's own consent gate — an Apple Developer signature would not remove it, and Homebrew installs never touch Gatekeeper (that remains a browser-download concern, already covered in the install matrix).

## Validation

Docs-only change. Behavior verified on Homebrew 6.0.14 against the live tap:

- Short-name `brew install decant` / `brew install dosu` on the untrusted tap: refused with the error above (installed and not-installed formulae alike).
- Fully qualified `brew install dosu-ai/dosu/decant` with the tap absent: auto-taps, installs non-interactively, and records trust for just the formula (`brew trust --json=v1` lists the formula; the tap stays untrusted).
- Fully qualified install with the tap present but untrusted: proceeds the same way.
- `brew trust` / `brew trust --formula`: idempotent, exit 0 when already trusted.

- [x] `just check` passes (`bun test`, `bunx tsc --noEmit`, `bunx biome check .`, distribution staging smoke).
- [x] New behavior has focused tests. No existing test was weakened or deleted to make this pass. (N/A — docs-only; no code paths changed.)

## Archive schema

The baseline is `LATEST_SCHEMA_VERSION` in `src/db.ts`. Check one:

- [x] This change does not touch the archive schema.
- [ ] This change bumps the schema. It ships the migration, and the summary above says what happens to archives created before it.

https://claude.ai/code/session_01EDD3rCJYjmQVVsBWcnZGSP
