### PR TITLE
feat(cli): make bare decant the fast entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,9 +48,9 @@ Run from the repo root.
 - `bun run dev` — one-command local UI + startup sync.
 - `just check` — the full local quality gate (see Definition of done).
 - `bun run src/cli.ts --help` — the `decant` CLI: `sync`, `ls`, `search`,
-  `stats`, `files`, `distill`, `recommendations`, `watch`, `serve`; add
-  `--db` to target an alternate archive. `just` lists wrapper recipes for
-  the common ones.
+  `stats`, `files`, `distill`, `recommendations`, `watch`, `serve` (the default
+  when `decant` runs bare); add `--db` to target an alternate archive. `just`
+  lists wrapper recipes for the common ones.
 
 ## Config
 
@@ -78,6 +78,10 @@ Run from the repo root.
   this suppresses syncs decant starts on its own, not one an operator asks for.
   Use it whenever pointing a command at a scratch archive, or the watcher will
   fill that archive from the real `~/.claude` and `~/.codex`.
+- `DECANT_NO_OPEN` (any value) or `serve --no-open`: never auto-open a browser.
+  `BROWSER` overrides the opener (`open`/`xdg-open`); `BROWSER=none` disables.
+  Auto-open is skipped in CI and non-TTY runs; the URL banner still prints
+  unless `-q`.
 - Global flags on every command: `--db`, `--json`, `--format table|json|md`,
   `-q/--quiet`, `--no-color`, `--no-sync`.
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,16 @@ Rendered from the repository's synthetic fixtures.](docs/assets/decant-serve.png
 Run Decant with `npx`—no Bun install or global package required:
 
 ```bash
-npx @dosu/decant@latest serve
+npx @dosu/decant@latest
 ```
 
