### PR TITLE
feat(agents): add pr-review skill for house-style PR reviews

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: pr-review
+description: Review a pull request in the decant house style and post it with gh. Use when asked to review, audit, or leave review comments on a decant PR, when drafting review feedback on another contributor's changes, or when posting review text under a maintainer's name.
+---
+
+# Reviewing a pull request
+
+The canonical workflow is `docs/prompts/review-pr.md` — read it and work
+through it top to bottom. It owns the voice rules, the severity callouts, the
+verification bar, suggestion-block mechanics, and the posting steps. The
+voice rules are hard requirements for posted text, not decoration.
+
+Anchors while you work:
+
+- Verify every finding against the PR head, not local `main`, and reproduce
+  bugs on a scratch archive (`--db` to a scratch path plus `--no-sync` on
+  reads), never the real one.
+- Every comment leads with a native callout tier. CAUTION Critical blocks
+  the merge, WARNING High rides with the blocking fix, IMPORTANT Medium
+  should land, NOTE Low is optional, and TIP is the single 🎉 Kudos each
+  review should carry when the code earns it.
+- Posted prose uses no em dashes, colons, or semicolons. Thank the author by
+  @handle, never approve unless explicitly told to, and never add an AI
+  attribution footer to review text.
+- Mechanical fixes ship as one-click suggestion blocks built from the head
+  files so indentation is exact, and heads move mid-review here, so re-check
+  `headRefOid` right before posting.
+
+## Gate
+
+A review changes no code, so the gate is on what you post. Every suggestion
+block must leave `bun test`, `bunx tsc --noEmit`, and `bunx biome check .`
+green if applied, and every claim must have survived verification on the PR
+head.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -5,12 +5,12 @@ description: Review a pull request in the decant house style and post it with gh
 
 # Reviewing a pull request
 
-The canonical workflow is `docs/prompts/review-pr.md` — read it and work
+The canonical workflow is `docs/prompts/review-pr.md`. Read it and work
 through it top to bottom. It owns the voice rules, the severity callouts, the
 verification bar, suggestion-block mechanics, and the posting steps. The
 voice rules are hard requirements for posted text, not decoration.
 
-Anchors while you work:
+Keep these anchors in mind while you work.
 
 - Verify every finding against the PR head, not local `main`, and reproduce
   bugs on a scratch archive (`--db` to a scratch path plus `--no-sync` on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ go wrong or drift, `new-source-parser` for invariant 6, `new-migration` for
 invariant 5, and `pr-review` for the house pull-request review style.
 The `new-source-parser` skill stays thin and defers to
 `docs/prompts/add-source.md`, the canonical add-a-source workflow that
-`CONTRIBUTING.md` also points at; `pr-review` defers the same way to
-`docs/prompts/review-pr.md` (voice, severity callouts, verification bar, and
-posting mechanics).
+`CONTRIBUTING.md` also points at. The `pr-review` skill defers the same way
+to `docs/prompts/review-pr.md` (voice, severity callouts, verification bar,
+and posting mechanics).
 `scripts/claude-hooks/reflect-on-stop.sh` is a Stop hook, wired in
 `.claude/settings.json`, that nudges toward recording durable findings when a
 session changed several files and wrote none down. It is offline, bash and jq

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,11 +28,14 @@ point). Docs: `docs/architecture.md` (module and data flow),
 `docs/distribution.md` (npm/installer/Docker/source), and `docs/releasing.md`
 (release operations).
 
-Agent tooling lives in `.claude/`. Two skills cover the work most likely to go
-wrong, `new-source-parser` for invariant 6 and `new-migration` for invariant 5.
+Agent tooling lives in `.claude/`. Three skills cover the work most likely to
+go wrong or drift, `new-source-parser` for invariant 6, `new-migration` for
+invariant 5, and `pr-review` for the house pull-request review style.
 The `new-source-parser` skill stays thin and defers to
 `docs/prompts/add-source.md`, the canonical add-a-source workflow that
