### PR TITLE
docs: add architecture and analytics guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,9 +21,12 @@ one Decant process. The pre-cutover tree is preserved in the signed
 ## Layout
 
 Start from `src/cli.ts`; parsers live in `src/sources/` (the extension
-point). Docs: `docs/api/openapi.yaml` (local API contract),
-`docs/api/routes.md` (serve semantics), `docs/distribution.md`
-(npm/installer/Docker/source), and `docs/releasing.md` (release operations).
+point). Docs: `docs/architecture.md` (module and data flow),
+`docs/analytics-methodology.md` (metric semantics), `docs/data-lifecycle.md`
+(sync and local state), `docs/api/openapi.yaml` (local API contract),
+`docs/api/routes.md` (serve semantics), `docs/api/recipes.md` (read recipes),
+`docs/distribution.md` (npm/installer/Docker/source), and `docs/releasing.md`
+(release operations).
 
 Agent tooling lives in `.claude/`. Two skills cover the work most likely to go
 wrong, `new-source-parser` for invariant 6 and `new-migration` for invariant 5.

--- a/README.md
+++ b/README.md
@@ -235,6 +235,11 @@ tag.
 The local API contract lives in
 [docs/api/openapi.yaml](docs/api/openapi.yaml), with operational semantics in
 [docs/api/routes.md](docs/api/routes.md).
+The [architecture guide](docs/architecture.md) maps the modules and data flow;
+[analytics methodology](docs/analytics-methodology.md) defines the reported
+units; [API recipes](docs/api/recipes.md) show reproducible local queries; and
+[archive lifecycle](docs/data-lifecycle.md) explains sync, visibility, deletion,
+and rebuild behavior.
 Operational log fields and privacy rules live in [docs/logging.md](docs/logging.md).
 Distribution notes live in [docs/distribution.md](docs/distribution.md), and the
 tag-driven release pipeline is documented in

