### PR TITLE
docs: reconcile add-source guidance with the goldens regenerator

### DIFF
--- a/.claude/skills/new-source-parser/SKILL.md
+++ b/.claude/skills/new-source-parser/SKILL.md
@@ -5,56 +5,21 @@ description: Add support for a new coding-agent session format to decant. Use wh
 
 # Adding a source parser
 
-Parsers are decant's extension point. A new source tool means a new file in
-`src/sources/`, never a special case threaded through ingest. Read
-`src/sources/codex.ts` first as the reference implementation, and `src/model.ts`
-for the normalized shape every parser must produce.
+Parsers are decant's extension point (invariant 6), and the canonical
+workflow is `docs/prompts/add-source.md` — read it and work through it top to
+bottom. It owns the full checklist: discovery, parser rules, the capability
+report the PR must include, synthetic fixtures, tests, and golden
+regeneration. Its privacy rules are hard requirements, not suggestions.
 
-## Steps
+Decant-side anchors while you work:
 
-1. **Write `src/sources/<tool>.ts`.** Export a parse function that takes the raw
-   session content and returns a `ParsedSession`. Normalize into the shared types
-   from `src/model.ts`, which are `NormalizedSession`, `NormalizedMessage`,
-   `NormalizedBlock`, `TokenUsage`, and `Role`.
-
-2. **Report problems as issues, do not throw.** Push onto
-   `ParsedSession["issues"]` so one malformed session cannot fail a whole sync.
-   Real logs are messy and a parser that throws makes the archive unbuildable.
-
-3. **Stay print-free.** Parsers return data and `Result`-style errors. Output and
-   exit-code policy belong in `src/cli.ts` and nowhere else.
-
-4. **Write synthetic fixtures only.** Never copy a real transcript into the repo.
-   `~/.claude` and `~/.codex` hold private conversations, and `test/golden/` must
-   stay generated from synthetic fixtures. Hand-write the smallest JSONL that
-   exercises the format, following the helpers in `test/codex.test.ts`.
-
-5. **Add tests at both levels.** A parser test in `test/<tool>.test.ts` for
-   shape and edge cases, plus ingest and query coverage proving a session lands
-   in the archive and comes back out of search and stats.
-
-6. **Wire discovery.** Add the source directory resolution and its environment
-   override alongside `DECANT_CLAUDE_DIR` and `DECANT_CODEX_DIR`, then document
-   the new variable in AGENTS.md and README.md.
-
-7. **Regenerate goldens** once behavior is settled.
-
-   ```bash
-   bun run scripts/regen-goldens.ts --i-reviewed-the-diff
-   ```
-
-   The flag is deliberate. Read the resulting diff before committing it, because
-   an unreviewed golden update hides a real behavior change.
-
-8. **Check cost handling.** Costs are computed at ingest by `cost::estimateCost`
-   and stored on the session row. If the tool reports usage differently, confirm
-   the token fields map correctly, since editing pricing later does not rewrite
-   historical rows.
-
-## Schema changes
-
-If the format needs a new column, that is a migration, and migrations freeze once
-committed. Use the `new-migration` skill.
+- Read `src/sources/codex.ts` first as the reference implementation, and
+  `src/model.ts` for the normalized shape every parser must produce.
+- Parsers return data and issues; never throw on malformed input, and never
+  write to stdout/stderr (invariant 1). Output and exit-code policy belong in
+  `src/cli.ts` and nowhere else.
+- If the format needs a new column, that is a schema migration, and migrations
+  freeze once committed. Use the `new-migration` skill.
 
 ## Gate
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,9 @@ point). Docs: `docs/api/openapi.yaml` (local API contract),
 
 Agent tooling lives in `.claude/`. Two skills cover the work most likely to go
 wrong, `new-source-parser` for invariant 6 and `new-migration` for invariant 5.
