### PR TITLE
chore: gitignore .mcp.json and correct the Dosu scoping command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@
 # hook wiring, and credentials, so it must never be committed. Shared agent
 # guidance belongs in AGENTS.md instead.
 .claude/settings.local.json
+# `dosu mcp add claude` writes the Dosu MCP server here with a literal
+# X-Dosu-API-Key, and this repo is public. Project-scoped MCP config is
+# normally shareable, but decant's Dosu wiring is per-developer by design
+# (see "Shared knowledge" in AGENTS.md), so nothing here belongs in a commit.
+.mcp.json
 
 # Browser-automation artifacts
 .playwright-mcp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,10 +147,22 @@ A change is ready when:
 
 Maintainers keep durable, cross-session context for this repo in a Dosu
 knowledge library, reachable over the Dosu MCP server. The wiring is
-per-developer and machine-local. `dosu setup --deployment <id>` writes it to
-your own agent config, never to the repo, because it carries an API key. Scope
-it to this project so a decant session cannot read or write another library's
-knowledge.
+per-developer and machine-local, and it carries an API key, so it must never
+reach a commit.
+
+Scope the server to this project, so a decant session cannot read or write
+another library's knowledge. From the repo root:
+
+```sh
+dosu deployments switch <id>
+dosu mcp add claude
+```
+
+`dosu setup --deployment <id>` is the wrong tool for that: it installs at your
+agent's user scope, which makes the server global to every project on the
+machine. `dosu mcp add` is the project-scoped path, but note that it writes
+the key into `.mcp.json` in your working tree rather than to a config outside
+the repo. `.gitignore` covers that path; do not force-add it.
 
 None of this is required to build, test, or ship Decant. Without Dosu access
 the tools are simply not listed and the guidance below no-ops. It is also

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,11 @@ machine. `dosu mcp add` is the project-scoped path, but note that it writes
 the key into `.mcp.json` in your working tree rather than to a config outside
 the repo. `.gitignore` covers that path; do not force-add it.
 
+Only that generated `.mcp.json` is per-project. `dosu deployments switch` sets
+the CLI's own active deployment globally, so `dosu ask` run from another
+checkout follows whichever deployment you switched to last, not that
+checkout's `.mcp.json`.
+
 None of this is required to build, test, or ship Decant. Without Dosu access
 the tools are simply not listed and the guidance below no-ops. It is also
 agent-side tooling only, never a runtime dependency of the app, so invariant 3


### PR DESCRIPTION
## Why

`dosu mcp add claude` — the project-scoped way to wire up the Dosu MCP server — writes `.mcp.json` into the working tree containing a **literal** `X-Dosu-API-Key`, with no env-var indirection:

```json
{ "mcpServers": { "dosu": {
  "url": "https://api.dosu.dev/v1/mcp/deployments/<id>",
  "headers": { "X-Dosu-API-Key": "sk_user_…" }
} } }
```

This repo is public and that path was not ignored, so the key sat one `git add -A` away from a public commit.

## The rule already existed

The `.gitignore` entry directly above the new one says it outright:

> Per-developer coding-agent config. Holds machine-local **MCP server entries**, hook wiring, and **credentials**, so it must never be committed.

That describes `.mcp.json` exactly; it just happened to name only `.claude/settings.local.json`. This finishes the rule rather than adding a new one.

Ignoring `.mcp.json` does forfeit its normal role as *shared* project MCP config — but #84 established that decant's Dosu wiring is per-developer and machine-local, so that is a cost we have already chosen. `git add -f` remains available if a keyless shared server is ever wanted.

## AGENTS.md correction

The section added in #84 says to run `dosu setup --deployment <id>` and to "scope it to this project". Those are incompatible — that command installs at the agent's **user scope**, making the server global to every project on the machine. Verified against `dosu` v0.40.0:

| Command | Project-scoped? | Stays out of the tree? |
|---|---|---|
| `dosu setup --deployment <id>` | no — user scope | yes |
| `dosu mcp add claude` | yes | no — writes `.mcp.json` |

Neither satisfies both, so the docs now name the project-scoped pair and state plainly that it writes into the tree, with `.gitignore` as the thing that keeps it out of commits.

## Upstream fix

The real fix belongs in dosu-cli: emit `${DOSU_API_KEY}` instead of the literal key, since Claude Code expands env vars in `.mcp.json`. Then the file is safe to commit and this whole question dissolves. This PR is the local mitigation meanwhile.

## Testing

`bun test` (798 pass), `bunx tsc --noEmit`, and `bunx biome check .` all pass. Not run: the `just check` distribution staging smoke, which needs network and is unrelated to a `.gitignore`/docs change. No test asserts this prose.

https://claude.ai/code/session_015FwqHJ4gifGjihdwPEVduP