### PR TITLE
fix(deps): override fast-uri to patched 3.1.5 (GHSA-7p8r-x3mc-p8w7)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,9 @@
       },
     },
   },
+  "overrides": {
+    "fast-uri": "^3.1.5",
+  },
   "packages": {
     "@biomejs/biome": ["@biomejs/biome@2.5.2", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.2", "@biomejs/cli-darwin-x64": "2.5.2", "@biomejs/cli-linux-arm64": "2.5.2", "@biomejs/cli-linux-arm64-musl": "2.5.2", "@biomejs/cli-linux-x64": "2.5.2", "@biomejs/cli-linux-x64-musl": "2.5.2", "@biomejs/cli-win32-arm64": "2.5.2", "@biomejs/cli-win32-x64": "2.5.2" }, "bin": { "biome": "bin/biome" } }, "sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA=="],
 
@@ -180,7 +183,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
 
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "engines": {
     "bun": ">=1.3.0"
   },
+  "overrides": {
+    "fast-uri": "^3.1.5"
+  },
   "scripts": {
     "predev": "bun install --frozen-lockfile",
     "dev": "bun run src/cli.ts serve",


### PR DESCRIPTION
Resolves Scorecard alert #23 (Vulnerabilities), opened by today's post-merge scan after [GHSA-7p8r-x3mc-p8w7](https://osv.dev/GHSA-7p8r-x3mc-p8w7) (CVE-2026-18446, host confusion via backslash authority introducer) was published for `fast-uri < 3.1.5`.

`fast-uri@3.1.4` reaches this repo only as a transitive dependency of `ajv@8.20.0` (`fast-uri: ^3.0.1`), which is itself a devDependency used by the contract tests — the runtime binary never ships it. The fix is a package.json `overrides` entry pinning `fast-uri` to `^3.1.5`: the lockfile re-resolves to the patched release while staying inside ajv's declared major, and no direct dependency is added for a package decant never imports. (A plain `bun update fast-uri` was rejected for exactly that reason: it adds a direct `^4.1.2` dependency and hoists ajv onto an untested major.)

`just check` passes (798 tests including the ajv-based contract tests, tsc, biome, dist smoke).

https://claude.ai/code/session_01SftxmCULJdnM293NJYt686