+The `new-source-parser` skill stays thin and defers to
+`docs/prompts/add-source.md`, the canonical add-a-source workflow that
+`CONTRIBUTING.md` also points at.
 `scripts/claude-hooks/reflect-on-stop.sh` is a Stop hook, wired in
 `.claude/settings.json`, that nudges toward recording durable findings when a
 session changed several files and wrote none down. It is offline, bash and jq

--- a/docs/prompts/add-source.md
+++ b/docs/prompts/add-source.md
@@ -22,7 +22,7 @@ not suggestions.
    (`src/ingest.ts: discover()`); non-session sidecars are excluded by name,
    like Codex's `session_index.jsonl` and Claude's `journal.jsonl`. Add an
    environment override alongside `DECANT_CLAUDE_DIR` and `DECANT_CODEX_DIR`,
-   and document it in AGENTS.md and README.md.
+   and document it in `AGENTS.md` and `README.md`.
 2. **A parser** — `src/sources/<tool>.ts` exporting
    `parse<Tool>Session(sourceSessionId: string, content: string, ...): ParsedSession`.
    Pure and print-free: return data and issues; never throw on malformed
@@ -80,8 +80,8 @@ PR so the maintainers wire the presentation tier deliberately.
 3. Ingest tests: extend `test/ingest.test.ts` discovery coverage.
 4. Goldens: add the new fixtures to `test/golden/meta.json`'s `fixtures`
    list, and teach both stagers the new tool's directory: `stageFixtures()`