--- a/docs/analytics-methodology.md
+++ b/docs/analytics-methodology.md
@@ -1,0 +1,137 @@
+# How Decant analytics work
+
+Decant derives analytics from the normalized session records already stored in
+the local archive. It does not call a model or upload transcripts. This page
+defines the units behind the CLI, API, UI, and reports so their numbers can be
+interpreted consistently.
+
+## Scope and dates
+
+The `from` and `to` filters are inclusive UTC calendar dates. A session belongs
+to a window according to the date prefix of its `started_at` timestamp. Invalid
+date strings are ignored by the API, so callers that need a strict contract
+should validate dates before sending them.
+
+Archived and deleted sessions are excluded by default. Statistics endpoints
+that accept `include_archived=true` can include user-archived sessions; deleted
+sessions remain excluded. See [Archive and data lifecycle](data-lifecycle.md).
+
+## Sessions, runs, and subagents
+
+A top-level session is a run that is not marked as a subagent. A subagent is a
+nested run linked to a parent session.
+
+- `sessions` in aggregate statistics counts top-level sessions only.
+- Message, tool-call, token, and estimated-cost totals include all visible
+  sessions in scope, including subagents.
+- `GET /api/sessions` omits subagents as list rows by default.
+  `include_subagents=true` includes them; `with_subagents=true` attaches nested
+  summaries to the returned rows.
+- `subagent_count` and `subagent_estimated_cost_usd` on one summary describe its
+  direct children. For a complete tree, request subagents as rows and join them
+  by `parent_session_id`; attached nested summaries are capped at five levels.
+
+This distinction matters when comparing throughput with cost: a single
+top-level session can coordinate many separately metered runs.
+
+## Work type and completion labels
+
+Work type and outcome are lightweight transcript-shape heuristics, not evidence
+that a change shipped or achieved its goal. Work type starts with keywords in
+the first user prompt and can fall back to the mix of file and web activity.
+Outcome looks at how the main transcript ended: a normal assistant completion,
+an interruption, a trailing user/tool turn, or an error result.
+
+Use these labels to organize follow-up analysis. Do not treat `completed` as a
+merged change, a passing test suite, or a successful business outcome without
+joining Decant data to evidence from the system where the work landed.
+
+## Token and cost totals
+
+Decant preserves provider-reported input, output, cache-read, cache-creation,
+and reasoning usage when the source exposes it. Claude reasoning can be
+estimated by subtraction when the source does not report it directly; the API
+keeps reported and estimated reasoning separate.
+
+Costs use the pricing table that existed when the session was ingested. They
+are estimates of standard API token rates, not a reconstruction of a ChatGPT
+subscription, Codex credits, discounts, or provider invoices. Updating
+[pricing](pricing.md) does not rewrite historical rows; rebuild the archive to
+re-estimate them.
+
+## Activity buckets
+
+Token economics assigns generation, context-window volume, tool calls,
+estimated cost, and active time to four buckets:
+
+| Bucket | What it represents |
+| --- | --- |
+| `context` | Reading, searching, listing, web/MCP retrieval, and read-only shell or Git commands. Unknown tools default here rather than overstating implementation. |
+| `planning` | Thinking/reasoning blocks and explicit plan-management tools. |
+| `code` | Structured edits and shell commands that clearly build, test, write, or otherwise mutate work. |
+| `communicating` | Visible text and other non-tool, non-thinking output. |
+
+Shell classification is deliberately conservative. Read-only commands such as
+`rg`, `cat`, and `git diff` are context; mutating or unrecognized shell commands
+are code. A bucket is an analytical attribution, not a provider billing field
+or a quality judgment.
+
+Generation is allocated from per-message usage when available, then by block
+size when it is not. Tool-result bytes contribute to context-window volume.
+Bucket costs are proportional allocations of the session's estimated input and
+output cost, so they reconcile to the total but should not be read as separate
+provider charges.
+
+## Orientation and implementation
+
+Phases are orthogonal to activity buckets:
+
+- **Orientation** is everything before the first detected file edit.
+- **Implementation** begins with that edit and includes everything after it.
+- A session that never edits a file is entirely orientation.
+
+Structured edit tools establish the boundary directly. Shell edits use narrow,
+high-confidence patterns such as `git apply`, `sed -i`, and explicit file-write
+APIs. The classifier prefers missing a weak signal over moving the boundary
+forward on a false positive.
+
+## Active time and user wait
+
+Active time is an attribution from message timestamps, not stopwatch time. The
+gap between two messages is charged to the later message, split across that
+message's blocks, and capped at five minutes. Gaps closed by user-authored text
+are reported separately as `waiting_on_user_ms`.
+
+Consequences:
+
+- long idle periods do not dominate the result;
+- blockless or missing-timestamp messages cannot contribute;
+- wall-clock session duration can be much larger than active time;
+- time estimates are best for relative comparisons, not billing or timesheets.
+
+## Context-window occupancy and compaction
+
+For one model call, occupancy is:
+
+`input_tokens + cache_read_tokens + cache_creation_tokens`
+
+It is the prompt resident in the window for that call, not cumulative token
+consumption. Peak occupancy is the largest observed call. Codex logs can carry
+an explicit model window; Claude window size is inferred from the model family
+when the source does not record it, and the API marks inferred values.
+
+Compactions come from provider boundary records. Pre- and post-compaction token
+counts are preserved when the source supplies enough information; missing
+values remain unavailable rather than being invented.
+
+## Data quality signals
+
+`unparsed_line` means Decant could not normalize a source line and is treated
+as a substantive ingest issue. Other diagnostics, such as an unknown record
+type or imperfect tool linkage, are informational format-drift sensors. Both
+are preserved, but informational notices should not be described as data loss
+without inspecting the session's issue details.
+
+For the machine-readable field definitions, see the
+[OpenAPI contract](api/openapi.yaml). For practical queries, see
+[Local API recipes](api/recipes.md).

