### PR TITLE
feat(dist): add just release recipe for cutting release tags

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -74,9 +74,9 @@ Every release after the bootstrap:
    git push origin v0.2.0
    ```
 
-   `just release 0.2.0` wraps this: it checks you're on a clean, up-to-date
-   `main` and then runs the two commands above. It only saves the typing —
-   you still choose the version number, same as today.
+   `just release 0.2.0` wraps this by checking that you are on a clean and
+   up-to-date `main` branch before running the two commands above. It only
+   saves typing because you still choose the version number.
 
 3. Watch the release workflow's job graph:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -74,6 +74,10 @@ Every release after the bootstrap:
    git push origin v0.2.0
    ```
 
+   `just release 0.2.0` wraps this: it checks you're on a clean, up-to-date
+   `main` and then runs the two commands above. It only saves the typing —
+   you still choose the version number, same as today.
+
 3. Watch the release workflow's job graph:
 
    ```

--- a/justfile
+++ b/justfile
@@ -55,6 +55,19 @@ docker-build *ARGS:
 docker-buildx *ARGS:
     docker buildx build --platform linux/amd64,linux/arm64 --output=type=cacheonly {{ARGS}} .
 
+# Cut and push a signed release tag (see docs/releasing.md). VERSION is semver, no leading "v".
+[group('dist')]
+release VERSION:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    [ -z "$(git status --porcelain)" ] || { echo "working tree is dirty"; exit 1; }
+    branch="$(git rev-parse --abbrev-ref HEAD)"
+    [ "$branch" = "main" ] || { echo "release from main, not $branch"; exit 1; }
+    git fetch origin main
+    [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ] || { echo "main is not up to date with origin/main"; exit 1; }
+    git tag -s "v{{VERSION}}" -m "v{{VERSION}}"
+    git push origin "v{{VERSION}}"
+
 # CLI
 [group('cli')]
 sync *ARGS:


### PR DESCRIPTION
## Summary
- Adds `just release VERSION`, wrapping the manual tag-and-push steps in `docs/releasing.md` into one command, gated on a clean, up-to-date `main`.
- Documents the shortcut inline in `docs/releasing.md` next to the manual commands it wraps.

Still a deliberate, human-triggered step before the build/sign/publish pipeline runs — this only removes the typing, not the checkpoint.

## Test plan
- [ ] `just release 0.2.0` run from a clean `main` correctly tags and pushes
- [ ] Recipe fails closed on a dirty tree
- [ ] Recipe fails closed when not on `main`
- [ ] Recipe fails closed when `main` is behind `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)