-   in `scripts/regen-goldens.ts` (it rejects fixture paths it does not
-   know) and its counterpart in `test/cli-golden.test.ts` (otherwise the
+   in `scripts/regen-goldens.ts` (it rejects unknown fixture paths) and
+   its counterpart in `test/cli-golden.test.ts` (otherwise the
    parity test stages a database without the new tool and fails against
    the regenerated goldens). Then regenerate:
 

--- a/docs/prompts/add-source.md
+++ b/docs/prompts/add-source.md
@@ -14,13 +14,15 @@ not suggestions.
   with invented content ("hello", "/tmp/example", "example-model"). A fixture
   that started life as a real transcript is a rejected PR, even if edited.
 - Parity checks against your own real store report **counts and shape
-  mismatches only** (see step 6), never content.
+  mismatches only** (see Definition of done), never content.
 
 ## What Decant needs from a source
 
 1. **Discovery** — where session files live and which filenames are sessions
    (`src/ingest.ts: discover()`); non-session sidecars are excluded by name,
-   like Codex's `session_index.jsonl` and Claude's `journal.jsonl`.
+   like Codex's `session_index.jsonl` and Claude's `journal.jsonl`. Add an
+   environment override alongside `DECANT_CLAUDE_DIR` and `DECANT_CODEX_DIR`,
+   and document it in AGENTS.md and README.md.
 2. **A parser** — `src/sources/<tool>.ts` exporting
    `parse<Tool>Session(sourceSessionId: string, content: string, ...): ParsedSession`.
    Pure and print-free: return data and issues; never throw on malformed
@@ -42,7 +44,10 @@ not suggestions.
 | timestamps | per record / per session / absent |
 | tool call/result linkage | by id / by adjacency / absent |
 
-Decant promises economics only where usage data exists. If this source
+Decant promises economics only where usage data exists. Costs are computed
+once at ingest by `estimateCost` (`src/cost.ts`) and stored on the session
+row; editing pricing later does not rewrite historical rows (invariant 4),
+so confirm the token fields map correctly on day one. If this source
 reports no usage, cost must surface as unavailable, not zero — say so in the
 PR so the maintainers wire the presentation tier deliberately.
 
@@ -68,18 +73,29 @@ PR so the maintainers wire the presentation tier deliberately.
 ## Tests (all required)
 
 1. Parser tests: `test/<tool>.test.ts` — happy path, malformed line,
-   unknown record type, tool call/result linkage, usage totals.
+   unknown record type, tool call/result linkage, usage totals;
+   `test/codex.test.ts` shows the pattern.
 2. Fixtures: `fixtures/<tool>/sample.jsonl` (+ variants your parser branches
    on), synthetic per the privacy rules.
 3. Ingest tests: extend `test/ingest.test.ts` discovery coverage.
-4. Goldens: new fixtures must appear in `test/golden/rows/*.json` and
-   `test/golden/meta.json`'s fixture list. Goldens are hand-maintained —
-   mirror the existing rows' field layout exactly; there is no regeneration
-   script.
+4. Goldens: add the new fixtures to `test/golden/meta.json`'s `fixtures`
+   list, and teach both stagers the new tool's directory: `stageFixtures()`
+   in `scripts/regen-goldens.ts` (it rejects fixture paths it does not
+   know) and its counterpart in `test/cli-golden.test.ts` (otherwise the
+   parity test stages a database without the new tool and fails against
+   the regenerated goldens). Then regenerate:
+
+   ```bash
+   bun run scripts/regen-goldens.ts --i-reviewed-the-diff
+   ```
+
+   The flag is deliberate. Read the resulting diff before committing it,
+   because an unreviewed golden update hides a real behavior change.
 
 ## Definition of done
 
-`bun test && bunx tsc --noEmit && bunx biome check .` green, plus a parity
-run over your own real store: parse every session, then report — in
-aggregate only — sessions parsed, sessions with issues, issue counts by
-code, and any record type your parser had to mark unknown.
+`just check` green (`bun test`, `bunx tsc --noEmit`, `bunx biome check .`,
+plus the distribution staging smoke), plus a parity run over your own real
+store: parse every session, then report — in aggregate only — sessions
+parsed, sessions with issues, issue counts by code, and any record type
+your parser had to mark unknown.


### PR DESCRIPTION
## Summary

`docs/prompts/add-source.md` contradicted the `new-source-parser` skill on goldens ("hand-maintained, no regeneration script" vs "run `scripts/regen-goldens.ts`"). The prompt doc is now the single canonical add-a-source workflow, corrected against what the regenerator actually does, and the skill thins down to defer to it.

## Why

The regenerator exists (since #72) and `test/golden/meta.json` names it as its `source_of_truth`, so a contributor following CONTRIBUTING.md's pointer got instructions that contradict the tree — and neither document mentioned that a new tool must be added to **both** fixture stagers: `stageFixtures()` in `scripts/regen-goldens.ts` (rejects unknown fixture paths) and its counterpart in `test/cli-golden.test.ts` (otherwise the parity test stages a database without the new tool and fails against regenerated goldens).

Two documents describing one workflow is what let them drift, so this also applies AGENTS.md's own "stay thin and defer" rule: the prompt doc owns the checklist (now including the env-override and cost-mapping steps that lived only in the skill, plus a definition of done aligned with `just check`), while the skill keeps only decant-side anchors (reference implementation, print-free/issues rules, the `new-migration` pointer). Also repairs a dangling "see step 6" reference from an earlier draft.

## Validation

Docs-only change; no runtime behavior touched.

- [x] `just check` passes (`bun test`, `bunx tsc --noEmit`, `bunx biome check .`, distribution staging smoke).
- [x] New behavior has focused tests. No existing test was weakened or deleted to make this pass. (No behavior change, no test change.)
- Every code reference in the rewritten text was verified against the tree: `estimateCost` (`src/cost.ts`), `discover()` (`src/ingest.ts`), both `stageFixtures()` implementations, the regenerator's `--i-reviewed-the-diff` guard and its rejection of unknown fixture paths, and `test/codex.test.ts` as the parser-test pattern.

## Archive schema

The baseline is `LATEST_SCHEMA_VERSION` in `src/db.ts`. Check one:

- [x] This change does not touch the archive schema.
- [ ] This change bumps the schema. It ships the migration, and the summary above says what happens to archives created before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)