-`CONTRIBUTING.md` also points at.
+`CONTRIBUTING.md` also points at; `pr-review` defers the same way to
+`docs/prompts/review-pr.md` (voice, severity callouts, verification bar, and
+posting mechanics).
 `scripts/claude-hooks/reflect-on-stop.sh` is a Stop hook, wired in
 `.claude/settings.json`, that nudges toward recording durable findings when a
 session changed several files and wrote none down. It is offline, bash and jq

--- a/docs/prompts/review-pr.md
+++ b/docs/prompts/review-pr.md
@@ -1,4 +1,4 @@
-# Review a pull request: the decant house style
+# Review a pull request in the decant house style
 
 You are reviewing a decant pull request and posting the review under a
 maintainer's name. Work through this document top to bottom. The voice rules
@@ -59,8 +59,8 @@ and give it the Kudos treatment. One is the right dose. Several is noise.
   semantics you are leaning on.
 - Reproduce bugs empirically when feasible and include the repro in the
   comment. For decant that means a scratch archive. Point `--db` at a
-  scratch path and pass `--no-sync` on reads, or sync-on-read and the serve
-  watcher will fill the scratch archive from the real `~/.claude` and
+  scratch path and pass `--no-sync` on reads. Otherwise sync-on-read and the
+  serve watcher will fill the scratch archive from the real `~/.claude` and
   `~/.codex`.
 - Check the diff against the project invariants and the definition of done
   in `AGENTS.md`. Watch especially for edits to committed migrations

--- a/docs/prompts/review-pr.md
+++ b/docs/prompts/review-pr.md
@@ -1,0 +1,105 @@
+# Review a pull request: the decant house style
+
+You are reviewing a decant pull request and posting the review under a
+maintainer's name. Work through this document top to bottom. The voice rules
+are part of the contract, not decoration.
+
+## Voice (hard requirements for posted text)
+
+- No em dashes, colons, or semicolons in prose. Code spans, code blocks,
+  suggestion blocks, and URLs are exempt. In prose, reference code as
+  "line 221 of `src/cli.ts`", never `src/cli.ts:221`.
+- Warm, direct, short sentences. When a change gets something right, say so
+  before the problem. Then the problem, then the fix.
+- Open the review summary by thanking the author with their GitHub handle
+  (`Thanks @handle,`) and close it inviting pushback.
+- Never approve unless the maintainer explicitly said to approve. Request
+  changes only when at least one finding is genuinely blocking. Otherwise
+  post a comment review.
+- Never append an AI attribution footer to review text. Commits and PR
+  bodies keep the repo's Co-Authored-By convention. Reviews do not.
+
+## Severity tiers
+
+Every comment leads with a GitHub-native alert callout. Copilot-style
+severity chips are integration-private metadata no public API can set, so
+callouts are the closest thing a human account can post, and they render
+theme-aware with no external images. The tier word is bold, and a middle dot
+(`·`) separates it from a short finding-specific phrase.
+
+| Callout          | Tier          | Use for                                          |
+| ---------------- | ------------- | ------------------------------------------------ |
+| `> [!CAUTION]`   | `**Critical**`| merge-blocking, the reason to request changes    |
+| `> [!WARNING]`   | `**High**`    | should land together with the blocking fix       |
+| `> [!IMPORTANT]` | `**Medium**`  | should fix, small and real                       |
+| `> [!NOTE]`      | `**Low**`     | nice to have, optional hardening                 |
+| `> [!TIP]`       | `🎉 **Kudos**`| the one genuine shoutout each review carries     |
+
+The first two lines of a finding look like
+
+```markdown
+> [!CAUTION]
+> **Critical** · blocking, one line fix
+```
+
+and the Kudos line is always
+
+```markdown
+> [!TIP]
+> 🎉 **Kudos** · much appreciated
+```
+
+A review should not be all nits. Find one thing genuinely worth a shoutout
+and give it the Kudos treatment. One is the right dose. Several is noise.
+
+## Verify before you post
+
+- Every finding must survive verification against the PR head, not local
+  `main`. Read the surrounding code, and cite the test or doc that pins the
+  semantics you are leaning on.
+- Reproduce bugs empirically when feasible and include the repro in the
+  comment. For decant that means a scratch archive. Point `--db` at a
+  scratch path and pass `--no-sync` on reads, or sync-on-read and the serve
+  watcher will fill the scratch archive from the real `~/.claude` and
+  `~/.codex`.
+- Check the diff against the project invariants and the definition of done
+  in `AGENTS.md`. Watch especially for edits to committed migrations
+  (invariant 5) and for tests weakened to make a change pass.
+
+## Suggestion blocks
+
+- Every mechanical fix ships as a one-click suggestion block.
+- Build replacement lines from the head files (fetch at the head SHA, then
+  transform with sed) so indentation matches the file exactly.
+- A suggestion must leave the repo green if applied on its own. When a fix
+  needs a companion change, say so in the comment.
+- Suggestions can only anchor to lines that appear in the diff. A fix that
+  lives outside the diff gets a plain code block and a sentence noting there
+  is no apply button.
+
+## Posting mechanics
+
+1. Gather context with `gh pr view <url> --json ...` and `gh pr diff <url>`.
+2. Re-read `headRefOid` immediately before posting. Heads move mid-review
+   here (bots push to decant PR branches, and maintainers merge main), so if
+   it moved, re-verify every path and line anchor against the head files.
+3. Write each comment body to its own markdown file, assemble with
+   `jq -n --rawfile` so nothing needs hand-escaping, and post one review
+
+   ```sh
+   gh api repos/dosu-ai/decant/pulls/<n>/reviews --input review.json
+   ```
+
+   with `commit_id` set to the head SHA, `event` set to `REQUEST_CHANGES` or
+   `COMMENT`, and `comments[]` entries of `{path, line, side, body}` plus
+   `start_line` and `start_side` for multi-line anchors.
+4. Iterate in place. `PATCH /pulls/comments/<id>` edits one comment and
+   `PUT /pulls/<n>/reviews/<id>` edits the summary body. Do not post a
+   second review to fix the first.
+
+## Summary body shape
+
+- `Thanks @author,` plus one honest sentence on what the PR gets right.
+- What blocks and why, in one or two sentences.
+- Bullets for real findings that have no diff line to anchor to.
+- A warm close ("Happy to pair on any of these.").