-Open `http://127.0.0.1:3000`. The first run syncs the Claude Code and Codex logs
-already on your machine, then keeps watching them for changes. `npx` downloads
-the launcher and matching native binary for this run without installing a
-persistent `decant` command.
+That starts the local web UI at `http://127.0.0.1:3000`, prints the link, and
+opens your browser (skipped when it can't — the printed link always works). The
+first run syncs the Claude Code and Codex logs already on your machine, then
+keeps watching them for changes. `decant serve` is the same thing with flags:
+`--port`, `--host`, `--no-open`, and friends. `npx` downloads the launcher and
+matching native binary for this run without installing a persistent `decant`
+command.
 
 Use the same package for one-off CLI commands:
 
@@ -59,21 +62,21 @@ For a persistent installation:
 
 ```bash
 npm install --global @dosu/decant@latest
-decant serve
+decant
 ```
 
 Install it with Homebrew:
 
 ```bash
 brew install dosu-ai/dosu/decant
-decant serve
+decant
 ```
 
 Install it without Node, straight from the release assets:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/dosu-ai/decant/main/install.sh | sh
-decant serve
+decant
 ```
 
 Run the GHCR image:
@@ -153,6 +156,12 @@ Claude `stream-json` logs; pass `--path` more than once to ingest multiple paths
   archive as-is and ingests nothing. The `--no-sync` flag does the same. The
   "Sync now" button and `POST /api/sync` still work; this only suppresses the
   syncing Decant starts on its own.
+- `DECANT_NO_OPEN`: set to any value to never auto-open a browser from
+  `decant serve`; the `--no-open` flag does the same per run.
+- `BROWSER`: opener command used instead of the platform default (`open` on
+  macOS, `xdg-open` on Linux). A bare command name or path, no arguments;
+  `BROWSER=none` disables opening. The URL is always printed either way, and
+  auto-open is skipped in CI or when stdout is not a terminal.
 - `DECANT_TRUSTED_PEERS`: comma-separated peer IPs or IPv4 CIDRs allowed through
   the local API guard when `serve` is bound to a non-loopback host. Unset by
   default. Keep it as narrow as the deployment allows: every listed address, and
@@ -239,7 +248,7 @@ details and per-artifact verification.
 1. **npx / npm** — zero persistent install, or a global one:
 
    ```bash
-   npx @dosu/decant@latest serve
+   npx @dosu/decant@latest
    npm install --global @dosu/decant@latest   # persistent, then use `decant`
    ```
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -13,6 +13,7 @@ The package is a release target, not a currently published install path until
 the first Release workflow run succeeds.
 
 ```sh
+npx @dosu/decant          # starts the web UI and opens your browser
 npx @dosu/decant --help
 npx @dosu/decant sync
 npx @dosu/decant serve

--- a/npm/decant/README.md
+++ b/npm/decant/README.md
@@ -11,8 +11,9 @@ selects the matching optional platform package, then runs the embedded
 Bun-compiled binary.
 
 ```sh
+npx @dosu/decant          # starts the web UI and opens your browser
+npx @dosu/decant --help
 npx @dosu/decant sync
-npx @dosu/decant ls
 npx @dosu/decant serve
 ```
 
@@ -20,11 +21,11 @@ For a persistent install:
 
 ```sh
 npm i -g @dosu/decant
-decant serve
+decant
 ```
 
 The global install puts a `decant` binary on your PATH, so day-to-day the
-command is just `decant`.
+command is just `decant`. Use `decant serve` when you need serve-specific flags.
 
 Supported platforms are macOS and Linux on x64 and arm64. On unsupported
 platforms, the launcher exits with a clear message:

--- a/packaging/homebrew/decant.rb.template
+++ b/packaging/homebrew/decant.rb.template
@@ -45,6 +45,13 @@ class Decant < Formula
     bin.install "decant"
   end
 
+  def caveats
+    <<~EOS
+      Run `decant` to start the local UI at http://127.0.0.1:3000
+      (it prints the link and opens your browser).
+    EOS
+  end
+
   test do
     assert_match version.to_s, shell_output("#{bin}/decant --version")
   end

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,91 @@
+import { spawn } from "node:child_process";
+
+/** Environment values that affect browser auto-open behavior. */
+export interface OpenEnv {
+  BROWSER?: string;
+  DECANT_NO_OPEN?: string;
+  CI?: string;
+}
+
+/** A pure decision describing whether and how Decant should open the UI. */
+export interface OpenDecision {
+  open: boolean;
+  command?: string;
+  reason: string;
+}
+
+export interface SpawnedLike {
+  on?: (event: "error", listener: (error: Error) => void) => unknown;
+  unref?: () => void;
+}
+
+export type SpawnLike = (
+  bin: string,
+  args: string[],
+  options: { stdio: "ignore"; detached: true },
+) => SpawnedLike;
+
+export function displayUrl(host: string, port: number): string {
+  const wildcard = host === "0.0.0.0" || host === "::" || host === "[::]";
+  const shown = wildcard ? "127.0.0.1" : host;
+  const bracketed = shown.includes(":") && !shown.startsWith("[") ? `[${shown}]` : shown;
+  return `http://${bracketed}:${port}`;
+}
+
+export function browserCommand(platform: NodeJS.Platform): string | null {
+  if (platform === "darwin") {
+    return "open";
+  }
+  if (platform === "linux") {
+    return "xdg-open";
+  }
+  // No Decant binaries ship for other platforms; never guess an opener.
+  return null;
+}
+
+export function decideOpen(input: {
+  enabled: boolean;
+  env: OpenEnv;
+  isTTY: boolean;
+  platform: NodeJS.Platform;
+}): OpenDecision {
+  if (!input.enabled) {
+    return { open: false, reason: "--no-open" };
+  }
+  // "Set to any value" disables, matching DECANT_NO_SYNC semantics.
+  if (input.env.DECANT_NO_OPEN != null) {
+    return { open: false, reason: "DECANT_NO_OPEN" };
+  }
+  const browser = input.env.BROWSER;
+  if (browser === "none") {
+    return { open: false, reason: "BROWSER=none" };
+  }
+  if (browser != null && browser !== "") {
+    // Deliberate configuration wins over CI and TTY detection. This also gives
+    // the serve E2E tests an opener seam while their stdio is piped.
+    return { open: true, command: browser, reason: "BROWSER" };
+  }
+  if (input.env.CI != null) {
+    return { open: false, reason: "CI" };
+  }
+  if (!input.isTTY) {
+    return { open: false, reason: "not a TTY" };
+  }
+  const command = browserCommand(input.platform);
+  if (command == null) {
+    return { open: false, reason: `no opener for ${input.platform}` };
+  }
+  return { open: true, command, reason: "platform default" };
+}
+
+export function openBrowser(url: string, command: string, spawner: SpawnLike = spawn): void {
+  try {
+    const child = spawner(command, [url], { stdio: "ignore", detached: true });
+    // Missing openers report ENOENT asynchronously; opening remains best-effort
+    // because the CLI always prints the authoritative URL.
+    child.on?.("error", () => {});
+    child.unref?.();
+  } catch {
+    // A synchronous spawn failure is also covered by the printed URL fallback.
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -346,28 +346,42 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
           // at all. POST /api/sync is deliberately untouched -- this turns off
           // syncing decant starts on its own, not a sync the operator asks for.
           const syncEnabled = shouldSync(globals(), options.env);
-          const server = serveApp({
-            config,
-            hostname: commandOptions.host ?? DEFAULT_SERVE_HOST,
-            port: commandOptions.port ?? DEFAULT_SERVE_PORT,
-            // Omit entirely (rather than passing []) when no --trusted-peer was
-            // given, so serve()'s resolveTrustedPeers() can still fall through
-            // to DECANT_TRUSTED_PEERS and then the gateway default. Any value
-            // passed here replaces both.
-            trustedPeers:
-              commandOptions.trustedPeer != null && commandOptions.trustedPeer.length > 0
-                ? trustedPeers(commandOptions.trustedPeer)
+          let server: ReturnType<typeof serveApp>;
+          try {
+            server = serveApp({
+              config,
+              hostname: commandOptions.host ?? DEFAULT_SERVE_HOST,
+              port: commandOptions.port ?? DEFAULT_SERVE_PORT,
+              // Omit entirely (rather than passing []) when no --trusted-peer was
+              // given, so serve()'s resolveTrustedPeers() can still fall through
+              // to DECANT_TRUSTED_PEERS and then the gateway default. Any value
+              // passed here replaces both.
+              trustedPeers:
+                commandOptions.trustedPeer != null && commandOptions.trustedPeer.length > 0
+                  ? trustedPeers(commandOptions.trustedPeer)
+                  : undefined,
+              logger: globals().quiet ? undefined : serverLogger,
+              watch: syncEnabled
+                ? {
+                    intervalMs: commandOptions.intervalMs,
+                    debounceMs: commandOptions.debounceMs,
+                    enableWatch: commandOptions.fsWatch !== false,
+                    onEvent: emitWatchEvent,
+                  }
                 : undefined,
-            logger: globals().quiet ? undefined : serverLogger,
-            watch: syncEnabled
-              ? {
-                  intervalMs: commandOptions.intervalMs,
-                  debounceMs: commandOptions.debounceMs,
-                  enableWatch: commandOptions.fsWatch !== false,
-                  onEvent: emitWatchEvent,
-                }
-              : undefined,
-          });
+            });
+          } catch (error) {
+            if (isPortInUse(error)) {
+              const wanted = commandOptions.port ?? DEFAULT_SERVE_PORT;
+              const url = displayUrl(commandOptions.host ?? DEFAULT_SERVE_HOST, wanted);
+              io.writeErr(
+                `error: port ${wanted} is already in use — is Decant already running at ${url}?\n` +
+                  "Pick another port with: decant serve --port <n>\n",
+              );
+              return 1;
+            }
+            throw error;
+          }
           if (!globals().quiet) {
             serverLogger.info("Server started.", {
               "event.name": "decant.server.started",
@@ -1129,6 +1143,14 @@ function serveBanner(url: string, opening: boolean): string {
     "",
     "",
   ].join("\n");
+}
+
+function isPortInUse(error: unknown): boolean {
+  if (typeof error !== "object" || error == null) {
+    return false;
+  }
+  const { code, message } = error as { code?: string; message?: string };
+  return code === "EADDRINUSE" || (message?.includes("in use") ?? false);
 }
 
 function openArchive(config: Config): Archive {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,6 +103,15 @@ interface DbInfo {
   tool_calls: number;
 }
 
+/**
+ * Bare `decant` is the fast entrypoint: it serves the UI. Only a completely
+ * empty argv rewrites — flag-only invocations stay errors because token
+ * splitting makes them ambiguous, and typos must never boot a server.
+ */
+export function defaultArgv(argv: string[]): string[] {
+  return argv.length === 0 ? ["serve"] : argv;
+}
+
 export async function runCli(argv: string[], options: CliRunOptions = {}): Promise<CliResult> {
   const watchLogger = getDecantLogger("watch");
   const serverLogger = getDecantLogger("server");
@@ -301,7 +310,9 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
 
   program
     .command("serve")
-    .description("serve the in-process web UI and keep the session log index current")
+    .description(
+      "serve the web UI and keep the index current (the default when run with no arguments)",
+    )
     .option("--host <host>", "host to bind", DEFAULT_SERVE_HOST)
     .option("--port <n>", "port to bind", parseInteger, DEFAULT_SERVE_PORT)
     .option("--claude-dir <dir>", "override the Claude projects directory")
@@ -1110,7 +1121,7 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
     );
 
   try {
-    await program.parseAsync(argv, { from: "user" });
+    await program.parseAsync(defaultArgv(argv), { from: "user" });
   } catch (error) {
     if (typeof error === "object" && error !== null && "exitCode" in error) {
       setCode(commanderExitCode(error as { exitCode: number; code?: string }));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 import { existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { Command, InvalidArgumentError } from "commander";
+import { decideOpen, displayUrl, openBrowser } from "./browser.ts";
 import { type Config, type ConfigOverrides, resolveConfig } from "./config.ts";
 import { ARCHIVE_DIR_MODE, closeDb, openDb } from "./db.ts";
 import {
@@ -319,6 +320,7 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
       collectOption,
       [] as string[],
     )
+    .option("--no-open", "do not open the browser after the server starts")
     .action(
       (commandOptions: {
         host?: string;
@@ -329,6 +331,7 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
         debounceMs?: number;
         fsWatch?: boolean;
         trustedPeer?: string[];
+        open?: boolean;
       }) =>
         runAsync(async () => {
           const config = resolve({
@@ -372,6 +375,25 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
               "server.port": server.port,
               "watch.enabled": syncEnabled,
             });
+          }
+          const boundPort = server.port ?? commandOptions.port ?? DEFAULT_SERVE_PORT;
+          const url = displayUrl(commandOptions.host ?? DEFAULT_SERVE_HOST, boundPort);
+          const environment = options.env ?? process.env;
+          const decision = decideOpen({
+            enabled: commandOptions.open !== false,
+            env: {
+              BROWSER: environment.BROWSER,
+              DECANT_NO_OPEN: environment.DECANT_NO_OPEN,
+              CI: environment.CI,
+            },
+            isTTY: process.stdout.isTTY === true,
+            platform: process.platform,
+          });
+          if (!globals().quiet) {
+            io.writeErr(serveBanner(url, decision.open));
+          }
+          if (decision.open && decision.command != null) {
+            openBrowser(url, decision.command);
           }
           try {
             await waitForProcessSignal();
@@ -1091,6 +1113,22 @@ function commanderExitCode(error: { exitCode: number; code?: string }): number {
     return 2;
   }
   return Number(error.exitCode);
+}
+
+function serveBanner(url: string, opening: boolean): string {
+  return [
+    "",
+    "  Decant is running.",
+    "",
+    `    ${url}`,
+    "",
+    opening
+      ? "  Opening your browser — the printed link works if it does not."
+      : "  Open the link in your browser.",
+    "  Ctrl-C stops the server; decant --help lists every command.",
+    "",
+    "",
+  ].join("\n");
 }
 
 function openArchive(config: Config): Archive {

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import { browserCommand, decideOpen, displayUrl, openBrowser } from "../src/browser.ts";
+
+describe("displayUrl", () => {
+  test("formats loopback host and port", () => {
+    expect(displayUrl("127.0.0.1", 3000)).toBe("http://127.0.0.1:3000");
+  });
+
+  test("maps wildcard hosts to loopback for display", () => {
+    expect(displayUrl("0.0.0.0", 8080)).toBe("http://127.0.0.1:8080");
+    expect(displayUrl("::", 3000)).toBe("http://127.0.0.1:3000");
+  });
+
+  test("brackets bare IPv6 hosts", () => {
+    expect(displayUrl("::1", 3000)).toBe("http://[::1]:3000");
+  });
+
+  test("passes named hosts through", () => {
+    expect(displayUrl("archive.local", 3000)).toBe("http://archive.local:3000");
+  });
+});
+
+describe("browserCommand", () => {
+  test("darwin uses open", () => {
+    expect(browserCommand("darwin")).toBe("open");
+  });
+
+  test("linux uses xdg-open", () => {
+    expect(browserCommand("linux")).toBe("xdg-open");
+  });
+
+  test("other platforms have no opener", () => {
+    expect(browserCommand("win32")).toBeNull();
+  });
+});
+
+describe("decideOpen", () => {
+  const base = {
+    enabled: true,
+    env: {},
+    isTTY: true,
+    platform: "darwin" as NodeJS.Platform,
+  };
+
+  test("opens with the platform command on an interactive terminal", () => {
+    expect(decideOpen(base)).toEqual({
+      open: true,
+      command: "open",
+      reason: "platform default",
+    });
+  });
+
+  test("--no-open wins over everything", () => {
+    const decision = decideOpen({ ...base, enabled: false, env: { BROWSER: "firefox" } });
+    expect(decision.open).toBe(false);
+  });
+
+  test("DECANT_NO_OPEN wins over BROWSER, even set to empty", () => {
+    expect(decideOpen({ ...base, env: { DECANT_NO_OPEN: "", BROWSER: "firefox" } }).open).toBe(
+      false,
+    );
+  });
+
+  test("BROWSER=none disables", () => {
+    expect(decideOpen({ ...base, env: { BROWSER: "none" } }).open).toBe(false);
+  });
+
+  test("an explicit BROWSER bypasses the TTY and CI gates", () => {
+    const decision = decideOpen({
+      ...base,
+      isTTY: false,
+      env: { BROWSER: "firefox", CI: "1" },
+    });
+    expect(decision).toEqual({ open: true, command: "firefox", reason: "BROWSER" });
+  });
+
+  test("CI blocks the platform default", () => {
+    expect(decideOpen({ ...base, env: { CI: "true" } }).open).toBe(false);
+  });
+
+  test("a non-TTY stdout blocks the platform default", () => {
+    expect(decideOpen({ ...base, isTTY: false }).open).toBe(false);
+  });
+
+  test("platforms without an opener never open", () => {
+    expect(decideOpen({ ...base, platform: "win32" }).open).toBe(false);
+  });
+});
+
+describe("openBrowser", () => {
+  test("spawns the command detached with the url as the only argument", () => {
+    const calls: Array<{ bin: string; args: string[]; options: unknown }> = [];
+    const child = { on: () => child, unref: () => {} };
+    openBrowser("http://127.0.0.1:3000", "open", (bin, args, options) => {
+      calls.push({ bin, args, options });
+      return child;
+    });
+    expect(calls).toEqual([
+      {
+        bin: "open",
+        args: ["http://127.0.0.1:3000"],
+        options: { stdio: "ignore", detached: true },
+      },
+    ]);
+  });
+
+  test("a throwing spawner is swallowed — the printed link is the fallback", () => {
+    expect(() =>
+      openBrowser("http://127.0.0.1:3000", "xdg-open", () => {
+        throw new Error("ENOENT");
+      }),
+    ).not.toThrow();
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -11,7 +11,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { runCli } from "../src/cli.ts";
+import { defaultArgv, runCli } from "../src/cli.ts";
 import { closeDb, LATEST_SCHEMA_VERSION, openDb } from "../src/db.ts";
 import { DECANT_VERSION } from "../src/distill.ts";
 import { upsertSession } from "../src/ingest.ts";
@@ -56,6 +56,29 @@ async function syncedCase(): Promise<{ dbPath: string }> {
   expect(JSON.parse(result.stdout)).toMatchObject({ scanned: 7, ingested: 7, issues: 0 });
   return { dbPath: fixtureCase.dbPath };
 }
+
+describe("defaultArgv", () => {
+  test("an empty invocation becomes serve", () => {
+    expect(defaultArgv([])).toEqual(["serve"]);
+  });
+
+  test("commands pass through untouched", () => {
+    expect(defaultArgv(["ls"])).toEqual(["ls"]);
+  });
+
+  test("flag-only invocations pass through untouched", () => {
+    expect(defaultArgv(["--db", "/tmp/x.db"])).toEqual(["--db", "/tmp/x.db"]);
+    expect(defaultArgv(["--help"])).toEqual(["--help"]);
+  });
+});
+
+describe("unknown commands still fail fast", () => {
+  test("a typo does not silently start a server", async () => {
+    const result = await runCli(["frobnicate"]);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain("frobnicate");
+  });
+});
 
 describe("runCli", () => {
   test("sync then list, project, db, stats, search, files, tool, and export", async () => {
@@ -654,7 +677,7 @@ describe("runCli", () => {
 
     const serve = await runCli(["serve", "--help"]);
     expect(serve).toMatchObject({ code: 0, stderr: "" });
-    expect(serve.stdout).toContain("in-process web UI");
+    expect(serve.stdout.replace(/\s+/g, " ")).toContain("default when run with no arguments");
     expect(serve.stdout).toContain("--host");
     expect(serve.stdout).toContain("--port");
     expect(serve.stdout).toContain("--trusted-peer");

--- a/test/serve-open.test.ts
+++ b/test/serve-open.test.ts
@@ -69,6 +69,9 @@ function stop(child: ChildProcess): Promise<number | null> {
 function freePort(): Promise<number> {
   return new Promise((resolve, reject) => {
     const probe = net.createServer();
+    // A failed listen (EACCES, fd limits) emits "error"; without a listener
+    // that is an uncaught exception instead of a clean test failure.
+    probe.on("error", reject);
     probe.listen(0, "127.0.0.1", () => {
       const address = probe.address();
       probe.close(() => {
@@ -170,7 +173,13 @@ describe("serve banner and auto-open", () => {
     const scratch = scratchDir();
     const port = await freePort();
     const holder = net.createServer();
-    await new Promise<void>((resolve) => holder.listen(port, "127.0.0.1", resolve));
+    // Same exposure as freePort's probe, plus a real race: this re-binds a
+    // port that was only just released, so a rare EADDRINUSE must reject
+    // rather than raise an unhandled "error" event.
+    await new Promise<void>((resolve, reject) => {
+      holder.on("error", reject);
+      holder.listen(port, "127.0.0.1", resolve);
+    });
     const cli = startCli(["serve", "--port", String(port)], scratch);
     try {
       const code = await new Promise<number | null>((resolve) => {

--- a/test/serve-open.test.ts
+++ b/test/serve-open.test.ts
@@ -162,4 +162,23 @@ describe("serve banner and auto-open", () => {
       rmSync(scratch, { recursive: true, force: true });
     }
   }, 30_000);
+
+  test("a busy port fails with a pointer instead of a stack trace", async () => {
+    const scratch = scratchDir();
+    const port = await freePort();
+    const holder = net.createServer();
+    await new Promise<void>((resolve) => holder.listen(port, "127.0.0.1", resolve));
+    const cli = startCli(["serve", "--port", String(port)], scratch);
+    try {
+      const code = await new Promise<number | null>((resolve) => {
+        cli.child.once("exit", (value) => resolve(value));
+      });
+      expect(code).toBe(1);
+      expect(cli.stderr()).toContain(`port ${port} is already in use`);
+      expect(cli.stderr()).toContain("decant serve --port");
+    } finally {
+      holder.close();
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  }, 30_000);
 });

--- a/test/serve-open.test.ts
+++ b/test/serve-open.test.ts
@@ -57,6 +57,9 @@ async function waitFor(
 }
 
 function stop(child: ChildProcess): Promise<number | null> {
+  if (child.exitCode != null || child.signalCode != null) {
+    return Promise.resolve(child.exitCode);
+  }
   return new Promise((resolve) => {
     child.once("exit", (code) => resolve(code));
     child.kill("SIGTERM");
@@ -178,6 +181,21 @@ describe("serve banner and auto-open", () => {
       expect(cli.stderr()).toContain("decant serve --port");
     } finally {
       holder.close();
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("bare decant serves instead of printing help", async () => {
+    const scratch = scratchDir();
+    const cli = startCli([], scratch, { BROWSER: "none" });
+    try {
+      await waitFor(
+        () => URL_LINE.test(cli.stderr()) || cli.stderr().includes("already in use"),
+        "serve banner or busy-port message",
+      );
+      expect(cli.stderr()).not.toContain("Usage:");
+    } finally {
+      await stop(cli.child);
       rmSync(scratch, { recursive: true, force: true });
     }
   }, 30_000);

--- a/test/serve-open.test.ts
+++ b/test/serve-open.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// E2E for the serve banner and browser auto-open: spawn the real CLI the way
+// test/serve-wiring.test.ts does. Piped stdio means stdout is not a TTY, so
+// the platform-default open path never fires here; the explicit-BROWSER
+// override is both a feature and the test seam.
+
+const repoRoot = join(import.meta.dir, "..");
+const URL_LINE = /http:\/\/127\.0\.0\.1:(\d+)/;
+
+interface CliProcess {
+  child: ChildProcess;
+  stderr: () => string;
+}
+
+function startCli(args: string[], scratch: string, env: Record<string, string> = {}): CliProcess {
+  const inherited = { ...process.env };
+  delete inherited.BROWSER;
+  delete inherited.DECANT_NO_OPEN;
+  delete inherited.CI;
+  const child = spawn("bun", ["run", join(repoRoot, "src/cli.ts"), ...args], {
+    env: {
+      ...inherited,
+      DECANT_DB: join(scratch, "decant.db"),
+      DECANT_CONFIG_DIR: join(scratch, "config"),
+      DECANT_NO_SYNC: "1",
+      DECANT_LOG_LEVEL: "off",
+      ...env,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stderr = "";
+  child.stderr?.on("data", (chunk) => {
+    stderr += String(chunk);
+  });
+  child.stdout?.on("data", () => {});
+  return { child, stderr: () => stderr };
+}
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  what: string,
+  ms = 15_000,
+): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (!(await predicate())) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${what}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+function stop(child: ChildProcess): Promise<number | null> {
+  return new Promise((resolve) => {
+    child.once("exit", (code) => resolve(code));
+    child.kill("SIGTERM");
+  });
+}
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = net.createServer();
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address();
+      probe.close(() => {
+        if (address != null && typeof address === "object") {
+          resolve(address.port);
+        } else {
+          reject(new Error("no port"));
+        }
+      });
+    });
+  });
+}
+
+function scratchDir(): string {
+  return mkdtempSync(join(tmpdir(), "decant-serve-open-"));
+}
+
+/** BROWSER stub that appends its single argument to a log file. */
+function spyBrowser(scratch: string): { script: string; log: string } {
+  const log = join(scratch, "opened.log");
+  const script = join(scratch, "spy-browser.sh");
+  writeFileSync(script, `#!/bin/sh\nprintf '%s\\n' "$1" >> ${JSON.stringify(log)}\n`, {
+    mode: 0o755,
+  });
+  return { script, log };
+}
+
+describe("serve banner and auto-open", () => {
+  test("prints the URL banner without opening when no BROWSER is set (non-TTY)", async () => {
+    const scratch = scratchDir();
+    const port = await freePort();
+    const cli = startCli(["serve", "--port", String(port)], scratch);
+    try {
+      await waitFor(() => URL_LINE.test(cli.stderr()), "url banner");
+      expect(cli.stderr()).toContain(`    http://127.0.0.1:${port}`);
+      expect(cli.stderr()).toContain("Open the link in your browser.");
+      expect(cli.stderr()).not.toContain("Opening your browser");
+    } finally {
+      expect(await stop(cli.child)).toBe(0);
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("BROWSER override opens exactly the printed URL", async () => {
+    const scratch = scratchDir();
+    const port = await freePort();
+    const spy = spyBrowser(scratch);
+    const cli = startCli(["serve", "--port", String(port)], scratch, { BROWSER: spy.script });
+    try {
+      await waitFor(() => existsSync(spy.log), "spy browser invocation");
+      expect(readFileSync(spy.log, "utf8").trim()).toBe(`http://127.0.0.1:${port}`);
+      expect(cli.stderr()).toContain("Opening your browser");
+    } finally {
+      expect(await stop(cli.child)).toBe(0);
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("--no-open beats BROWSER and still prints the link", async () => {
+    const scratch = scratchDir();
+    const port = await freePort();
+    const spy = spyBrowser(scratch);
+    const cli = startCli(["serve", "--port", String(port), "--no-open"], scratch, {
+      BROWSER: spy.script,
+    });
+    try {
+      await waitFor(() => URL_LINE.test(cli.stderr()), "url banner");
+      expect(cli.stderr()).toContain(`    http://127.0.0.1:${port}`);
+    } finally {
+      expect(await stop(cli.child)).toBe(0);
+      // If the opener were going to fire, it would have done so before startup
+      // finished and the server shut down cleanly.
+      expect(existsSync(spy.log)).toBe(false);
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("quiet suppresses the banner but the server still runs", async () => {
+    const scratch = scratchDir();
+    const port = await freePort();
+    const cli = startCli(["serve", "--port", String(port), "-q"], scratch);
+    try {
+      await waitFor(async () => {
+        try {
+          const response = await fetch(`http://127.0.0.1:${port}/api/health`);
+          return response.ok;
+        } catch {
+          return false;
+        }
+      }, "health endpoint");
+      expect(cli.stderr()).not.toContain("http://");
+    } finally {
+      expect(await stop(cli.child)).toBe(0);
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- make bare `decant` start the local web UI while preserving explicit commands, `--help`, and typo failures
- always print the bound URL, then best-effort open it with `open`, `xdg-open`, or `BROWSER`
- add opt-outs for `--no-open`, `DECANT_NO_OPEN`, `BROWSER=none`, CI, and non-TTY runs
- replace raw busy-port failures with an actionable message
- update npm, Homebrew, installer, and contributor documentation for the fast entrypoint

Implements the fast-entrypoint request from @mmangus: open the UI and keep the printed URL as the reliable fallback.

## Verification

- `just check` — 825 tests, TypeScript, Biome, and distribution staging smoke
- native `darwin-arm64` binary served HTTP 200 from a scratch archive and stopped cleanly
- native binary opened the default browser through the real `BROWSER=open` path
- all five commits are signed by `teedole`

## Distribution

There is no channel-specific runtime code: npx, npm global installs, Homebrew, the shell installer, Docker, and source all execute the same compiled CLI. Docker keeps its explicit `serve` command and does not use the bare-argv default.
