### PR TITLE
fix(workers): guard message handlers to parent-origin messages

### DIFF
--- a/src/stats-worker.ts
+++ b/src/stats-worker.ts
@@ -3,6 +3,11 @@ import { closeDb } from "./db.ts";
 import { computeSessionEconomicsVectors } from "./token-economics.ts";
 
 self.addEventListener("message", (event) => {
+  // Dedicated worker: the only sender is the spawning parent thread, whose
+  // messages carry an empty origin. Drop anything else.
+  if (event.origin !== "") {
+    return;
+  }
   const { dbPath, cancelBuffer } = event.data as {
     dbPath: string;
     cancelBuffer: SharedArrayBuffer | null;

--- a/src/sync-worker.ts
+++ b/src/sync-worker.ts
@@ -8,6 +8,11 @@ type SyncWorkerMessage =
   | { type: "complete"; ok: false; error: string };
 
 self.addEventListener("message", (event) => {
+  // Dedicated worker: the only sender is the spawning parent thread, whose
+  // messages carry an empty origin. Drop anything else.
+  if (event.origin !== "") {
+    return;
+  }
   const { config, cancelBuffer } = event.data as {
     config: Config;
     cancelBuffer: SharedArrayBuffer | null;


### PR DESCRIPTION
Resolves CodeQL alerts #21 and #22 (`js/missing-origin-check`) on the two dedicated Bun workers.

Both `src/sync-worker.ts` and `src/stats-worker.ts` are dedicated workers spawned in-process (`src/server.ts` sync endpoint, `src/economics-cache.ts` stats cache). Their only possible sender is the spawning parent thread, whose messages carry an empty `origin` per the HTML spec — verified against Bun 1.3.11, which delivers `origin === ""` (string). The handlers now drop any message with a non-empty origin, which admits exactly the one legitimate sender and makes the dedicated-thread contract explicit.

No behavior change for legitimate traffic: the worker round-trip tests (`test/economics-cache.test.ts` real stats-worker spawn, `test/server-sync.test.ts` via `POST /api/sync`) pass unchanged, as does `just check` (798 tests, tsc, biome, dist smoke).

The CodeQL run on this PR is the verification that both alerts read as fixed.

https://claude.ai/code/session_01SftxmCULJdnM293NJYt686