### PR TITLE
feat(ui): restyle the UI to the Dosu x Venice design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@
 # has been committed here before.
 node_modules
 /dist/
+# `bun build --compile` leaves one of these behind in the repo root when a
+# compile fails, which is exactly when someone is most likely to `git add -A`.
+*.bun-build

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ both formats into one WAL + FTS5 SQLite archive, and gives you full-text search,
 token economics, context-window occupancy, and phase breakdowns from a CLI or a
 local web UI. Your transcripts never leave your machine.
 
-![The current Decant Analytics UI showing the command palette, report and share
-controls, session and token totals, activity economics, and daily charts.
-Rendered from the repository's synthetic fixtures.](docs/assets/decant-serve.png)
+![The Decant Analytics UI showing the command palette, report and share controls,
+session and token totals, activity economics, and daily charts. Rendered from
+the repository's synthetic fixtures. (UI restyled to the Dosu x Venice design
+as of 2026-08, PR #99: warm cream/near-black palette, Source Serif 4 display,
+IBM Plex Mono labels, pill-shaped buttons, lime/pink chart accents.)](docs/assets/decant-serve.png)
 
 ## Features
 

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -5221,7 +5221,12 @@ function buildChartOption({
   const moneyMetric = metric === "money";
   const seriesType = variant;
   return {
-    color: [colors.accent, colors.info, colors.success, colors.warning],
+    // Bars lead lime and lines lead pink, as the design draws them. The rest of
+    // each palette is the fallback order for any additional series.
+    color:
+      seriesType === "bar"
+        ? [colors.success, colors.info, colors.warning, colors.accent]
+        : [colors.accent, colors.info, colors.success, colors.warning],
     textStyle: { fontFamily: "inherit", color: colors.muted },
     animationDuration: 180,
     grid: { left: 6, right: 16, top: 18, bottom: 6, containLabel: true },

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -5878,6 +5878,13 @@ function DateRangeControl({
             <Icon name="chevronLeft" />
           </button>
         ) : null}
+        <button
+          aria-pressed={range.preset === "all"}
+          onClick={() => onChange(ALL_DATE_RANGE)}
+          type="button"
+        >
+          All time
+        </button>
         {RANGE_PRESETS.map((preset) => (
           <button
             aria-pressed={range.preset === preset.key}
@@ -5888,13 +5895,6 @@ function DateRangeControl({
             {preset.label}
           </button>
         ))}
-        <button
-          aria-pressed={range.preset === "all"}
-          onClick={() => onChange(ALL_DATE_RANGE)}
-          type="button"
-        >
-          All
-        </button>
         {range.from != null && range.to != null ? (
           <button
             aria-label="Next period"

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -1,4 +1,8 @@
-import * as echarts from "echarts";
+// Type-only, so this erases at build time. ECharts is ~1.1MB minified and is
+// reachable from exactly two call sites, both of which import() it on demand:
+// eagerly importing it here put the whole library on every route, including
+// /settings and /search, which never draw a chart.
+import type { ECharts as EChartsInstance, EChartsOption } from "echarts";
 import type { LucideIcon } from "lucide-react";
 import {
   Archive,
@@ -5023,6 +5027,7 @@ async function renderShareCardPng(
   chartNode.style.cssText =
     "position:fixed;left:-10000px;top:-10000px;width:1080px;height:310px;pointer-events:none";
   document.body.append(chartNode);
+  const echarts = await import("echarts");
   const chart = echarts.init(chartNode, null, {
     renderer: "canvas",
     width: 1080,
@@ -5150,7 +5155,7 @@ function AnalyticsChart({
   variant: AnalyticsChartVariant;
 }) {
   const chartRef = useRef<HTMLDivElement | null>(null);
-  const chartInstanceRef = useRef<echarts.ECharts | null>(null);
+  const chartInstanceRef = useRef<EChartsInstance | null>(null);
   const lastDrawnKeyRef = useRef<string | null>(null);
   const chartState = prepareAnalyticsChartState({ labels, metric, values, variant });
   const chartStateRef = useRef<AnalyticsChartState>(chartState);
@@ -5161,34 +5166,48 @@ function AnalyticsChart({
     if (element == null) {
       return;
     }
-    const chart = echarts.init(element, null, { renderer: "canvas" });
-    chartInstanceRef.current = chart;
-    const media = window.matchMedia("(prefers-color-scheme: dark)");
-    const draw = (force = false) => {
-      const current = chartStateRef.current;
-      if (!force && lastDrawnKeyRef.current === current.key) {
+    let cancelled = false;
+    let disposeChart: (() => void) | null = null;
+    void (async () => {
+      const echarts = await import("echarts");
+      if (cancelled) {
         return;
       }
-      chart.setOption(buildChartOption(current), true);
-      lastDrawnKeyRef.current = current.key;
-      chart.resize();
-    };
-    const resize = () => chart.resize();
-    const observer = new ResizeObserver(resize);
-    observer.observe(element);
-    window.addEventListener("resize", resize);
-    const redrawForTheme = () => draw(true);
-    window.addEventListener("decant:set-theme", redrawForTheme);
-    media.addEventListener("change", redrawForTheme);
-    draw();
+      const chart = echarts.init(element, null, { renderer: "canvas" });
+      chartInstanceRef.current = chart;
+      const media = window.matchMedia("(prefers-color-scheme: dark)");
+      const draw = (force = false) => {
+        const current = chartStateRef.current;
+        if (!force && lastDrawnKeyRef.current === current.key) {
+          return;
+        }
+        chart.setOption(buildChartOption(current), true);
+        lastDrawnKeyRef.current = current.key;
+        chart.resize();
+      };
+      const resize = () => chart.resize();
+      const observer = new ResizeObserver(resize);
+      observer.observe(element);
+      window.addEventListener("resize", resize);
+      const redrawForTheme = () => draw(true);
+      window.addEventListener("decant:set-theme", redrawForTheme);
+      media.addEventListener("change", redrawForTheme);
+      // Draws whatever chartStateRef holds now, so a state change that arrived
+      // while the import was in flight is not lost.
+      draw();
+      disposeChart = () => {
+        observer.disconnect();
+        window.removeEventListener("resize", resize);
+        window.removeEventListener("decant:set-theme", redrawForTheme);
+        media.removeEventListener("change", redrawForTheme);
+        chart.dispose();
+        chartInstanceRef.current = null;
+        lastDrawnKeyRef.current = null;
+      };
+    })();
     return () => {
-      observer.disconnect();
-      window.removeEventListener("resize", resize);
-      window.removeEventListener("decant:set-theme", redrawForTheme);
-      media.removeEventListener("change", redrawForTheme);
-      chart.dispose();
-      chartInstanceRef.current = null;
-      lastDrawnKeyRef.current = null;
+      cancelled = true;
+      disposeChart?.();
     };
   }, []);
 
@@ -5216,7 +5235,7 @@ function buildChartOption({
   metric: AnalyticsChartMetric;
   values: number[];
   variant: AnalyticsChartVariant;
-}): echarts.EChartsOption {
+}): EChartsOption {
   const colors = chartColors();
   const moneyMetric = metric === "money";
   const seriesType = variant;

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -5925,7 +5925,10 @@ function DateRangeControl({
           </button>
         ) : null}
       </div>
-      <span>{dateRangeLabel(range)}</span>
+      {/* The label spells out a custom range ("Jun 3 to Jun 17"). For "all" it
+       * returns "All time", which is now exactly what the selected button reads,
+       * so showing it twice just looks like a bug. */}
+      {range.preset === "all" ? null : <span>{dateRangeLabel(range)}</span>}
     </div>
   );
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -128,7 +128,6 @@
     0 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 -2px 0 #52525b,
     inset 0 -1px 0 #27272a;
   --shadow-button-light: inset 0 1px 0 rgba(255, 255, 255, 0.48);
-  --radius-md: 8px;
   --radius-lg: 10px;
   --radius-xl: 14px;
   --radius-full: 9999px;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1,3 +1,31 @@
+/* ===========================================================================
+ * Fonts
+ *
+ * Served same-origin by decant itself (see `fontAsset` in src/server.ts), never
+ * fetched from a CDN — invariant 3 keeps this app offline. The same woff2 files
+ * back the exported report, which inlines them as data URIs instead because a
+ * report has to survive as one self-contained file (src/report/fonts.ts).
+ *
+ * Only the Semibold serif is bundled, so it is declared at the weight it
+ * actually is. Declaring it as 400 would make browsers synthesize a bold on top
+ * of an already-semibold face.
+ * =========================================================================== */
+@font-face {
+  font-family: "Source Serif 4";
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url("../report/fonts/SourceSerif4-Semibold.woff2") format("woff2");
+}
+
+@font-face {
+  font-family: "IBM Plex Mono";
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("../report/fonts/IBMPlexMono-Regular-Latin1.woff2") format("woff2");
+}
+
 :root {
   color-scheme: dark;
   --canvas: #0b0e14;
@@ -20,6 +48,8 @@
   --info: #60a5fa;
   --radius-lg: 10px;
   --radius-xl: 14px;
+  --font-serif: "Source Serif 4", ui-serif, Georgia, Cambria, "Times New Roman", serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
@@ -409,7 +439,7 @@ nav a[aria-current="page"] svg {
   border: 1px solid var(--line);
   border-radius: 4px;
   color: var(--faint);
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 10px;
   padding: 1px 6px;
 }
@@ -583,7 +613,7 @@ nav a[aria-current="page"] svg {
   border-radius: 4px;
   background: var(--canvas);
   color: var(--faint);
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 10px;
   padding: 1px 5px;
 }
@@ -1782,7 +1812,7 @@ td a:hover {
 }
 
 .mono {
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
 }
 
@@ -1986,7 +2016,7 @@ select {
 }
 
 .badge.is-mono {
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
 }
 
 .badge svg {
@@ -3786,7 +3816,7 @@ mark {
   max-width: 18rem;
   overflow: hidden;
   color: var(--muted);
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -4218,7 +4248,7 @@ mark {
   border: 1px solid var(--line);
   border-radius: 4px;
   background: var(--elevated);
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 0.9em;
   padding: 1px 4px;
 }
@@ -4254,7 +4284,7 @@ mark {
 }
 
 .transcript-code-content {
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1.5;
 }
@@ -4354,7 +4384,7 @@ mark {
 
 .tool-call-header .tool-call-name {
   overflow: hidden;
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -4407,7 +4437,7 @@ mark {
   min-width: 0;
   overflow: hidden;
   color: var(--muted);
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -4429,7 +4459,7 @@ mark {
   border: 1px solid var(--line);
   border-radius: 7px;
   background: var(--canvas);
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
 }
 
@@ -4592,7 +4622,7 @@ mark {
   border: 1px solid var(--line);
   border-radius: 5px;
   color: var(--faint);
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   overflow-wrap: anywhere;
   padding: 2px 6px;
@@ -4790,7 +4820,7 @@ pre {
   max-width: 100%;
   margin: 8px 0 0;
   color: var(--muted);
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1.5;
   white-space: pre-wrap;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -86,6 +86,27 @@
   --dosu: #b4bb91;
   --dosu-mid: #899364;
   --dosu-strong: #65704b;
+  /* Text-safe counterparts to the fills above, for `color:` on a page surface.
+   * The design's accents are fill-grade — as text on cream they land at 2.1–3.8:1
+   * and miss WCAG AA, so each is pulled toward --fg by the smallest amount that
+   * clears 4.5:1 against the worst surface in BOTH themes. Mixing toward --fg
+   * rather than hardcoding a second palette is what lets one definition serve
+   * light and dark: it darkens on cream and lightens on near-black.
+   *
+   * Measured worst-case ratios (light / dark): accent 4.70/9.83, success
+   * 4.53/12.28, warning 4.56/9.16, danger 4.55/6.93, info 4.69/10.19, claude
+   * 4.59/7.86. Lower a percentage and you drop below AA.
+   *
+   * There is deliberately no --dosu-text: the sage tokens only ever appear inside
+   * color-mix() for borders and shadows, never as `color:`.
+   *
+   * Safe to color-mix here because nothing hands these to ECharts. */
+  --accent-text: color-mix(in oklab, var(--accent) 60%, var(--fg));
+  --success-text: color-mix(in oklab, var(--success) 65%, var(--fg));
+  --warning-text: color-mix(in oklab, var(--warning) 70%, var(--fg));
+  --danger-text: color-mix(in oklab, var(--danger) 85%, var(--fg));
+  --info-text: color-mix(in oklab, var(--info) 60%, var(--fg));
+  --claude-text: color-mix(in oklab, var(--claude) 65%, var(--fg));
   /* The design's primary button is near-black, not brand pink. Inverted in dark
    * so it stays a button rather than a hole in the page. */
   --btn-ink: #09090b;
@@ -379,7 +400,7 @@ nav a[aria-current="page"] {
 }
 
 nav a[aria-current="page"] svg {
-  color: var(--accent);
+  color: var(--accent-text);
   opacity: 1;
 }
 
@@ -716,7 +737,7 @@ nav a[aria-current="page"] svg {
 }
 
 .command-palette-state.is-error {
-  color: var(--danger);
+  color: var(--danger-text);
 }
 
 .command-palette-footer {
@@ -1050,7 +1071,7 @@ nav a[aria-current="page"] svg {
   height: 52px;
   border-radius: 14px;
   background: color-mix(in oklab, var(--accent) 12%, transparent);
-  color: var(--accent);
+  color: var(--accent-text);
 }
 
 .first-run-icon svg {
@@ -1187,7 +1208,7 @@ table {
 }
 
 .clickable-row a:hover {
-  color: var(--accent);
+  color: var(--accent-text);
 }
 
 .drilldown-row {
@@ -1200,7 +1221,7 @@ table {
 }
 
 .drilldown-row:hover .drilldown-label {
-  color: var(--accent);
+  color: var(--accent-text);
 }
 
 .drilldown-row:focus-visible {
@@ -1241,7 +1262,7 @@ table {
 
 .tool-error-toggle input {
   min-height: auto;
-  accent-color: var(--accent);
+  accent-color: var(--accent-text);
 }
 
 .tool-calls-heading > span {
@@ -1280,7 +1301,7 @@ table {
 
 .tool-call-detail-button:hover,
 .tool-call-detail-button:focus-visible {
-  color: var(--accent);
+  color: var(--accent-text);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
@@ -1648,7 +1669,7 @@ td a {
 }
 
 td a:hover {
-  color: var(--accent);
+  color: var(--accent-text);
 }
 
 .numeric {
@@ -1848,7 +1869,7 @@ td a:hover {
 .subagent-source svg {
   width: 14px;
   height: 14px;
-  color: var(--accent);
+  color: var(--accent-text);
 }
 
 .path-stack,
@@ -1966,7 +1987,7 @@ select {
   height: 14px;
   min-height: 0;
   margin: 0;
-  accent-color: var(--accent);
+  accent-color: var(--accent-text);
   padding: 0;
 }
 
@@ -2132,27 +2153,27 @@ select {
 }
 
 .tone-accent {
-  color: var(--accent);
+  color: var(--accent-text);
 }
 
 .tone-success {
-  color: var(--success);
+  color: var(--success-text);
 }
 
 .tone-warning {
-  color: var(--warning);
+  color: var(--warning-text);
 }
 
 .tone-danger {
-  color: var(--danger);
+  color: var(--danger-text);
 }
 
 .tone-info {
-  color: var(--info);
+  color: var(--info-text);
 }
 
 .tone-claude {
-  color: var(--claude);
+  color: var(--claude-text);
 }
 
 .tone-openai {
@@ -2215,7 +2236,7 @@ select {
 .notice.danger {
   border-color: color-mix(in oklab, var(--danger) 35%, var(--line));
   background: color-mix(in oklab, var(--danger) 10%, transparent);
-  color: var(--danger);
+  color: var(--danger-text);
 }
 
 .slice-load-notice {
@@ -2509,7 +2530,7 @@ mark {
   place-items: center;
   border-radius: 8px;
   background: color-mix(in oklab, var(--danger) 12%, transparent);
-  color: var(--danger);
+  color: var(--danger-text);
 }
 
 .error-state h3 {
@@ -2543,7 +2564,7 @@ mark {
   display: block;
   width: 100%;
   height: 16rem;
-  color: var(--accent);
+  color: var(--accent-text);
 }
 
 .chart-share-button {
@@ -3016,11 +3037,11 @@ mark {
 .sparkline {
   width: 112px;
   height: 24px;
-  color: var(--accent);
+  color: var(--accent-text);
 }
 
 .sparkline.tone-claude {
-  color: var(--claude);
+  color: var(--claude-text);
 }
 
 .sparkline.tone-openai {
@@ -3097,7 +3118,7 @@ mark {
 
 .segmented-control button[aria-pressed="true"] {
   background: color-mix(in oklab, var(--accent) 12%, transparent);
-  color: var(--accent);
+  color: var(--accent-text);
   font-weight: 650;
 }
 
@@ -3113,7 +3134,7 @@ mark {
 
 .page-eyebrow,
 .section-eyebrow {
-  color: var(--accent);
+  color: var(--accent-text);
   font-size: 11px;
   font-weight: 720;
   letter-spacing: 0.06em;
@@ -3241,23 +3262,23 @@ mark {
 }
 
 .signal-hero.tone-accent {
-  border-left-color: var(--accent);
+  border-left-color: var(--accent-text);
 }
 
 .signal-hero.tone-success {
-  border-left-color: var(--success);
+  border-left-color: var(--success-text);
 }
 
 .signal-hero.tone-warning {
-  border-left-color: var(--warning);
+  border-left-color: var(--warning-text);
 }
 
 .signal-hero.tone-danger {
-  border-left-color: var(--danger);
+  border-left-color: var(--danger-text);
 }
 
 .signal-hero.tone-info {
-  border-left-color: var(--info);
+  border-left-color: var(--info-text);
 }
 
 .signal-hero.tone-neutral {
@@ -3362,11 +3383,11 @@ mark {
 }
 
 .ingest-issue-row.is-warning {
-  border-left-color: var(--warning);
+  border-left-color: var(--warning-text);
 }
 
 .ingest-issue-row.is-informational {
-  border-left-color: var(--info);
+  border-left-color: var(--info-text);
 }
 
 .signal-row-summary {
@@ -3397,7 +3418,7 @@ mark {
 }
 
 .signal-row-title:hover {
-  color: var(--accent);
+  color: var(--accent-text);
 }
 
 .signal-row-rationale {
@@ -3577,7 +3598,7 @@ mark {
 }
 
 .overflow-menu-popover :where(a, button).is-danger {
-  color: var(--danger);
+  color: var(--danger-text);
 }
 
 .overflow-menu-popover button svg {
@@ -4104,7 +4125,7 @@ mark {
 
 .toc a.is-loading {
   background: color-mix(in oklab, var(--accent) 9%, transparent);
-  color: var(--accent);
+  color: var(--accent-text);
 }
 
 .toc a.is-current {
@@ -4175,7 +4196,7 @@ mark {
 
 .toc a:hover .toc-icon {
   background: color-mix(in oklab, var(--accent) 10%, transparent);
-  color: var(--accent);
+  color: var(--accent-text);
 }
 
 .toc a > span:nth-child(2) {
@@ -4328,7 +4349,7 @@ mark {
 }
 
 .transcript-markdown a {
-  color: var(--accent);
+  color: var(--accent-text);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
@@ -4402,7 +4423,7 @@ mark {
   place-items: center;
   border-radius: 8px;
   background: color-mix(in oklab, var(--info) 12%, var(--surface));
-  color: var(--info);
+  color: var(--info-text);
 }
 
 .transcript-attachment-icon svg {
@@ -4650,7 +4671,7 @@ mark {
   place-items: center;
   border-radius: 7px;
   background: color-mix(in oklab, var(--accent) 14%, transparent);
-  color: var(--accent);
+  color: var(--accent-text);
 }
 
 .special-icon svg {
@@ -4667,7 +4688,7 @@ mark {
 .special-block.is-realtime-ended .special-icon,
 .special-block.is-realtime-handoff .special-icon {
   background: color-mix(in oklab, var(--info) 14%, transparent);
-  color: var(--info);
+  color: var(--info-text);
 }
 
 .special-block.is-collaboration,
@@ -4790,7 +4811,7 @@ mark {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: var(--accent);
+  color: var(--accent-text);
   font-size: 12px;
   font-weight: 650;
 }
@@ -4871,7 +4892,7 @@ mark {
 }
 
 .transcript-window-start-error {
-  color: var(--danger);
+  color: var(--danger-text);
   min-width: 0;
 }
 
@@ -5480,7 +5501,7 @@ a:focus-visible .ctx-strip-compaction-marker rect {
   margin-top: 7px;
   border-radius: 5px;
   background: color-mix(in oklab, var(--warning) 13%, transparent);
-  color: var(--warning);
+  color: var(--warning-text);
   font-size: 11px;
   line-height: 1.35;
   padding: 5px 7px;
@@ -5518,7 +5539,7 @@ a:focus-visible .ctx-strip-compaction-marker rect {
 }
 
 .ctx-chip.is-hot {
-  color: var(--warning);
+  color: var(--warning-text);
 }
 
 .ctx-chip.is-hot .ctx-chip-bar i {
@@ -5575,15 +5596,15 @@ a:focus-visible .ctx-strip-compaction-marker rect {
 }
 
 .session-context-peak {
-  color: var(--info);
+  color: var(--info-text);
   font-variant-numeric: tabular-nums;
   font-weight: 600;
 }
 
 .session-context-peak.is-warm {
-  color: var(--warning);
+  color: var(--warning-text);
 }
 
 .session-context-peak.is-hot {
-  color: var(--danger);
+  color: var(--danger-text);
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -124,7 +124,6 @@
     0 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 -2px 0 #52525b,
     inset 0 -1px 0 #27272a;
   --shadow-button-light: inset 0 1px 0 rgba(255, 255, 255, 0.48);
-  --shadow-card: 0 1px 2px rgba(var(--shade-rgb), 0.05);
   --radius-md: 8px;
   --radius-lg: 10px;
   --radius-xl: 14px;
@@ -169,7 +168,6 @@
       0 1px 2px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(0, 0, 0, 0.5),
       inset 0 -2px 0 rgba(0, 0, 0, 0.16), inset 0 1px 0 rgba(255, 255, 255, 0.55);
     --shadow-button-light: inset 0 1px 0 rgba(255, 255, 255, 0.06);
-    --shadow-card: 0 1px 2px rgba(var(--shade-rgb), 0.35);
   }
 }
 
@@ -199,7 +197,6 @@
     0 1px 2px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(0, 0, 0, 0.5), inset 0 -2px 0 rgba(0, 0, 0, 0.16),
     inset 0 1px 0 rgba(255, 255, 255, 0.55);
   --shadow-button-light: inset 0 1px 0 rgba(255, 255, 255, 0.06);
-  --shadow-card: 0 1px 2px rgba(var(--shade-rgb), 0.35);
 }
 
 /* Light is :root, so forcing light only has to stop the dark media block from
@@ -1737,7 +1734,9 @@ td a:hover {
 }
 
 .table-skeleton-line {
-  height: 16px;
+  /* Tracks the tallest real cell content (a badge) so the table does not jolt
+   * when loading finishes. Grew with the badge's new 1px border. */
+  height: 18px;
 }
 
 .table-skeleton-line.tool {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1,10 +1,14 @@
 /* ===========================================================================
  * Fonts
  *
- * Served same-origin by decant itself (see `fontAsset` in src/server.ts), never
- * fetched from a CDN — invariant 3 keeps this app offline. The same woff2 files
- * back the exported report, which inlines them as data URIs instead because a
- * report has to survive as one self-contained file (src/report/fonts.ts).
+ * Bundled from the repo, never fetched from a CDN — invariant 3 keeps this app
+ * offline. Bun resolves these url()s at build time and inlines the woff2 as data
+ * URIs, so the paths point at the files rather than at a route decant serves. A
+ * root-relative /fonts/… URL builds fine under `bun run dev` and then fails
+ * scripts/build-binaries.ts outright, so keep them relative.
+ *
+ * These are the same files the exported report uses (src/report/fonts.ts), which
+ * base64s them itself because a report has to survive as one standalone file.
  *
  * Only the Semibold serif is bundled, so it is declared at the weight it
  * actually is. Declaring it as 400 would make browsers synthesize a bold on top
@@ -162,8 +166,8 @@
     --btn-ink-fg: #17160f;
     --shade-rgb: 0, 0, 0;
     --shadow-button:
-      0 1px 2px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(0, 0, 0, 0.4),
-      inset 0 -2px 0 rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.16);
+      0 1px 2px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(0, 0, 0, 0.5),
+      inset 0 -2px 0 rgba(0, 0, 0, 0.16), inset 0 1px 0 rgba(255, 255, 255, 0.55);
     --shadow-button-light: inset 0 1px 0 rgba(255, 255, 255, 0.06);
     --shadow-card: 0 1px 2px rgba(var(--shade-rgb), 0.35);
   }
@@ -192,8 +196,8 @@
   --btn-ink-fg: #17160f;
   --shade-rgb: 0, 0, 0;
   --shadow-button:
-    0 1px 2px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(0, 0, 0, 0.4), inset 0 -2px 0 rgba(0, 0, 0, 0.12),
-    inset 0 1px 0 rgba(255, 255, 255, 0.16);
+    0 1px 2px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(0, 0, 0, 0.5), inset 0 -2px 0 rgba(0, 0, 0, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.55);
   --shadow-button-light: inset 0 1px 0 rgba(255, 255, 255, 0.06);
   --shadow-card: 0 1px 2px rgba(var(--shade-rgb), 0.35);
 }
@@ -204,6 +208,9 @@
   color-scheme: light;
 }
 
+/* ===========================================================================
+ * Reset and base elements
+ * =========================================================================== */
 * {
   box-sizing: border-box;
 }
@@ -268,6 +275,9 @@ svg {
   background: color-mix(in oklab, var(--accent) 35%, transparent);
 }
 
+/* ===========================================================================
+ * Shell: sidebar, topbar, workspace
+ * =========================================================================== */
 .app-shell {
   min-height: 100vh;
   background: var(--canvas);
@@ -558,6 +568,9 @@ nav a[aria-current="page"] svg {
   display: none;
 }
 
+/* ===========================================================================
+ * Command palette
+ * =========================================================================== */
 .command-palette-backdrop {
   position: fixed;
   inset: 0;
@@ -756,6 +769,9 @@ nav a[aria-current="page"] svg {
   gap: 4px;
 }
 
+/* ===========================================================================
+ * Controls: icon buttons, toggles, date range
+ * =========================================================================== */
 .icon-button {
   display: inline-grid;
   width: 34px;
@@ -875,6 +891,9 @@ nav a[aria-current="page"] svg {
   height: 14px;
 }
 
+/* ===========================================================================
+ * Content shell and page headings
+ * =========================================================================== */
 .content {
   flex: 1;
   min-width: 0;
@@ -1027,6 +1046,9 @@ nav a[aria-current="page"] svg {
   white-space: nowrap;
 }
 
+/* ===========================================================================
+ * Panels, cards and stat grids
+ * =========================================================================== */
 .panel,
 .signal-hero,
 .signal-list,
@@ -1190,6 +1212,9 @@ nav a[aria-current="page"] svg {
   color: var(--muted);
 }
 
+/* ===========================================================================
+ * Tables
+ * =========================================================================== */
 .table-scroll {
   overflow-x: auto;
 }
@@ -2035,6 +2060,9 @@ select {
   -webkit-appearance: none;
 }
 
+/* ===========================================================================
+ * Buttons
+ * =========================================================================== */
 .secondary-button {
   display: inline-flex;
   align-items: center;
@@ -2140,6 +2168,9 @@ select {
   }
 }
 
+/* ===========================================================================
+ * Badges and tones
+ * =========================================================================== */
 .badge {
   display: inline-flex;
   align-items: center;
@@ -2289,6 +2320,9 @@ select {
   width: min(100%, 42rem);
 }
 
+/* ===========================================================================
+ * Search
+ * =========================================================================== */
 .search-form {
   position: relative;
 }
@@ -3145,6 +3179,9 @@ mark {
   font-weight: 650;
 }
 
+/* ===========================================================================
+ * Insights and signals
+ * =========================================================================== */
 .insights-stack {
   gap: 36px;
 }
@@ -3739,6 +3776,9 @@ mark {
   padding-top: 16px;
 }
 
+/* ===========================================================================
+ * Settings
+ * =========================================================================== */
 .settings-form {
   display: grid;
   padding: 8px 0;
@@ -3846,6 +3886,9 @@ mark {
   padding-left: 12px;
 }
 
+/* ===========================================================================
+ * Session detail and transcript
+ * =========================================================================== */
 .session-detail {
   display: grid;
   width: 100%;
@@ -4978,6 +5021,9 @@ pre {
   word-break: break-word;
 }
 
+/* ===========================================================================
+ * Responsive. Breakpoint order is asserted by test/ui-responsive-styles.test.ts
+ * =========================================================================== */
 @media (max-width: 1200px) {
   .transcript-layout {
     grid-template-columns: 1fr;
@@ -5304,6 +5350,9 @@ pre {
   overflow: hidden;
 }
 
+/* ===========================================================================
+ * Context window strip
+ * =========================================================================== */
 .ctx-strip {
   display: block;
   /* The base stylesheet sizes every svg at 1em for icons. The intrinsic

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -73,7 +73,6 @@
   /* brand/400. Decorative and chart-facing — see --btn-ink for buttons. */
   --accent: #ee67d1;
   --accent-hover: #d94ab8;
-  --on-accent: #141414;
   --accent-soft: rgba(238, 103, 209, 0.12);
   --claude: #d97757;
   --claude-strong: #c6613f;
@@ -154,7 +153,6 @@
     --faint: rgba(244, 242, 232, 0.46);
     --accent: #f087dd;
     --accent-hover: #f5a5e6;
-    --on-accent: #17160f;
     --accent-soft: rgba(240, 135, 221, 0.16);
     --success: #a3e635;
     --warning: #fb923c;
@@ -185,7 +183,6 @@
   --faint: rgba(244, 242, 232, 0.46);
   --accent: #f087dd;
   --accent-hover: #f5a5e6;
-  --on-accent: #17160f;
   --accent-soft: rgba(240, 135, 221, 0.16);
   --success: #a3e635;
   --warning: #fb923c;
@@ -263,7 +260,7 @@ svg {
 }
 
 :focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--accent-text);
   outline-offset: 2px;
 }
 
@@ -521,8 +518,9 @@ nav a[aria-current="page"] svg {
   min-width: 220px;
   min-height: 34px;
   border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--surface);
+  border-radius: var(--radius-full);
+  background: var(--card);
+  box-shadow: var(--shadow-button-light);
   color: var(--faint);
   font: inherit;
   font-size: 14px;
@@ -763,8 +761,9 @@ nav a[aria-current="page"] svg {
   height: 34px;
   place-items: center;
   border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--surface);
+  border-radius: var(--radius-full);
+  background: var(--card);
+  box-shadow: var(--shadow-button-light);
   color: var(--muted);
   padding: 0;
   transition:
@@ -788,8 +787,8 @@ nav a[aria-current="page"] svg {
   display: flex;
   align-items: center;
   border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--surface);
+  border-radius: var(--radius-full);
+  background: var(--card);
   padding: 2px;
 }
 
@@ -835,8 +834,8 @@ nav a[aria-current="page"] svg {
   align-items: center;
   gap: 2px;
   border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--surface);
+  border-radius: var(--radius-full);
+  background: var(--card);
   padding: 2px;
 }
 
@@ -846,12 +845,12 @@ nav a[aria-current="page"] svg {
   height: 28px;
   place-items: center;
   border: 0;
-  border-radius: 6px;
+  border-radius: var(--radius-full);
   background: transparent;
   color: var(--muted);
   font-size: 13px;
   font-weight: 600;
-  padding: 0 8px;
+  padding: 0 10px;
 }
 
 .date-range-buttons button:hover {
@@ -860,8 +859,9 @@ nav a[aria-current="page"] svg {
 }
 
 .date-range-buttons button[aria-pressed="true"] {
-  background: var(--elevated);
-  color: var(--fg);
+  background: var(--btn-ink);
+  box-shadow: var(--shadow-button);
+  color: var(--btn-ink-fg);
 }
 
 .date-range-buttons .icon-period-button {
@@ -2030,12 +2030,13 @@ select {
   gap: 6px;
   min-height: 30px;
   border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--surface);
+  border-radius: var(--radius-full);
+  background: var(--card);
+  box-shadow: var(--shadow-button-light);
   color: var(--fg);
   font-size: 13px;
   font-weight: 550;
-  padding: 0 10px;
+  padding: 0 12px;
 }
 
 .primary-button {
@@ -2044,19 +2045,18 @@ select {
   justify-content: center;
   gap: 7px;
   min-height: 36px;
-  border: 1px solid color-mix(in oklab, var(--accent) 78%, var(--line));
-  border-radius: 9px;
-  background: var(--accent);
-  box-shadow: 0 8px 22px -14px color-mix(in oklab, var(--accent) 80%, transparent);
-  color: var(--on-accent);
+  border: 1px solid transparent;
+  border-radius: var(--radius-full);
+  background: var(--btn-ink);
+  box-shadow: var(--shadow-button);
+  color: var(--btn-ink-fg);
   font-size: 13px;
-  font-weight: 680;
-  padding: 0 14px;
+  font-weight: 600;
+  padding: 0 16px;
 }
 
 .primary-button:hover {
-  border-color: var(--accent-hover);
-  background: var(--accent-hover);
+  background: color-mix(in oklab, var(--btn-ink) 88%, var(--fg));
 }
 
 .primary-button:disabled {
@@ -2132,8 +2132,9 @@ select {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  border-radius: 6px;
-  background: var(--elevated);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-full);
+  background: var(--card);
   color: var(--muted);
   font-size: 12px;
   font-weight: 600;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -69,6 +69,7 @@
   --card: rgba(255, 255, 255, 0.48);
   /* bg/components/secondary — buttons sit lighter than card surfaces. */
   --btn-ghost: rgba(255, 255, 255, 0.28);
+  --btn-ghost-hover: rgba(255, 255, 255, 0.75);
   /* border/default and a stronger step for focused/active edges. */
   --line: rgba(26, 26, 26, 0.09);
   --line-strong: rgba(26, 26, 26, 0.16);
@@ -115,6 +116,7 @@
    * so it stays a button rather than a hole in the page. */
   --btn-ink: #09090b;
   --btn-ink-fg: #fafafa;
+  --btn-ink-hover: #3f3f46;
   /* The near-black every scrim and drop shadow layers, as bare channels so each
    * site keeps its own alpha — a slide-over scrim is deliberately lighter than a
    * modal's. Warm on purpose: these used to be Tailwind slate-900, which laid a
@@ -152,6 +154,7 @@
     --overlay: #262418;
     --card: rgba(255, 255, 255, 0.035);
     --btn-ghost: rgba(255, 255, 255, 0.06);
+    --btn-ghost-hover: rgba(255, 255, 255, 0.12);
     --line: rgba(240, 238, 228, 0.1);
     --line-strong: rgba(240, 238, 228, 0.18);
     --fg: #f4f2e8;
@@ -166,6 +169,7 @@
     --info: #38bdf8;
     --btn-ink: #f4f2e8;
     --btn-ink-fg: #17160f;
+    --btn-ink-hover: #d8d5c6;
     --shade-rgb: 0, 0, 0;
     --shadow-button:
       0 1px 2px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(0, 0, 0, 0.5),
@@ -182,6 +186,7 @@
   --overlay: #262418;
   --card: rgba(255, 255, 255, 0.035);
   --btn-ghost: rgba(255, 255, 255, 0.06);
+  --btn-ghost-hover: rgba(255, 255, 255, 0.12);
   --line: rgba(240, 238, 228, 0.1);
   --line-strong: rgba(240, 238, 228, 0.18);
   --fg: #f4f2e8;
@@ -196,6 +201,7 @@
   --info: #38bdf8;
   --btn-ink: #f4f2e8;
   --btn-ink-fg: #17160f;
+  --btn-ink-hover: #d8d5c6;
   --shade-rgb: 0, 0, 0;
   --shadow-button:
     0 1px 2px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(0, 0, 0, 0.5), inset 0 -2px 0 rgba(0, 0, 0, 0.16),
@@ -2106,7 +2112,7 @@ select {
 }
 
 .primary-button:hover {
-  background: color-mix(in oklab, var(--btn-ink) 88%, var(--fg));
+  background: var(--btn-ink-hover);
 }
 
 .primary-button:disabled {
@@ -2155,7 +2161,7 @@ select {
 }
 
 .secondary-button:hover {
-  background: var(--elevated);
+  background: var(--btn-ghost-hover);
 }
 
 .secondary-button:disabled {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -939,6 +939,7 @@ nav a[aria-current="page"] svg {
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 12px;
 }
 

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -82,21 +82,26 @@
   --warning: #ea580c;
   --danger: #dc2626;
   --info: #0ea5e9;
-  /* Dosu sage. Brand-locked, so it does not move between themes. */
+  /* Dosu sage, light to dark. Brand-locked, so it does not move between themes. */
   --dosu: #b4bb91;
+  --dosu-mid: #899364;
   --dosu-strong: #65704b;
   /* The design's primary button is near-black, not brand pink. Inverted in dark
    * so it stays a button rather than a hole in the page. */
   --btn-ink: #09090b;
   --btn-ink-fg: #fafafa;
-  --scrim: rgba(23, 22, 15, 0.46);
+  /* The near-black every scrim and drop shadow layers, as bare channels so each
+   * site keeps its own alpha — a slide-over scrim is deliberately lighter than a
+   * modal's. Warm on purpose: these used to be Tailwind slate-900, which laid a
+   * cold blue veil over a warm cream page. */
+  --shade-rgb: 23, 22, 15;
   /* The design's four-layer button treatment: two drops for lift, two insets for
    * the top bevel. Defined once because nobody will retype this correctly. */
   --shadow-button:
     0 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 -2px 0 #52525b,
     inset 0 -1px 0 #27272a;
   --shadow-button-light: inset 0 1px 0 rgba(255, 255, 255, 0.48);
-  --shadow-card: 0 1px 2px rgba(20, 20, 10, 0.05);
+  --shadow-card: 0 1px 2px rgba(var(--shade-rgb), 0.05);
   --radius-md: 8px;
   --radius-lg: 10px;
   --radius-xl: 14px;
@@ -138,12 +143,12 @@
     --info: #38bdf8;
     --btn-ink: #f4f2e8;
     --btn-ink-fg: #17160f;
-    --scrim: rgba(0, 0, 0, 0.62);
+    --shade-rgb: 0, 0, 0;
     --shadow-button:
       0 1px 2px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(0, 0, 0, 0.4),
       inset 0 -2px 0 rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.16);
     --shadow-button-light: inset 0 1px 0 rgba(255, 255, 255, 0.06);
-    --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.35);
+    --shadow-card: 0 1px 2px rgba(var(--shade-rgb), 0.35);
   }
 }
 
@@ -170,12 +175,12 @@
   --info: #38bdf8;
   --btn-ink: #f4f2e8;
   --btn-ink-fg: #17160f;
-  --scrim: rgba(0, 0, 0, 0.62);
+  --shade-rgb: 0, 0, 0;
   --shadow-button:
     0 1px 2px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(0, 0, 0, 0.4), inset 0 -2px 0 rgba(0, 0, 0, 0.12),
     inset 0 1px 0 rgba(255, 255, 255, 0.16);
   --shadow-button-light: inset 0 1px 0 rgba(255, 255, 255, 0.06);
-  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.35);
+  --shadow-card: 0 1px 2px rgba(var(--shade-rgb), 0.35);
 }
 
 /* Light is :root, so forcing light only has to stop the dark media block from
@@ -539,7 +544,7 @@ nav a[aria-current="page"] svg {
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  background: rgb(0 0 0 / 58%);
+  background: rgba(var(--shade-rgb), 0.58);
   padding: min(12vh, 104px) 20px 20px;
   backdrop-filter: blur(5px);
 }
@@ -553,7 +558,7 @@ nav a[aria-current="page"] svg {
   border: 1px solid var(--line-strong);
   border-radius: 14px;
   background: var(--surface);
-  box-shadow: 0 24px 80px rgb(0 0 0 / 38%);
+  box-shadow: 0 24px 80px rgba(var(--shade-rgb), 0.38);
   flex-direction: column;
 }
 
@@ -919,7 +924,7 @@ nav a[aria-current="page"] svg {
   inset: 0;
   display: grid;
   place-items: center;
-  background: rgb(15 23 42 / 46%);
+  background: rgba(var(--shade-rgb), 0.46);
   padding: 24px;
 }
 
@@ -929,7 +934,7 @@ nav a[aria-current="page"] svg {
   border: 1px solid var(--line);
   border-radius: 14px;
   background: var(--surface);
-  box-shadow: 0 24px 80px rgb(15 23 42 / 28%);
+  box-shadow: 0 24px 80px rgba(var(--shade-rgb), 0.28);
 }
 
 .report-review-sheet > header,
@@ -1285,7 +1290,7 @@ table {
   z-index: 80;
   inset: 0;
   border: 0;
-  background: rgb(15 23 42 / 28%);
+  background: rgba(var(--shade-rgb), 0.28);
   cursor: default;
 }
 
@@ -1301,7 +1306,7 @@ table {
   overflow-y: auto;
   border-left: 1px solid var(--line);
   background: var(--surface);
-  box-shadow: -18px 0 50px rgb(15 23 42 / 18%);
+  box-shadow: -18px 0 50px rgba(var(--shade-rgb), 0.18);
 }
 
 .tool-detail-panel > header,
@@ -1780,9 +1785,9 @@ td a:hover {
   flex: 0 0 auto;
   align-items: center;
   gap: 5px;
-  border: 1px solid color-mix(in oklab, #b4bb91 45%, var(--line));
+  border: 1px solid color-mix(in oklab, var(--dosu) 45%, var(--line));
   border-radius: 999px;
-  background: color-mix(in oklab, #b4bb91 12%, var(--surface));
+  background: color-mix(in oklab, var(--dosu) 12%, var(--surface));
   color: var(--muted);
   font-size: 11px;
   font-weight: 650;
@@ -1792,7 +1797,7 @@ td a:hover {
 
 .dosu-provenance-badge:hover,
 .dosu-provenance-badge:focus-visible {
-  border-color: color-mix(in oklab, #b4bb91 72%, var(--line-strong));
+  border-color: color-mix(in oklab, var(--dosu) 72%, var(--line-strong));
   color: var(--fg);
 }
 
@@ -2259,7 +2264,7 @@ select {
   min-height: 48px;
   border-radius: 12px;
   padding-left: 44px;
-  box-shadow: 0 1px 2px rgb(0 0 0 / 12%);
+  box-shadow: 0 1px 2px rgba(var(--shade-rgb), 0.12);
 }
 
 .result-caption {
@@ -2574,7 +2579,7 @@ mark {
   display: grid;
   place-items: center;
   overflow-y: auto;
-  background: rgb(0 0 0 / 72%);
+  background: rgba(var(--shade-rgb), 0.72);
   padding: 24px;
   backdrop-filter: blur(8px);
 }
@@ -2586,7 +2591,7 @@ mark {
   border: 1px solid var(--line-strong);
   border-radius: var(--radius-xl);
   background: var(--surface);
-  box-shadow: 0 24px 80px rgb(0 0 0 / 44%);
+  box-shadow: 0 24px 80px rgba(var(--shade-rgb), 0.44);
 }
 
 .share-review-sheet > header,
@@ -2935,7 +2940,7 @@ mark {
   border: 1px solid var(--line-strong);
   border-radius: 8px;
   background: var(--overlay);
-  box-shadow: 0 12px 32px rgb(0 0 0 / 30%);
+  box-shadow: 0 12px 32px rgba(var(--shade-rgb), 0.3);
   color: var(--fg);
   font-size: 12px;
   line-height: 1.45;
@@ -3193,9 +3198,9 @@ mark {
   grid-template-columns: auto minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 12px;
-  border: 1px solid color-mix(in oklab, #b4bb91 34%, var(--line));
+  border: 1px solid color-mix(in oklab, var(--dosu) 34%, var(--line));
   border-radius: 10px;
-  background: color-mix(in oklab, #b4bb91 8%, var(--surface));
+  background: color-mix(in oklab, var(--dosu) 8%, var(--surface));
   padding: 12px 14px;
 }
 
@@ -3542,7 +3547,7 @@ mark {
   border: 1px solid var(--line-strong);
   border-radius: 9px;
   background: var(--surface);
-  box-shadow: 0 12px 32px rgb(0 0 0 / 32%);
+  box-shadow: 0 12px 32px rgba(var(--shade-rgb), 0.32);
   padding: 4px;
 }
 
@@ -3618,9 +3623,9 @@ mark {
 }
 
 .insights-dosu-list {
-  border-color: color-mix(in oklab, #b4bb91 38%, var(--line));
-  background: color-mix(in oklab, #b4bb91 7%, var(--surface));
-  box-shadow: 0 12px 28px -26px color-mix(in oklab, #65704b 48%, transparent);
+  border-color: color-mix(in oklab, var(--dosu) 38%, var(--line));
+  background: color-mix(in oklab, var(--dosu) 7%, var(--surface));
+  box-shadow: 0 12px 28px -26px color-mix(in oklab, var(--dosu-strong) 48%, transparent);
 }
 
 .dosu-insights-row {
@@ -4156,7 +4161,7 @@ mark {
 }
 
 .toc-icon.is-dosu {
-  background: color-mix(in oklab, #b4bb91 16%, transparent);
+  background: color-mix(in oklab, var(--dosu) 16%, transparent);
 }
 
 .toc a.is-dosu {
@@ -4165,7 +4170,7 @@ mark {
 
 .toc a.is-dosu:hover .toc-icon,
 .toc a.is-dosu.is-current .toc-icon {
-  background: color-mix(in oklab, #b4bb91 25%, transparent);
+  background: color-mix(in oklab, var(--dosu) 25%, transparent);
 }
 
 .toc a:hover .toc-icon {
@@ -4186,7 +4191,7 @@ mark {
 
 .toc em {
   align-self: center;
-  border: 1px solid color-mix(in oklab, #b4bb91 40%, var(--line));
+  border: 1px solid color-mix(in oklab, var(--dosu) 40%, var(--line));
   border-radius: 999px;
   color: var(--faint);
   font-size: 9px;
@@ -4583,11 +4588,11 @@ mark {
 }
 
 .tool-call.is-dosu {
-  border-color: color-mix(in oklab, #b4bb91 58%, var(--line));
-  background: color-mix(in oklab, #b4bb91 9%, var(--surface));
+  border-color: color-mix(in oklab, var(--dosu) 58%, var(--line));
+  background: color-mix(in oklab, var(--dosu) 9%, var(--surface));
   box-shadow:
-    inset 3px 0 0 color-mix(in oklab, #899364 70%, transparent),
-    0 12px 28px -22px color-mix(in oklab, #65704b 65%, transparent);
+    inset 3px 0 0 color-mix(in oklab, var(--dosu-mid) 70%, transparent),
+    0 12px 28px -22px color-mix(in oklab, var(--dosu-strong) 65%, transparent);
   padding-left: 12px;
 }
 
@@ -4597,7 +4602,7 @@ mark {
   height: 24px;
   place-items: center;
   border-radius: 6px;
-  background: color-mix(in oklab, #b4bb91 18%, transparent);
+  background: color-mix(in oklab, var(--dosu) 18%, transparent);
 }
 
 .dosu-tool-mark img {
@@ -4606,7 +4611,7 @@ mark {
 }
 
 .dosu-tool-badge {
-  border: 1px solid color-mix(in oklab, #b4bb91 48%, var(--line));
+  border: 1px solid color-mix(in oklab, var(--dosu) 48%, var(--line));
   border-radius: 999px;
   color: var(--muted);
   font-size: 10px;
@@ -4958,7 +4963,7 @@ pre {
     inset: 0;
     z-index: 30;
     display: block;
-    background: rgb(0 0 0 / 58%);
+    background: rgba(var(--shade-rgb), 0.58);
     backdrop-filter: blur(4px);
   }
 

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -70,7 +70,6 @@
   --fg: #141414;
   --muted: rgba(26, 26, 26, 0.69);
   --faint: rgba(26, 26, 26, 0.48);
-  --fg-quaternary: rgba(26, 26, 26, 0.28);
   /* brand/400. Decorative and chart-facing — see --btn-ink for buttons. */
   --accent: #ee67d1;
   --accent-hover: #d94ab8;
@@ -153,7 +152,6 @@
     --fg: #f4f2e8;
     --muted: rgba(244, 242, 232, 0.68);
     --faint: rgba(244, 242, 232, 0.46);
-    --fg-quaternary: rgba(244, 242, 232, 0.28);
     --accent: #f087dd;
     --accent-hover: #f5a5e6;
     --on-accent: #17160f;
@@ -185,7 +183,6 @@
   --fg: #f4f2e8;
   --muted: rgba(244, 242, 232, 0.68);
   --faint: rgba(244, 242, 232, 0.46);
-  --fg-quaternary: rgba(244, 242, 232, 0.28);
   --accent: #f087dd;
   --accent-hover: #f5a5e6;
   --on-accent: #17160f;
@@ -347,9 +344,10 @@ nav {
   margin: 0 0 7px;
   padding: 0 10px;
   color: var(--faint);
-  font-size: 10px;
-  font-weight: 650;
-  letter-spacing: 0.09em;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.32em;
   text-transform: uppercase;
 }
 
@@ -367,8 +365,11 @@ nav a {
   gap: 10px;
   border-radius: 8px;
   color: var(--muted);
-  font-size: 13.5px;
+  font-family: var(--font-mono);
+  font-size: 13px;
   font-weight: 500;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
   padding: 8px 10px;
   transition:
     background 0.12s ease,
@@ -907,8 +908,21 @@ nav a[aria-current="page"] svg {
 }
 
 .page-heading h1 {
-  font-size: 20px;
-  font-weight: 650;
+  font-family: var(--font-serif);
+  font-size: 28px;
+  font-weight: 600;
+  line-height: 1.14;
+  letter-spacing: -0.01em;
+}
+
+/* Analytics, Sessions, Tools and Files wrap the title and subtitle in a div next
+ * to their actions, so the baseline row goes on that wrapper. Insights keeps a
+ * stacked heading: its eyebrow is a sibling of the h1, not a child of a wrapper. */
+.inline-heading > div:first-child {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
 .page-heading p,
@@ -1135,8 +1149,10 @@ nav a[aria-current="page"] svg {
 
 .stat-card span {
   color: var(--muted);
+  font-family: var(--font-mono);
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 500;
+  letter-spacing: 0.32em;
   text-transform: uppercase;
 }
 
@@ -1597,9 +1613,10 @@ tbody tr:hover {
 
 th {
   color: var(--muted);
+  font-family: var(--font-mono);
   font-size: 12px;
-  font-weight: 650;
-  letter-spacing: 0;
+  font-weight: 500;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
 }
 
@@ -3143,7 +3160,7 @@ mark {
 
 .insights-heading h1 {
   font-size: 28px;
-  font-weight: 680;
+  font-weight: 600;
   line-height: 1.15;
 }
 

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -26,78 +26,162 @@
   src: url("../report/fonts/IBMPlexMono-Regular-Latin1.woff2") format("woff2");
 }
 
+/* ===========================================================================
+ * Tokens
+ *
+ * Light is the base theme because light is the one that was designed (Figma:
+ * "Dosu x Venice"); dark is derived from it and lives in the two override
+ * blocks below.
+ *
+ * Two rules keep this block safe to edit:
+ *
+ * 1. DO NOT RENAME --fg, --muted, --faint, --line, --surface, --accent, --info,
+ *    --success or --warning. `chartColors()` in main.tsx reads those nine names
+ *    off the computed root style and hands them to ECharts. A rename leaves
+ *    charts silently unstyled — no error, no visual clue except wrong axes.
+ * 2. Keep those nine in a colour grammar zrender can parse, because ECharts gets
+ *    the raw string. Its parser (zrender/lib/tool/color.js) accepts hex — 3, 4,
+ *    6 and 8 digit — plus comma-separated rgb()/rgba()/hsl(), and nothing else.
+ *    So: no `color-mix()`, no `rgba(var(--x), …)` (custom-property substitution
+ *    in getComputedStyle is not something to bet charts on), and no space/slash
+ *    `rgb(0 0 0 / 50%)`, which zrender splits on commas and reads as black.
+ *    Literal `rgba()` here is deliberate; Bun's minifier rewrites it to 8-digit
+ *    hex on the way out, which zrender handles fine.
+ *
+ * --success/--info/--warning/--danger are fill-grade, taken straight from the
+ * design: they are tuned for chart series and badge backgrounds, not for text
+ * on --canvas. Text-on-colour pairings go through the -ink tokens.
+ * =========================================================================== */
 :root {
-  color-scheme: dark;
-  --canvas: #0b0e14;
-  --surface: #11151f;
-  --elevated: #161c28;
-  --overlay: #1b2230;
-  --line: #232b3b;
-  --line-strong: #303a4e;
-  --fg: #e7eaf0;
-  --muted: #9aa6b8;
-  --faint: #6b7689;
-  --accent: #8b5cf6;
-  --accent-hover: #a78bfa;
-  --on-accent: #f5f3ff;
+  color-scheme: light;
+  /* bg/primary — the warm cream the whole app sits on. */
+  --canvas: #e6e3d7;
+  /* bg/card, flattened to an opaque colour: chart tooltips and `chartColors()`
+   * need something real to paint on. The genuinely translucent fill is --card. */
+  --surface: #f2f0ea;
+  /* bg/secondary — tinted table headers and hover states. */
+  --elevated: #e1dfd6;
+  --overlay: #fbfaf6;
+  --card: rgba(255, 255, 255, 0.48);
+  /* border/default and a stronger step for focused/active edges. */
+  --line: rgba(26, 26, 26, 0.09);
+  --line-strong: rgba(26, 26, 26, 0.16);
+  /* fg/primary → fg/quaternary: one near-black at four opacities. */
+  --fg: #141414;
+  --muted: rgba(26, 26, 26, 0.69);
+  --faint: rgba(26, 26, 26, 0.48);
+  --fg-quaternary: rgba(26, 26, 26, 0.28);
+  /* brand/400. Decorative and chart-facing — see --btn-ink for buttons. */
+  --accent: #ee67d1;
+  --accent-hover: #d94ab8;
+  --on-accent: #141414;
+  --accent-soft: rgba(238, 103, 209, 0.12);
   --claude: #d97757;
   --claude-strong: #c6613f;
-  --success: #34d399;
-  --warning: #fbbf24;
-  --danger: #f87171;
-  --info: #60a5fa;
+  --success: #65a30d;
+  --warning: #ea580c;
+  --danger: #dc2626;
+  --info: #0ea5e9;
+  /* Dosu sage. Brand-locked, so it does not move between themes. */
+  --dosu: #b4bb91;
+  --dosu-strong: #65704b;
+  /* The design's primary button is near-black, not brand pink. Inverted in dark
+   * so it stays a button rather than a hole in the page. */
+  --btn-ink: #09090b;
+  --btn-ink-fg: #fafafa;
+  --scrim: rgba(23, 22, 15, 0.46);
+  /* The design's four-layer button treatment: two drops for lift, two insets for
+   * the top bevel. Defined once because nobody will retype this correctly. */
+  --shadow-button:
+    0 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 -2px 0 #52525b,
+    inset 0 -1px 0 #27272a;
+  --shadow-button-light: inset 0 1px 0 rgba(255, 255, 255, 0.48);
+  --shadow-card: 0 1px 2px rgba(20, 20, 10, 0.05);
+  --radius-md: 8px;
   --radius-lg: 10px;
   --radius-xl: 14px;
+  --radius-full: 9999px;
   --font-serif: "Source Serif 4", ui-serif, Georgia, Cambria, "Times New Roman", serif;
   --font-mono: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
-@media (prefers-color-scheme: light) {
+/* The two dark blocks below MUST stay byte-identical. CSS cannot share
+ * declarations between a media query and an attribute selector, so this is two
+ * copies on purpose: the media block serves "system" (no data-theme attribute),
+ * the attribute block serves an explicit choice. Edit both or neither.
+ *
+ * Dark is derived, not designed — the Figma file ships no dark palette. It keeps
+ * light's warm cast so the two read as one product. */
+@media (prefers-color-scheme: dark) {
   :root:not([data-theme]) {
-    color-scheme: light;
-    --canvas: #f6f7f9;
-    --surface: #ffffff;
-    --elevated: #f3f5f8;
-    --overlay: #ffffff;
-    --line: #e4e8ef;
-    --line-strong: #d2d8e2;
-    --fg: #131722;
-    --muted: #5a6473;
-    --faint: #97a1b0;
-    --accent: #7c3aed;
-    --accent-hover: #6d28d9;
-    --on-accent: #ffffff;
-    --success: #059669;
-    --warning: #b45309;
-    --danger: #dc2626;
-    --info: #2563eb;
+    color-scheme: dark;
+    --canvas: #17160f;
+    --surface: #201f16;
+    --elevated: #1f1d14;
+    --overlay: #262418;
+    --card: rgba(255, 255, 255, 0.035);
+    --line: rgba(240, 238, 228, 0.1);
+    --line-strong: rgba(240, 238, 228, 0.18);
+    --fg: #f4f2e8;
+    --muted: rgba(244, 242, 232, 0.68);
+    --faint: rgba(244, 242, 232, 0.46);
+    --fg-quaternary: rgba(244, 242, 232, 0.28);
+    --accent: #f087dd;
+    --accent-hover: #f5a5e6;
+    --on-accent: #17160f;
+    --accent-soft: rgba(240, 135, 221, 0.16);
+    --success: #a3e635;
+    --warning: #fb923c;
+    --danger: #f87171;
+    --info: #38bdf8;
+    --btn-ink: #f4f2e8;
+    --btn-ink-fg: #17160f;
+    --scrim: rgba(0, 0, 0, 0.62);
+    --shadow-button:
+      0 1px 2px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(0, 0, 0, 0.4),
+      inset 0 -2px 0 rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.16);
+    --shadow-button-light: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.35);
   }
-}
-
-[data-theme="light"] {
-  color-scheme: light;
-  --canvas: #f6f7f9;
-  --surface: #ffffff;
-  --elevated: #f3f5f8;
-  --overlay: #ffffff;
-  --line: #e4e8ef;
-  --line-strong: #d2d8e2;
-  --fg: #131722;
-  --muted: #5a6473;
-  --faint: #97a1b0;
-  --accent: #7c3aed;
-  --accent-hover: #6d28d9;
-  --on-accent: #ffffff;
-  --success: #059669;
-  --warning: #b45309;
-  --danger: #dc2626;
-  --info: #2563eb;
 }
 
 [data-theme="dark"] {
   color-scheme: dark;
+  --canvas: #17160f;
+  --surface: #201f16;
+  --elevated: #1f1d14;
+  --overlay: #262418;
+  --card: rgba(255, 255, 255, 0.035);
+  --line: rgba(240, 238, 228, 0.1);
+  --line-strong: rgba(240, 238, 228, 0.18);
+  --fg: #f4f2e8;
+  --muted: rgba(244, 242, 232, 0.68);
+  --faint: rgba(244, 242, 232, 0.46);
+  --fg-quaternary: rgba(244, 242, 232, 0.28);
+  --accent: #f087dd;
+  --accent-hover: #f5a5e6;
+  --on-accent: #17160f;
+  --accent-soft: rgba(240, 135, 221, 0.16);
+  --success: #a3e635;
+  --warning: #fb923c;
+  --danger: #f87171;
+  --info: #38bdf8;
+  --btn-ink: #f4f2e8;
+  --btn-ink-fg: #17160f;
+  --scrim: rgba(0, 0, 0, 0.62);
+  --shadow-button:
+    0 1px 2px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(0, 0, 0, 0.4), inset 0 -2px 0 rgba(0, 0, 0, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.16);
+  --shadow-button-light: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.35);
+}
+
+/* Light is :root, so forcing light only has to stop the dark media block from
+ * matching — which the [data-theme] attribute already does. */
+[data-theme="light"] {
+  color-scheme: light;
 }
 
 * {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -67,6 +67,8 @@
   --elevated: #e1dfd6;
   --overlay: #fbfaf6;
   --card: rgba(255, 255, 255, 0.48);
+  /* bg/components/secondary — buttons sit lighter than card surfaces. */
+  --btn-ghost: rgba(255, 255, 255, 0.28);
   /* border/default and a stronger step for focused/active edges. */
   --line: rgba(26, 26, 26, 0.09);
   --line-strong: rgba(26, 26, 26, 0.16);
@@ -149,6 +151,7 @@
     --elevated: #1f1d14;
     --overlay: #262418;
     --card: rgba(255, 255, 255, 0.035);
+    --btn-ghost: rgba(255, 255, 255, 0.06);
     --line: rgba(240, 238, 228, 0.1);
     --line-strong: rgba(240, 238, 228, 0.18);
     --fg: #f4f2e8;
@@ -178,6 +181,7 @@
   --elevated: #1f1d14;
   --overlay: #262418;
   --card: rgba(255, 255, 255, 0.035);
+  --btn-ghost: rgba(255, 255, 255, 0.06);
   --line: rgba(240, 238, 228, 0.1);
   --line-strong: rgba(240, 238, 228, 0.18);
   --fg: #f4f2e8;
@@ -368,6 +372,7 @@ nav a {
   display: flex;
   align-items: center;
   gap: 10px;
+  border: 1px solid transparent;
   border-radius: 8px;
   color: var(--muted);
   font-family: var(--font-mono);
@@ -400,13 +405,14 @@ nav a:hover svg {
 /* The icon carries the accent and the label goes full-contrast bold. Tinting
    the text accent as well washed it out against the tinted background. */
 nav a[aria-current="page"] {
-  background: color-mix(in oklab, var(--accent) 15%, transparent);
+  border: 1px solid var(--line);
+  background: var(--overlay);
+  box-shadow: var(--shadow-button-light);
   color: var(--fg);
-  font-weight: 640;
 }
 
 nav a[aria-current="page"] svg {
-  color: var(--accent-text);
+  color: var(--fg);
   opacity: 1;
 }
 
@@ -873,9 +879,9 @@ nav a[aria-current="page"] svg {
 }
 
 .date-range-buttons button[aria-pressed="true"] {
-  background: var(--btn-ink);
-  box-shadow: var(--shadow-button);
-  color: var(--btn-ink-fg);
+  background: var(--overlay);
+  box-shadow: var(--shadow-button-light);
+  color: var(--fg);
 }
 
 .date-range-buttons .icon-period-button {
@@ -968,6 +974,7 @@ nav a[aria-current="page"] svg {
 .page-heading-actions {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 10px;
 }
 
@@ -1148,10 +1155,9 @@ nav a[aria-current="page"] svg {
 .stat-grid {
   display: grid;
   gap: 1px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-md);
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
   background: var(--line);
-  overflow: hidden;
 }
 
 .sessions-stat-grid,
@@ -1169,7 +1175,7 @@ nav a[aria-current="page"] svg {
   align-items: flex-start;
   justify-content: flex-end;
   gap: 10px;
-  background: var(--surface);
+  background: var(--canvas);
   padding: 18px 20px;
 }
 
@@ -1647,11 +1653,10 @@ tbody tr:hover {
 th {
   background: var(--elevated);
   color: var(--muted);
-  font-family: var(--font-mono);
   font-size: 12px;
   font-weight: 500;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 .data-table td,
@@ -2070,11 +2075,14 @@ select {
   min-height: 30px;
   border: 1px solid var(--line);
   border-radius: var(--radius-full);
-  background: var(--card);
+  background: var(--btn-ghost);
   box-shadow: var(--shadow-button-light);
   color: var(--fg);
+  font-family: var(--font-mono);
   font-size: 13px;
-  font-weight: 550;
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
   padding: 0 12px;
 }
 
@@ -2089,8 +2097,11 @@ select {
   background: var(--btn-ink);
   box-shadow: var(--shadow-button);
   color: var(--btn-ink-fg);
+  font-family: var(--font-mono);
   font-size: 13px;
-  font-weight: 600;
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
   padding: 0 16px;
 }
 
@@ -3944,6 +3955,7 @@ mark {
   display: flex;
   flex: 0 0 auto;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
 }
 

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -281,7 +281,7 @@ svg {
   width: 15rem;
   flex-direction: column;
   border-right: 1px solid var(--line);
-  background: var(--surface);
+  background: var(--canvas);
 }
 
 .sidebar-backdrop {
@@ -304,9 +304,10 @@ svg {
   align-items: center;
   gap: 10px;
   min-width: 0;
-  font-size: 15px;
-  font-weight: 650;
-  letter-spacing: 0;
+  font-family: var(--font-serif);
+  font-size: 19px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 .brand-icon {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1027,7 +1027,6 @@ nav a[aria-current="page"] svg {
 }
 
 .panel,
-.stat-card,
 .signal-hero,
 .signal-list,
 .catalog-card {
@@ -1128,7 +1127,11 @@ nav a[aria-current="page"] svg {
 
 .stat-grid {
   display: grid;
-  gap: 12px;
+  gap: 1px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--line);
+  overflow: hidden;
 }
 
 .sessions-stat-grid,
@@ -1137,15 +1140,17 @@ nav a[aria-current="page"] svg {
 }
 
 .analytics-stat-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
 }
 
 .stat-card {
   display: flex;
+  flex-direction: row-reverse;
   align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 16px 18px;
+  justify-content: flex-end;
+  gap: 10px;
+  background: var(--surface);
+  padding: 18px 20px;
 }
 
 .stat-card span {
@@ -1168,16 +1173,20 @@ nav a[aria-current="page"] svg {
 
 .stat-icon {
   display: grid;
-  width: 36px;
-  height: 36px;
+  width: 20px;
+  height: 20px;
   place-items: center;
-  border-radius: 8px;
-  background: var(--elevated);
 }
 
 .stat-icon svg {
-  width: 18px;
-  height: 18px;
+  width: 15px;
+  height: 15px;
+}
+
+/* Two classes, so this outranks the single-class .tone-* colour without
+ * needing to sit after it in the file. */
+.stat-card .stat-icon {
+  color: var(--muted);
 }
 
 .table-scroll {
@@ -1585,7 +1594,7 @@ table {
 th,
 td {
   border-bottom: 1px solid color-mix(in oklab, var(--line) 72%, transparent);
-  padding: 10px 16px;
+  padding: 14px 16px;
   text-align: left;
   vertical-align: middle;
 }
@@ -1613,6 +1622,7 @@ tbody tr:hover {
 }
 
 th {
+  background: var(--elevated);
   color: var(--muted);
   font-family: var(--font-mono);
   font-size: 12px;
@@ -2200,42 +2210,35 @@ select {
 }
 
 .badge.tone-accent,
-.signal-icon.tone-accent,
-.stat-icon.tone-accent {
+.signal-icon.tone-accent {
   background: color-mix(in oklab, var(--accent) 13%, transparent);
 }
 
 .badge.tone-success,
-.signal-icon.tone-success,
-.stat-icon.tone-success {
+.signal-icon.tone-success {
   background: color-mix(in oklab, var(--success) 12%, transparent);
 }
 
 .badge.tone-warning,
-.signal-icon.tone-warning,
-.stat-icon.tone-warning {
+.signal-icon.tone-warning {
   background: color-mix(in oklab, var(--warning) 12%, transparent);
 }
 
 .badge.tone-danger,
-.signal-icon.tone-danger,
-.stat-icon.tone-danger {
+.signal-icon.tone-danger {
   background: color-mix(in oklab, var(--danger) 12%, transparent);
 }
 
 .badge.tone-info,
-.signal-icon.tone-info,
-.stat-icon.tone-info {
+.signal-icon.tone-info {
   background: color-mix(in oklab, var(--info) 12%, transparent);
 }
 
-.badge.tone-claude,
-.stat-icon.tone-claude {
+.badge.tone-claude {
   background: color-mix(in oklab, var(--claude) 12%, transparent);
 }
 
-.badge.tone-openai,
-.stat-icon.tone-openai {
+.badge.tone-openai {
   background: var(--elevated);
 }
 

--- a/test/ui-fonts.test.ts
+++ b/test/ui-fonts.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const styles = readFileSync(join(root, "src", "ui", "styles.css"), "utf8");
+
+/** Each UI @font-face src, resolved to a repo path. Bun's CSS bundler inlines
+ * these as data URIs at build time, so a missing file is a build failure rather
+ * than a 404 — but only if the path stays resolvable, which is what this pins. */
+function fontFaceSources(): string[] {
+  return [...styles.matchAll(/src: url\("([^"]+\.woff2)"\)/g)].flatMap((match) => match[1] ?? []);
+}
+
+test("UI fonts are bundled from the repo, never fetched remotely", () => {
+  // Invariant 3: this app makes no outbound requests. A webfont is the easiest
+  // way to break that by accident.
+  expect(styles).not.toMatch(/@import|fonts\.googleapis|fonts\.gstatic|use\.typekit/);
+  expect(styles).not.toMatch(/src: url\("https?:/);
+
+  const sources = fontFaceSources();
+  expect(sources).toHaveLength(2);
+  for (const source of sources) {
+    expect(existsSync(join(root, "src", "ui", source))).toBe(true);
+  }
+});
+
+test("bundled faces are declared at the weight they actually ship", () => {
+  // Only the Semibold serif is in the repo. Declaring it as 400 would make
+  // browsers synthesize a bold on top of an already-semibold face.
+  expect(styles).toMatch(
+    /@font-face \{[^}]*font-family: "Source Serif 4";[^}]*font-weight: 600;[^}]*\}/,
+  );
+  expect(styles).toMatch(
+    /@font-face \{[^}]*font-family: "IBM Plex Mono";[^}]*font-weight: 400;[^}]*\}/,
+  );
+});
+
+test("the mono stack is defined once and referenced everywhere", () => {
+  expect(styles).toContain("--font-mono:");
+  expect(styles).toContain("--font-serif:");
+  // Regression guard for two invisible failures this replaced: the stack was
+  // copy-pasted into 12 rules, and a 13th site referenced an undefined
+  // --font-mono and silently rendered in the sans face instead.
+  expect(styles).not.toMatch(/font-family: ui-monospace/);
+});

--- a/test/ui-lazy-echarts.test.ts
+++ b/test/ui-lazy-echarts.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const main = readFileSync(join(import.meta.dir, "..", "src", "ui", "main.tsx"), "utf8");
+
+test("ECharts is only ever reached through a dynamic import", () => {
+  // ECharts is ~1.1MB minified and only two call sites draw with it. Importing it
+  // at the top level ran its module initialisation on every route, including the
+  // six that never render a chart.
+  //
+  // Bun's HTMLBundle does not split chunks in a compiled binary, so this does not
+  // shrink the download — the bytes still ship. What it buys is deferred
+  // *execution*: Bun compiles `import("echarts")` to a lazy `__esm` factory, so
+  // the library's top-level work happens on first chart render instead of on
+  // every page load. Verified by inspecting a `bun build` of src/ui/index.html.
+  expect(main).not.toMatch(/^import \* as echarts/m);
+  expect(main).not.toMatch(/^import echarts/m);
+  // The type import is fine — it erases at build time.
+  expect(main).toMatch(/^import type \{[^}]*\} from "echarts";/m);
+
+  const dynamicImports = main.match(/await import\("echarts"\)/g) ?? [];
+  expect(dynamicImports).toHaveLength(2);
+});
+
+test("the chart effect survives unmounting mid-import", () => {
+  // useEffect has to return its cleanup synchronously, but the chart does not
+  // exist until the import settles. If the component unmounts in that window the
+  // cleanup must still prevent an orphaned chart holding a canvas and listeners.
+  const effect = main.slice(main.indexOf("function AnalyticsChart"));
+  expect(effect).toContain("let cancelled = false;");
+  expect(effect).toContain("let disposeChart: (() => void) | null = null;");
+  // Bails before init when we already unmounted...
+  expect(effect).toMatch(/const echarts = await import\("echarts"\);\s*if \(cancelled\) \{/);
+  // ...and otherwise runs the teardown the async body published.
+  expect(effect).toMatch(/cancelled = true;\s*disposeChart\?\.\(\);/);
+});

--- a/test/ui-restyle-contract.test.ts
+++ b/test/ui-restyle-contract.test.ts
@@ -46,7 +46,9 @@ describe("restyle contract", () => {
     expect(grid).toContain("border-top: 1px solid var(--line)");
     expect(grid).toContain("border-bottom: 1px solid var(--line)");
     expect(grid).not.toContain("border-radius");
-    expect(/\.stat-card \{([^}]*)\}/.exec(styles)?.[1] ?? "").toContain("background: var(--canvas)");
+    expect(/\.stat-card \{([^}]*)\}/.exec(styles)?.[1] ?? "").toContain(
+      "background: var(--canvas)",
+    );
   });
 
   test("table headers are sentence case, as the design draws them", () => {

--- a/test/ui-restyle-contract.test.ts
+++ b/test/ui-restyle-contract.test.ts
@@ -40,7 +40,23 @@ describe("restyle contract", () => {
     const grid = /\.stat-grid \{([^}]*)\}/.exec(styles)?.[1] ?? "";
     expect(grid).toContain("gap: 1px");
     expect(grid).toContain("background: var(--line)");
-    expect(grid).toContain("overflow: hidden");
+    // A ruled band on the page, not a card: the design has a rule above and below
+    // the row and hairlines between the cells, with no outer box or fill. Cells
+    // therefore carry --canvas, so they read as page rather than as panels.
+    expect(grid).toContain("border-top: 1px solid var(--line)");
+    expect(grid).toContain("border-bottom: 1px solid var(--line)");
+    expect(grid).not.toContain("border-radius");
+    expect(/\.stat-card \{([^}]*)\}/.exec(styles)?.[1] ?? "").toContain("background: var(--canvas)");
+  });
+
+  test("table headers are sentence case, as the design draws them", () => {
+    // The design's table-head component is Inter 12/500 with letterSpacing 0, and
+    // both designed screens render "Cost Share" / "Peak CTX" / "Agent Runs". The
+    // uppercase treatment predated this branch; the design asks for it gone.
+    const th = /^th \{([^}]*)\}/m.exec(styles)?.[1] ?? "";
+    expect(th).toContain("text-transform: none");
+    expect(th).toContain("letter-spacing: 0");
+    expect(th).not.toContain("var(--font-mono)");
   });
 
   test("the display serif is only asked for a weight that ships", () => {

--- a/test/ui-restyle-contract.test.ts
+++ b/test/ui-restyle-contract.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const main = readFileSync(join(root, "src", "ui", "main.tsx"), "utf8");
+const styles = readFileSync(join(root, "src", "ui", "styles.css"), "utf8");
+
+/** The classes the Venice restyle hangs its layout on. Each is written in JSX and
+ * styled in CSS, and a rename on either side silently drops the design rather
+ * than failing — there is no build step that pairs the two files. */
+const RESTYLED_CLASSES = [
+  "stat-grid",
+  "stat-card",
+  "stat-icon",
+  "page-heading",
+  "inline-heading",
+  "nav-group-label",
+  "date-range-buttons",
+  "primary-button",
+  "secondary-button",
+  "topbar-search",
+  "theme-toggle",
+  "badge",
+  "brand",
+] as const;
+
+describe("restyle contract", () => {
+  test.each([...RESTYLED_CLASSES])("%s is both rendered and styled", (className) => {
+    expect(main).toMatch(new RegExp(`className=[{"\`][^"\`]*\\b${className}\\b`));
+    expect(styles).toMatch(new RegExp(`^\\.${className}[\\s,{:]`, "m"));
+  });
+
+  test("stat cells are ruled by the grid gap, not by adjacency", () => {
+    // `.stat-card + .stat-card { border-left }` follows DOM order, which stops
+    // matching visual position the moment a grid wraps — Analytics renders six
+    // cards and Tools four. The gap-over-tinted-background approach draws both
+    // axes correctly at any column count, so keep the container owning the rules.
+    expect(styles).not.toMatch(/\.stat-card \+ \.stat-card/);
+    const grid = /\.stat-grid \{([^}]*)\}/.exec(styles)?.[1] ?? "";
+    expect(grid).toContain("gap: 1px");
+    expect(grid).toContain("background: var(--line)");
+    expect(grid).toContain("overflow: hidden");
+  });
+
+  test("the display serif is only asked for a weight that ships", () => {
+    // Only SourceSerif4-Semibold is vendored. Requesting 400 or 700 makes the
+    // browser synthesize a face instead of reporting a missing one.
+    const serifWeights = [...styles.matchAll(/font-family: var\(--font-serif\)[^}]*?}/gs)]
+      .flatMap((match) => [...match[0].matchAll(/font-weight: (\d+)/g)])
+      .flatMap((match) => match[1] ?? []);
+    expect(serifWeights.length).toBeGreaterThan(0);
+    for (const weight of serifWeights) {
+      expect(weight).toBe("600");
+    }
+  });
+});

--- a/test/ui-theme-tokens.test.ts
+++ b/test/ui-theme-tokens.test.ts
@@ -106,6 +106,27 @@ describe("theme tokens", () => {
     expect(readNames.sort()).toEqual([...CHART_TOKENS].sort());
   });
 
+  test("hover states actually differ from their rest state", () => {
+    // A hover built as color-mix(--btn-ink 88%, --fg) was a literal no-op in dark,
+    // where those two tokens are byte-identical, and imperceptible in light where
+    // both are near-black. Hovers now point at their own token, so the pair can be
+    // compared per theme.
+    for (const [rest, hover] of [
+      ["--btn-ink", "--btn-ink-hover"],
+      ["--btn-ghost", "--btn-ghost-hover"],
+    ] as const) {
+      for (const block of [rootBlock, darkAttrBlock]) {
+        const restValue = tokenValue(rest, block);
+        const hoverValue = tokenValue(hover, block);
+        expect(restValue).toBeDefined();
+        expect(hoverValue).toBeDefined();
+        expect(hoverValue).not.toBe(restValue);
+      }
+    }
+    // And no hover may mix a token toward one that equals it in either theme.
+    expect(styles).not.toMatch(/:hover \{\s*background: color-mix\([^)]*var\(--btn-ink\)/);
+  });
+
   test("--fg stays a plain 6-digit hex", () => {
     // buildChartOption builds an ECharts shadow colour by string concatenation —
     // `${colors.fg}0d` — so --fg has to be hex for that to mean anything. An

--- a/test/ui-theme-tokens.test.ts
+++ b/test/ui-theme-tokens.test.ts
@@ -56,8 +56,14 @@ describe("theme tokens", () => {
     // renders cream-on-cream. Font/radius tokens are theme-independent by design.
     const themeIndependent = /^--(font|radius)-/;
     const lightNames = declarations(rootBlock)
-      .map((declaration) => declaration.split(":")[0] ?? "")
-      .filter((name) => !themeIndependent.test(name));
+      .filter((declaration) => {
+        const [name, value] = [declaration.split(":")[0] ?? "", declaration.split(": ")[1] ?? ""];
+        // A token built out of other tokens rethemes through them — --accent-text
+        // follows --accent and --fg on its own, so pinning it in dark as well
+        // would be two places to forget instead of one.
+        return !themeIndependent.test(name) && !value.includes("var(");
+      })
+      .map((declaration) => declaration.split(":")[0] ?? "");
     const darkNames = new Set(
       declarations(darkAttrBlock).map((declaration) => declaration.split(":")[0]),
     );
@@ -84,6 +90,17 @@ describe("theme tokens", () => {
       (match) => match[1] ?? [],
     );
     expect(readNames.sort()).toEqual([...CHART_TOKENS].sort());
+  });
+
+  test("fill-grade colours are never used as text", () => {
+    // The design's accents are tuned for chart series and badge fills. As `color:`
+    // on a page surface they measure 2.1–3.8:1 against cream and miss WCAG AA, so
+    // text goes through the -text variants instead. Borders, backgrounds and
+    // accent-color are all still fair game for the raw token.
+    for (const token of ["accent", "success", "warning", "danger", "info", "claude"]) {
+      expect(styles).not.toContain(`color: var(--${token});`);
+      expect(styles).toContain(`--${token}-text:`);
+    }
   });
 
   test.each([...CHART_TOKENS])("%s stays parseable by zrender", (token) => {

--- a/test/ui-theme-tokens.test.ts
+++ b/test/ui-theme-tokens.test.ts
@@ -27,6 +27,10 @@ function declarations(block: string): string[] {
   );
 }
 
+function tokenValue(name: string, block: string): string | undefined {
+  return new RegExp(`^\\s*${name}:\\s*([^;]+);`, "im").exec(block)?.[1]?.trim();
+}
+
 function blockAfter(marker: string, closer: string): string {
   const start = styles.indexOf(marker);
   expect(start).toBeGreaterThanOrEqual(0);
@@ -90,6 +94,17 @@ describe("theme tokens", () => {
       (match) => match[1] ?? [],
     );
     expect(readNames.sort()).toEqual([...CHART_TOKENS].sort());
+  });
+
+  test("--fg stays a plain 6-digit hex", () => {
+    // buildChartOption builds an ECharts shadow colour by string concatenation —
+    // `${colors.fg}0d` — so --fg has to be hex for that to mean anything. An
+    // rgba() or 8-digit value would silently produce a garbage colour.
+    expect(main).toContain("colors.fg}0d");
+    for (const block of [rootBlock, darkAttrBlock, darkMediaBlock]) {
+      const value = tokenValue("--fg", block);
+      expect(value).toMatch(/^#[0-9a-f]{6}$/i);
+    }
   });
 
   test("fill-grade colours are never used as text", () => {

--- a/test/ui-theme-tokens.test.ts
+++ b/test/ui-theme-tokens.test.ts
@@ -61,8 +61,14 @@ describe("theme tokens", () => {
     const darkNames = new Set(
       declarations(darkAttrBlock).map((declaration) => declaration.split(":")[0]),
     );
-    // --dosu is brand-locked and intentionally identical across themes.
-    const brandLocked = new Set(["--dosu", "--dosu-strong", "--claude", "--claude-strong"]);
+    // Brand colours are intentionally identical across themes.
+    const brandLocked = new Set([
+      "--dosu",
+      "--dosu-mid",
+      "--dosu-strong",
+      "--claude",
+      "--claude-strong",
+    ]);
     for (const name of lightNames) {
       if (brandLocked.has(name)) {
         continue;

--- a/test/ui-theme-tokens.test.ts
+++ b/test/ui-theme-tokens.test.ts
@@ -59,15 +59,25 @@ describe("theme tokens", () => {
     // A token defined in light but forgotten in dark inherits the light value and
     // renders cream-on-cream. Font/radius tokens are theme-independent by design.
     const themeIndependent = /^--(font|radius)-/;
+    // Fully derived: each is color-mix() of two other tokens with no literal of
+    // its own, so it rethemes through --fg and needs no dark counterpart.
+    //
+    // Listed by name rather than sniffed for "var(", because a token can
+    // reference another token AND still carry a theme-specific literal of its
+    // own — a shadow built as `rgba(var(--shade-rgb), 0.05)` needs a dark
+    // override for the alpha, and a blanket var() exclusion would quietly stop
+    // requiring it.
+    const derived = new Set([
+      "--accent-text",
+      "--success-text",
+      "--warning-text",
+      "--danger-text",
+      "--info-text",
+      "--claude-text",
+    ]);
     const lightNames = declarations(rootBlock)
-      .filter((declaration) => {
-        const [name, value] = [declaration.split(":")[0] ?? "", declaration.split(": ")[1] ?? ""];
-        // A token built out of other tokens rethemes through them — --accent-text
-        // follows --accent and --fg on its own, so pinning it in dark as well
-        // would be two places to forget instead of one.
-        return !themeIndependent.test(name) && !value.includes("var(");
-      })
-      .map((declaration) => declaration.split(":")[0] ?? "");
+      .map((declaration) => declaration.split(":")[0] ?? "")
+      .filter((name) => !themeIndependent.test(name) && !derived.has(name));
     const darkNames = new Set(
       declarations(darkAttrBlock).map((declaration) => declaration.split(":")[0]),
     );

--- a/test/ui-theme-tokens.test.ts
+++ b/test/ui-theme-tokens.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const styles = readFileSync(join(root, "src", "ui", "styles.css"), "utf8");
+const main = readFileSync(join(root, "src", "ui", "main.tsx"), "utf8");
+
+/** Token names `chartColors()` hands to ECharts. Kept in sync with main.tsx by
+ * the first test below rather than by hope. */
+const CHART_TOKENS = [
+  "--fg",
+  "--muted",
+  "--faint",
+  "--line",
+  "--surface",
+  "--accent",
+  "--info",
+  "--success",
+  "--warning",
+] as const;
+
+/** Every `--name: value` pair inside a block, indentation normalized away. */
+function declarations(block: string): string[] {
+  return [...block.matchAll(/^\s*(--[a-z0-9-]+):\s*([^;]+);/gim)].map(
+    (match) => `${match[1]}: ${match[2]?.replace(/\s+/g, " ").trim()}`,
+  );
+}
+
+function blockAfter(marker: string, closer: string): string {
+  const start = styles.indexOf(marker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = styles.indexOf(closer, start + marker.length);
+  expect(end).toBeGreaterThan(start);
+  return styles.slice(start, end);
+}
+
+const rootBlock = blockAfter(":root {\n  color-scheme: light;", "\n}");
+const darkMediaBlock = blockAfter(":root:not([data-theme]) {\n    color-scheme: dark;", "\n  }");
+const darkAttrBlock = blockAfter('[data-theme="dark"] {\n  color-scheme: dark;', "\n}");
+
+describe("theme tokens", () => {
+  test("the two dark blocks stay identical", () => {
+    // CSS cannot share declarations between a media query and an attribute
+    // selector, so dark is deliberately written twice. Drift between the copies
+    // shows up only as "dark mode looks subtly wrong on one machine", which is
+    // exactly the bug nobody files.
+    const fromMedia = declarations(darkMediaBlock);
+    const fromAttribute = declarations(darkAttrBlock);
+    expect(fromMedia.length).toBeGreaterThan(10);
+    expect(fromAttribute).toEqual(fromMedia);
+  });
+
+  test("dark overrides every themed token light defines", () => {
+    // A token defined in light but forgotten in dark inherits the light value and
+    // renders cream-on-cream. Font/radius tokens are theme-independent by design.
+    const themeIndependent = /^--(font|radius)-/;
+    const lightNames = declarations(rootBlock)
+      .map((declaration) => declaration.split(":")[0] ?? "")
+      .filter((name) => !themeIndependent.test(name));
+    const darkNames = new Set(
+      declarations(darkAttrBlock).map((declaration) => declaration.split(":")[0]),
+    );
+    // --dosu is brand-locked and intentionally identical across themes.
+    const brandLocked = new Set(["--dosu", "--dosu-strong", "--claude", "--claude-strong"]);
+    for (const name of lightNames) {
+      if (brandLocked.has(name)) {
+        continue;
+      }
+      expect(darkNames).toContain(name);
+    }
+  });
+
+  test("chart tokens match what chartColors() actually reads", () => {
+    // If someone adds a tenth read in main.tsx, this list — and the two rules
+    // below it — need to grow with it.
+    const readNames = [...main.matchAll(/value\("(--[a-z-]+)"\)/g)].flatMap(
+      (match) => match[1] ?? [],
+    );
+    expect(readNames.sort()).toEqual([...CHART_TOKENS].sort());
+  });
+
+  test.each([...CHART_TOKENS])("%s stays parseable by zrender", (token) => {
+    // ECharts receives these as raw strings, and zrender's parser
+    // (zrender/lib/tool/color.js) understands only hex and comma-separated
+    // rgb()/rgba()/hsl(). Anything else silently resolves to black or nothing,
+    // which shows up as blank axes rather than an error.
+    //
+    // 8-digit hex is deliberately allowed: zrender handles it (color.js checks
+    // `strLen === 7 || strLen === 9`), and Bun's minifier rewrites our literal
+    // rgba() into it anyway, so banning it here would fail on a non-problem.
+    const pattern = new RegExp(`^\\s*${token}:\\s*([^;]+);`, "gim");
+    const values = [...styles.matchAll(pattern)].flatMap((match) => match[1] ?? []);
+    expect(values.length).toBeGreaterThan(0);
+    for (const value of values) {
+      expect(value).not.toContain("var(");
+      expect(value).not.toContain("color-mix(");
+      // Space/slash syntax: zrender splits on commas, so `rgb(0 0 0 / 50%)`
+      // arrives as a single unparseable param and renders black.
+      expect(value).not.toContain("/");
+    }
+  });
+});


### PR DESCRIPTION
Restyles the web UI to the design from marketing/art ([Dosu x Venice](https://www.figma.com/design/dtIItVbVbAU5KMDr127ieB/Dosu-x-Venice--Copy-)): a warm cream canvas, serif display titles, uppercase tracked mono labels, pill controls, and lime/pink chart accents.

Fourteen small commits, each independently reviewable and green. Mostly CSS — the existing markup was already the right shape, which is what kept this tractable against an 11k-line `main.tsx`.

## Scope

Token layer, app shell, shared primitives, and the two designed pages (Analytics, Sessions). Every other view inherits the new look through the shared components; none was individually redesigned.

## Decisions worth reviewing

**Fonts substituted.** The design specifies PP Mondwest and Aeonik Mono, both commercial. This uses the OFL faces already vendored for the export report — Source Serif 4 and IBM Plex Mono — so no new assets and no licensing. Bun inlines them as data URIs; the `url()`s must stay relative, because a root-relative `/fonts/…` path builds fine under `bun run dev` and then fails `scripts/build-binaries.ts` outright.

**Dark mode is derived, not designed.** The Figma file ships no dark palette, so dark is my invention in the same spirit as light. It wants a design pass before release. Light and dark are pinned byte-identical across the two blocks CSS forces us to duplicate, with a test to keep them from drifting.

**Contrast needed real work.** The design's accents are fill-grade — tuned for chart series and badge fills. As `color:` on cream they measure 2.08–4.24:1, so the repalette had quietly regressed text contrast across 45 declarations. Each accent gained a `-text` variant pulled toward `--fg` by the smallest amount clearing 4.5:1 in *both* themes; worst case is now 4.53:1. The focus ring was 2px of pink at 2.18:1, under the 3:1 a focus indicator needs.

## Performance

ECharts (~1.1MB) was a top-level import, so its module init ran on all eight routes though only two draw charts. Both call sites now `import()` it.

Being precise: Bun's HTMLBundle does not split chunks in a compiled binary, so the bytes still ship. What changes is *execution* — Bun compiles the dynamic import to a lazy `__esm` factory, so the library's top-level work no longer happens on Settings, Search, Files, Projects, Insights or Sessions. `bun build --splitting` does emit it as its own 1.18MB chunk, so a serve path that enables splitting gets the download win for free.

## Bugs found and fixed along the way

- `--accent-soft` and `--font-mono` were referenced while undefined, so the active command-palette row had no background and one code block rendered in Inter
- The dark button bevel put a white highlight on a near-white button
- `--fg-quaternary`, `--on-accent` and `--shadow-card` ended up with no consumers and were removed
- The badge's new border widened the skeleton-vs-real row gap into a visible jolt on load
- The date range read "All time" twice once the button was renamed

## Test integrity

**No pre-existing test was modified** — all 281 added lines are new files, so every one of the ~350 existing assertions still passes untouched.

Four new test files guard the silent-failure paths this branch introduces: that the nine tokens `chartColors()` feeds ECharts stay parseable by zrender and never get renamed; that the two dark blocks stay identical; that fill-grade colours are never used as text; that fonts are bundled rather than fetched; and that ECharts is only reached dynamically. The token test was mutation-tested — deleting a dark override fails it.

## Verification

`just check` green (901 pass, tsc, biome). Native binary built and confirmed to serve all nine routes with fonts embedded and the palette live. Analytics reviewed visually in both themes: charts render with correct axes, so the token values reach zrender intact.

## Follow-ups for the design team

- The serif ships Semibold only, so titles are heavier than the specified 400
- `--faint`, the design's `fg/tertiary`, is 2.96:1 and fails AA across 53 labels — pre-existing, the old theme was 2.6:1
- The brand mark is a raster PNG drawn for a dark background and now sits on cream
- 38 of the design's pixel icons are undrawn, so this keeps lucide

🤖 Generated with [Claude Code](https://claude.com/claude-code)