### PR DESCRIPTION
## Summary
Codifies the PR review conventions settled while reviewing #96 into a third repo skill, following the same thin-pointer pattern as `new-source-parser`.

- **`.claude/skills/pr-review/SKILL.md`** — thin skill with the hard rules inline, defers to the canonical prompt.
- **`docs/prompts/review-pr.md`** — the canonical workflow. Voice rules for posted prose (no em dashes, colons, or semicolons; thank the author by @handle; no AI attribution footers; never approve unless told), the native alert-callout severity tiers (`[!CAUTION]` Critical through `[!NOTE]` Low, plus exactly one `[!TIP]` 🎉 Kudos per review), the verify-before-you-post bar (verify on the PR head, reproduce on a scratch archive with `--db` + `--no-sync`), suggestion-block mechanics (build replacements from head files so indentation is exact), and gh posting steps including re-checking `headRefOid` right before anchoring since heads move mid-review on this repo.
- **`AGENTS.md`** — the agent-tooling paragraph now describes three skills instead of two.

Native callouts were chosen over Copilot-style severity chips because those chips are integration-private metadata no public API can set, and over hosted badge images because callouts are theme-aware with no external dependencies.

## Test plan
- [x] `bun test` (836/836)
- [x] `bunx tsc --noEmit`
- [x] `bunx biome check .`
- [x] Skill registers and is invocable in a live Claude Code session against this repo
- [x] Conventions exercised end to end on the #96 review (callout tiers, suggestion blocks, Kudos, summary shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)