--- a/docs/api/recipes.md
+++ b/docs/api/recipes.md
@@ -1,0 +1,159 @@
+# Local API recipes
+
+These examples use Decant's local, unauthenticated API. Keep it on loopback
+unless you deliberately configured the trusted-peer boundary in
+[Local Serve API](routes.md).
+
+The reference schema is [openapi.yaml](openapi.yaml). The running binary serves
+the same document at `/api/openapi.json`.
+
+## Start a read-only snapshot server
+
+Use `--no-sync` when you want to analyze the archive as it exists without a
+startup sync or source watcher:
+
+```sh
+decant serve --no-sync --no-open
+```
+
+This does not make write routes read-only. An explicit `POST /api/sync` still
+runs, and admitted clients can still change session state or recommendations.
+
+Set a base URL for the examples:
+
+```sh
+BASE=http://127.0.0.1:3000
+```
+
+## Check freshness before analysis
+
+```sh
+curl --fail --silent --show-error "$BASE/api/health"
+curl --fail --silent --show-error "$BASE/api/sync-status"
+curl --fail --silent --show-error "$BASE/api/date-bounds"
+```
+
+`sync-status` reports whether a sync is in progress, its last terminal report,
+and its last error. For a reproducible snapshot, wait for `in_progress` to be
+false or start the server with `--no-sync` before collecting endpoints.
+
+## Query a complete date window
+
+`from` and `to` are inclusive UTC dates. Exclude the current UTC date when you
+want complete days, then compare with an equal-length preceding window.
+
+```sh
+FROM=2026-07-04
+TO=2026-08-02
+
+curl --fail --silent --show-error --get \
+  --data-urlencode "from=$FROM" \
+  --data-urlencode "to=$TO" \
+  "$BASE/api/stats/summary"
+```
+
+Group the same scope without changing its denominator:
+
+```sh
+curl --fail --silent --show-error --get \
+  --data-urlencode "dim=project" \
+  --data-urlencode "from=$FROM" \
+  --data-urlencode "to=$TO" \
+  "$BASE/api/stats/by-dimension"
+```
+
+Available dimensions are `tool`, `model`, `project`, and `day`. Aggregate
+`sessions` counts top-level sessions; token, cost, message, and tool totals
+include visible subagents. See [How Decant analytics work](../analytics-methodology.md).
+
+## Paginate sessions
+
+`GET /api/sessions` returns a bare newest-first array. Its default limit is 50
+and its effective maximum is 100. Increase `offset` by the number of rows
+received until a page is short or empty:
+
+```sh
+curl --fail --silent --show-error --get \
+  --data-urlencode "from=$FROM" \
+  --data-urlencode "to=$TO" \
+  --data-urlencode "limit=100" \
+  --data-urlencode "offset=0" \
+  "$BASE/api/sessions"
+```
+
+When the total is an exact multiple of the page size, one empty request is
+required to confirm the end. There is no total or continuation token in this
+response.
+
+Use `include_subagents=true` to return subagents as rows. Use
+`with_subagents=true` to attach nested summaries to top-level rows, capped at
+five levels. For a complete tree, request subagents as rows and join them by
+`parent_session_id`. Do not add parent cost and archive-wide cost totals
+together: aggregate statistics already include every visible run.
+
+## Economics, activity, tools, and files
+
+The same date query works on the analytical endpoints:
+
+```sh
+curl --fail --silent --show-error \
+  "$BASE/api/analytics/token-economics?from=$FROM&to=$TO"
+curl --fail --silent --show-error \
+  "$BASE/api/analytics/activity?from=$FROM&to=$TO"
+curl --fail --silent --show-error \
+  "$BASE/api/tools/usage?from=$FROM&to=$TO"
+curl --fail --silent --show-error \
+  "$BASE/api/tools/mcp-usage?from=$FROM&to=$TO"
+curl --fail --silent --show-error \
+  "$BASE/api/files?group=path&from=$FROM&to=$TO"
+```
+
+Activity distributions use the machine's local timezone and include subagent
+starts. Avoid presenting their peak hour or weekday as a human work schedule
+without first checking for a highly parallel session tree.
+
+## Filter one project safely
+
+Project filters require the exact archived path. Let `curl` encode it:
+
+```sh
+PROJECT=/path/to/project
+
+curl --fail --silent --show-error --get \
+  --data-urlencode "project=$PROJECT" \
+  --data-urlencode "from=$FROM" \
+  --data-urlencode "to=$TO" \
+  "$BASE/api/stats/summary"
+```
+
+## Read one session without over-fetching
+
+Session detail supports message pagination. Pass `message_limit=0` only when
+you intentionally want the complete transcript; otherwise request the slice
+needed by the client. Separate endpoints expose token economics, context-window
+history, outline, and ingest issues:
+
+```sh
+SESSION_ID=123
+
+curl --fail --silent --show-error \
+  "$BASE/api/sessions/$SESSION_ID?message_limit=100&message_offset=0"
+curl --fail --silent --show-error \
+  "$BASE/api/sessions/$SESSION_ID/token-economics"
+curl --fail --silent --show-error \
+  "$BASE/api/sessions/$SESSION_ID/context-window"
+curl --fail --silent --show-error \
+  "$BASE/api/sessions/$SESSION_ID/issues"
+```
+
+## Handle errors by code
+
+JSON failures use `{ "error": string, "code": string, ... }`. Branch on the
+stable code, not prose. Expected recovery cases include `service_starting`,
+`archive_locked`, `schema_drift`, `schema_too_new`, `schema_too_old`, and
+`session_not_found`. `service_starting` and `archive_locked` are retryable;
+schema conflicts require operator action.
+
+Mutating routes also enforce content-type and browser-origin rules. Follow the
+write example and trusted-peer details in [Local Serve API](routes.md) rather
+than weakening those guards in a client.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,115 @@
+# Architecture
+
+Decant is one local Bun and TypeScript application. The CLI process discovers
+coding-agent logs, normalizes and enriches them, owns the SQLite archive, and
+optionally serves the React UI and local API. There is no daemon, hosted
+service, bearer token, or second application process.
+
+## Data flow
+
+```text
+~/.claude + ~/.codex
+        |
+        v
+discover -> parse -> normalize -> enrich -> ingest
+                                      |       |
+                                      |       +-> SQLite WAL + FTS5
+                                      +-> cost, context, files, tools,
+                                          diagnostics, economics vectors
+                                                     |
+                          +--------------------------+------------------+
+                          |                          |                  |
+                          v                          v                  v
+                     CLI queries              local API + SSE       React UI
+```
+
+Source logs remain the source of truth. The archive is a rebuildable local
+index plus local user state such as recommendations and session tombstones.
+
+## Main modules
+
+| Area | Primary modules | Responsibility |
+| --- | --- | --- |
+| Composition | `src/cli.ts`, `src/config.ts` | Commands, global flags, output policy, configuration, and process lifecycle. |
+| Sources | `src/sources/`, `src/model.ts` | Pure, print-free parsers and the normalized wire model. |
+| Ingest | `src/ingest.ts`, `src/enrich.ts`, `src/diagnostics.ts` | Discovery, change detection, normalization writes, derived facets, and ingest issues. |
+| Economics | `src/cost.ts`, `src/buckets.ts`, `src/token-economics.ts`, `src/context-window.ts` | Pricing, activity attribution, persisted vectors, and occupancy timelines. |
+| Storage | `src/db.ts`, `src/schema.sql`, `src/schema-manifest.ts` | SQLite ownership, WAL, migrations, permissions, and schema-drift detection. |
+| Reads | `src/query.ts`, `src/stats.ts`, `src/recommendations.ts`, `src/distill.ts` | Session retrieval, aggregates, recommendations, and deterministic artifacts. |
+| Serve | `src/server.ts`, `src/watch.ts`, `src/*-worker.ts` | HTTP routing, trusted peers, sync coordination, SSE, and background worker execution. |
+| Presentation | `src/ui/`, `src/report/` | The local React application and self-contained HTML reports. |
+
+Core modules return data or structured failures. Human-readable output and exit
+codes belong in `src/cli.ts`; HTTP status and error-envelope policy belong in
+`src/server.ts`.
+
+## Parsing and ingest
+
+Each source file produces one normalized session. Parsers retain canonical raw
+records while mapping provider-specific roles, blocks, usage, tool calls, and
+lineage into shared tables. Malformed lines and unknown record types become
+diagnostics rather than aborting the file.
+
+Ingest uses file metadata and hashes to avoid unnecessary work. A changed
+session is replaced transactionally, then Decant materializes context-window
+rollups and versioned per-session economics vectors. Costs are also stored at
+ingest, so later pricing edits do not mutate history.
+
+The supported extension point is a new parser under `src/sources/`. Follow
+[Add a source](prompts/add-source.md); it defines the privacy, capability,
+fixture, ingest, and golden requirements.
+
+## SQLite ownership and schema
+
+The active CLI process opens the archive directly. WAL mode permits concurrent
+reads and the worker-owned ingest connection, but Decant does not put another
+daemon or API process in front of SQLite.
+
+`src/schema.sql` is the effective v21 baseline. Narrow migrations preserve
+v8-and-newer TypeScript archives; older archives are rebuild-only. A migration
+is immutable once committed because a dogfooding archive may already have
+applied it. Schema manifests detect missing, unexpected, or structurally
+different owned objects before Decant continues on a drifted archive.
+
+Archive files and sidecars are created or narrowed to owner-only permissions
+where the platform supports POSIX modes.
+
+## Serve, workers, and caches
+
+`decant serve` binds the HTTP listener before opening the archive. This makes a
+second server fail with a truthful port-in-use message instead of first
+becoming another database owner.
+
+The server keeps request handling responsive by running source syncs in
+`src/sync-worker.ts` and economics-vector scans in `src/stats-worker.ts`.
+Economics vectors are cached in memory. `PRAGMA data_version` detects writes by
+other connections; the server serves the previous model while rebuilding and
+then emits `archive_updated` so clients can refresh.
+
+The worker files are also standalone-binary entrypoints. See the compiled
+worker rule in [Distribution](distribution.md#standalone-worker-entrypoints).
+
+## Local API and UI
+
+The UI, JSON routes, reports, and event stream are served by the same process.
+[OpenAPI](api/openapi.yaml) is the reference contract, and the running binary
+exposes that contract at `/api/openapi.json`. Operational behavior that does
+not fit the schema lives in [Local Serve API](api/routes.md).
+
+The default loopback listener is unauthenticated. A broad bind must pass the
+trusted-peer source-address guard; `Host` and browser-origin checks are defense
+in depth, not credentials. The app never adds an outbound runtime dependency.
+
+## Change map
+
+- New source format: parser, synthetic fixtures, ingest tests, and goldens.
+- New schema state: a new migration plus schema and migration tests; never edit
+  a committed migration.
+- New serve behavior: implementation, OpenAPI, route documentation, and
+  contract tests together.
+- New aggregate: preserve archive-state, date, project, and tool scope across
+  the CLI, API, UI, and report consumers.
+- New distribution runtime module: update compile entrypoints and exercise the
+  installed artifact through its real behavior.
+
+Run `just check` before considering any of these changes ready.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,7 +87,7 @@ other connections; the server serves the previous model while rebuilding and
 then emits `archive_updated` so clients can refresh.
 
 The worker files are also standalone-binary entrypoints. See the compiled
-worker rule in [Distribution](distribution.md#standalone-worker-entrypoints).
+worker rule in the Standalone worker entrypoints section of docs/distribution.md.
 
 ## Local API and UI
 

--- a/docs/data-lifecycle.md
+++ b/docs/data-lifecycle.md
@@ -101,6 +101,6 @@ files, and economics exclude user-hidden sessions. Statistics operations that
 accept `include_archived=true` add archived sessions back; deleted sessions and
 their content remain absent.
 
-See [Local Serve API](api/routes.md#response-and-archive-semantics) for the
+See the Response and archive semantics section of docs/api/routes.md for the
 wire behavior and [How Decant analytics work](analytics-methodology.md) for the
 effect on analytical denominators.

--- a/docs/data-lifecycle.md
+++ b/docs/data-lifecycle.md
@@ -1,0 +1,106 @@
+# Archive and data lifecycle
+
+Decant reads coding-agent logs into a local SQLite archive. The source logs and
+the archive have different jobs: source JSONL is the durable record produced by
+Claude Code or Codex; `~/.decant/decant.db` is a searchable, rebuildable index
+plus Decant-owned user state.
+
+Nothing in this lifecycle uploads transcripts or calls a hosted service.
+
+## Source logs and the archive
+
+By default Decant discovers:
+
+- Claude Code sessions under `~/.claude/projects`;
+- Codex sessions under `~/.codex/sessions` and source-archived sessions under
+  `~/.codex/archived_sessions`.
+
+`decant sync` inserts new sessions and replaces changed ones transactionally.
+Unchanged files are skipped by metadata and content checks. Watch mode combines
+native filesystem events with a periodic sweep so missed notifications do not
+leave the archive stale.
+
+The archive stores normalized messages and blocks, canonical raw records,
+tools, files, costs, context rollups, diagnostics, recommendations, and local
+session state. Deleting or rebuilding the archive does not delete the source
+JSONL files.
+
+## Automatic and explicit sync
+
+Read commands normally sync first. `decant serve` performs a startup sync and
+then watches the configured source directories.
+
+Set `DECANT_NO_SYNC` or pass `--no-sync` to suppress syncs Decant starts on its
+own. With `serve`, this also disables the source watcher. It does not disable an
+operator-requested `POST /api/sync` or the UI's **Sync now** action.
+
+Always use `--no-sync` with a scratch database unless you want it populated
+from the real default source directories:
+
+```sh
+decant --db /tmp/decant-review.db --no-sync serve --no-open
+```
+
+## Visible, archived, and deleted
+
+Session state is keyed by stable provider identity rather than the transient
+SQLite row id.
+
+| Action | Archive rows | Default reads and statistics | Later sync | Source JSONL |
+| --- | --- | --- | --- | --- |
+| Archive | Retained | Hidden, including effective descendants | Remains archived | Unchanged |
+| Restore visibility | Retained | Visible unless an ancestor or source state still hides it | Remains visible | Unchanged |
+| Delete | Selected session tree is physically removed | Excluded | Tombstones prevent resurrection | Unchanged |
+
+Archiving records a direct override only on the selected session. Descendants
+inherit effective visibility from their current ancestry. This lets a child
+that was archived independently stay archived after its parent is restored.
+
+Deleting applies to the existing descendant tree and keeps identity tombstones.
+Provider lineage metadata lets a late-arriving descendant inherit the deletion
+instead of reappearing after a later sync. Deleted sessions are not returned by
+`include_archived=true` and cannot be restored through the normal session-state
+API after their rows are removed.
+
+A provider can also mark a session archived in its own source layout. Clearing
+a Decant user override does not move or rewrite provider files.
+
+## Sensitive sessions
+
+Deleting a session tree removes its transcript-derived rows from Decant and
+prevents the configured source from re-ingesting that identity. The original
+Claude Code or Codex log remains on disk. If the source record must also be
+removed, manage it through the owning tool or delete that source file only
+after deciding that losing the original transcript is intended.
+
+Never commit a real archive, transcript, exported session, source path dump, or
+fixture derived from private content. Synthetic fixtures are the only session
+data allowed in this repository.
+
+## Rebuilds and migrations
+
+Source logs are sufficient to rebuild transcript-derived state. Archives older
+than schema v8 are intentionally rebuild-only; v8 through v20 migrate to the
+current v21 baseline on open. The next sync backfills persisted economics and
+context rollups when required.
+
+Costs are materialized at ingest. A rebuild uses the pricing table in the new
+Decant version and can therefore change historical estimates even when the
+source logs did not change.
+
+Local state that does not come from provider logs belongs to the archive. That
+includes recommendation status, session archive overrides, and deletion
+tombstones.
+Preserve the database before a rebuild if that state matters, and do not assume
+it can be reconstructed from transcripts.
+
+## API visibility
+
+Default lists, full-text search, command-palette search, statistics, tools,
+files, and economics exclude user-hidden sessions. Statistics operations that
+accept `include_archived=true` add archived sessions back; deleted sessions and
+their content remain absent.
+
+See [Local Serve API](api/routes.md#response-and-archive-semantics) for the
+wire behavior and [How Decant analytics work](analytics-methodology.md) for the
+effect on analytical denominators.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -48,6 +48,27 @@ Build all release artifacts:
 bun run scripts/build-npm.ts --target all --clean --version 0.1.0
 ```
 
+### Standalone worker entrypoints
+
+Bun does not infer modules passed to `new Worker(...)` when compiling a
+standalone executable. Every runtime worker must therefore be an explicit
+entrypoint in `buildTargetArgs()` alongside `src/cli.ts`. Decant currently
+embeds `src/sync-worker.ts` and `src/stats-worker.ts`.
+
+A missing worker can pass `decant --help` and other shallow binary checks, then
+fail only when the runtime tries to sync or calculate token economics. When a
+worker is added or renamed, update all three parts of the distribution
+contract:
+
+1. the entrypoint list in `scripts/distribution.ts`;
+2. the exact argument assertion in `test/distribution.test.ts`;
+3. the native staging smoke in `scripts/dist-check.ts`, exercising meaningful
+   worker-backed output rather than only process startup.
+
+`just check` builds the native binary, runs `POST /api/sync`, waits for
+`/api/analytics/token-economics` to return populated totals, then packs and
+installs the launcher and platform packages.
+
 Release builds stamp the same version into package metadata and the compiled
 binary. The release workflow publishes all platform packages first, then the
 launcher, so `optionalDependencies` always point at packages that already


### PR DESCRIPTION
## Summary

Add public, source-backed guides for Decant analytics interpretation, architecture, API recipes, and data lifecycle. Extend the existing distribution guide with standalone worker-entrypoint checks and link the new guides from the repo navigation.

The approved K1, K2, K3, K4, and K6 items are included. K5, the separate troubleshooting note, is intentionally excluded.

## Why

The Decant public knowledge library monitors this repository, so durable product guidance should live beside the code and API contract. These guides make the most reusable session-analysis methods and implementation invariants retrievable without creating duplicate native knowledge pages.

## Validation

- [x] `just check` passes (`bun test`, `bunx tsc --noEmit`, `bunx biome check .`, distribution staging smoke).
- [x] Focused API, distribution, stats, economics, and session-state tests pass. No existing test was weakened or deleted.

## Archive schema

The baseline is `LATEST_SCHEMA_VERSION` in `src/db.ts`. Check one:

- [x] This change does not touch the archive schema.
- [ ] This change bumps the schema. It ships the migration, and the summary above says what happens to archives created before it.
