### PR TITLE
fix(ui): speed up the Tools and MCP page and fix the tool call detail panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,10 +123,10 @@ A change is ready when:
 4. **Costs are computed at ingest** with `cost::estimateCost` and stored on the
    session row. Editing pricing does not rewrite historical rows; rebuild the
    archive to recompute.
-5. **The schema baseline is v22.** Pre-v8 archives are intentionally rebuild-only:
+5. **The schema baseline is v23.** Pre-v8 archives are intentionally rebuild-only:
    delete the archive and re-ingest from the source directories. Do not add
    broad forward migrations unless that product decision changes; the narrow
-   v8-to-v22 migrations preserve existing TypeScript-cutover archives.
+   v8-to-v23 migrations preserve existing TypeScript-cutover archives.
    `ingest_source.ingest_revision` is the parser/enrichment checkpoint: bump
    `INGEST_PIPELINE_REVISION` whenever unchanged sources must be re-derived so
    the next sync backfills them once and later syncs remain idempotent. A

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,10 @@ A change is ready when:
 - Commits: Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, `test:`,
   scope optional). Sign commits when the environment supports it.
 - Prefer surrounding code style, narrow changes, and focused tests.
+- Comments default to none. A comment earns its place by explaining why the
+  code is the way it is, never what it does. Investigation notes, benchmark
+  numbers, and the history of a change belong in the PR description or in the
+  Dosu knowledge library, not above the code.
 - Branch off `main`; open a PR. CI must be green.
 - Install hooks once with `pre-commit install` if you use pre-commit locally.
 

--- a/README.md
+++ b/README.md
@@ -183,8 +183,10 @@ means no gateway is derived.
 deliberately want other hosts in: the `Host` header check is not an access
 control for non-browser clients, which can send `Host: localhost` freely.
 
-Archives older than schema v8 are rebuild-only. v8 through v21 archives migrate
-forward to v22 on open. Schema v22 tracks the ingest-pipeline revision for every
+Archives older than schema v8 are rebuild-only. v8 through v22 archives migrate
+forward to v23 on open. Schema v23 indexes tool calls in the order the Tools and
+MCP page pages through them, so that page stops scanning the whole table to
+return fifty rows. Schema v22 tracks the ingest-pipeline revision for every
 source: when parser or enrichment behavior advances, the next `decant sync`
 transactionally re-ingests each unchanged stale source once, and later syncs
 skip it again. Existing archives therefore backfill new derived data without a

--- a/src/db.ts
+++ b/src/db.ts
@@ -730,17 +730,22 @@ function migrate(db: Database, current: number): void {
       // after 50, so the message lookups fall from 20k to 50 and the sort
       // disappears. test/db.test.ts asserts that plan.
       //
-      // What this is and is not worth, measured rather than assumed. At the query
-      // level, on two copies of one 20k-call archive with the index present on
-      // only one, it runs 1.6x to 2.8x faster. End to end over HTTP with the page
-      // cache warm it is a wash: median first-hit latency was 59 ms without and
-      // 68 ms with, across nine server restarts each, so per-request overhead
-      // swamps the difference at this size.
+      // What this is worth depends on the size of the archive, so the number
+      // moves. On a 20k-call archive the query-level win is 1.6x to 2.8x and
+      // end to end over HTTP it is a wash. On a 57k-call, 3 GB archive it is
+      // not. Without the index the plan sorts every matching row through a
+      // temp b-tree while carrying `t.input`, so dropping and recreating the
+      // index on one copy of that archive measured tens of seconds without it
+      // against single-digit milliseconds with it, and `/api/tools/calls` at
+      // offset 50 went from 0.6-1.4 s to a steady 0.12 s.
       //
       // It is kept because the work it removes grows with the table while the
-      // work it adds does not, so the margin widens as an archive does. It is not
-      // the fix for a slow-feeling first load; see the note on bundle size in the
-      // pull request that added this.
+      // work it adds does not, so the margin widens as an archive does. It is
+      // not the whole fix for a slow first load. listToolCalls also runs its
+      // summary CTE whenever offset is 0, and that aggregates the entire
+      // filtered join through window functions no index on tool_call can
+      // serve, which costs tens of seconds on a 57k-call archive against
+      // milliseconds for the row query beside it.
       if (hasTable(db, "tool_call")) {
         db.exec(
           "CREATE INDEX IF NOT EXISTS idx_toolcall_timestamp ON tool_call(timestamp DESC, id DESC)",

--- a/src/db.ts
+++ b/src/db.ts
@@ -724,17 +724,23 @@ function migrate(db: Database, current: number): void {
     if (current < 23) {
       // listToolCalls orders by (timestamp DESC, id DESC) and takes a page of 50.
       // Without an index in that order SQLite joins every tool call to session,
-      // project and message, then sorts the whole result in a temp b-tree to
-      // discard all but 50 rows. On a 669 MB archive with 20k tool calls the
-      // first request for the Tools & MCP page measured 705 ms, because each of
-      // those 20k rows also drew a random `message` row for its `seq`.
+      // project and message, then sorts the whole result in a temp b-tree and
+      // discards all but 50 rows, drawing a random `message` row per call for its
+      // `seq` on the way. With the index it walks tool_call in order and stops
+      // after 50, so the message lookups fall from 20k to 50 and the sort
+      // disappears. test/db.test.ts asserts that plan.
       //
-      // With the index SQLite walks tool_call in order and stops after 50, so
-      // the message lookups fall from 20k to 50 and the temp b-tree disappears.
-      // Measured on two copies of the same 20k-call archive, one with the index
-      // dropped, both on raw connections so no migration could blur the two:
-      // every page got faster, by 1.6x at offset 0 to 2.8x at offset 1000, and
-      // the errors-only view by 1.6x. Nothing measured slower.
+      // What this is and is not worth, measured rather than assumed. At the query
+      // level, on two copies of one 20k-call archive with the index present on
+      // only one, it runs 1.6x to 2.8x faster. End to end over HTTP with the page
+      // cache warm it is a wash: median first-hit latency was 59 ms without and
+      // 68 ms with, across nine server restarts each, so per-request overhead
+      // swamps the difference at this size.
+      //
+      // It is kept because the work it removes grows with the table while the
+      // work it adds does not, so the margin widens as an archive does. It is not
+      // the fix for a slow-feeling first load; see the note on bundle size in the
+      // pull request that added this.
       if (hasTable(db, "tool_call")) {
         db.exec(
           "CREATE INDEX IF NOT EXISTS idx_toolcall_timestamp ON tool_call(timestamp DESC, id DESC)",

--- a/src/db.ts
+++ b/src/db.ts
@@ -21,7 +21,7 @@ import {
 /// effective DDL with migrations 1..LATEST_SCHEMA_VERSION already applied
 /// and is now the frozen baseline, so a fresh archive is created in one step
 /// and stamped with the full migration history.
-export const LATEST_SCHEMA_VERSION = 22;
+export const LATEST_SCHEMA_VERSION = 23;
 
 const logger = getDecantLogger("db");
 let expectedSchemaManifest: SchemaManifest | null = null;
@@ -719,6 +719,29 @@ function migrate(db: Database, current: number): void {
       }
       db.query(
         "INSERT INTO schema_migrations (version, applied_at) VALUES (22, datetime('now'))",
+      ).run();
+    }
+    if (current < 23) {
+      // listToolCalls orders by (timestamp DESC, id DESC) and takes a page of 50.
+      // Without an index in that order SQLite joins every tool call to session,
+      // project and message, then sorts the whole result in a temp b-tree to
+      // discard all but 50 rows. On a 669 MB archive with 20k tool calls the
+      // first request for the Tools & MCP page measured 705 ms, because each of
+      // those 20k rows also drew a random `message` row for its `seq`.
+      //
+      // With the index SQLite walks tool_call in order and stops after 50, so
+      // the message lookups fall from 20k to 50 and the temp b-tree disappears.
+      // Measured on two copies of the same 20k-call archive, one with the index
+      // dropped, both on raw connections so no migration could blur the two:
+      // every page got faster, by 1.6x at offset 0 to 2.8x at offset 1000, and
+      // the errors-only view by 1.6x. Nothing measured slower.
+      if (hasTable(db, "tool_call")) {
+        db.exec(
+          "CREATE INDEX IF NOT EXISTS idx_toolcall_timestamp ON tool_call(timestamp DESC, id DESC)",
+        );
+      }
+      db.query(
+        "INSERT INTO schema_migrations (version, applied_at) VALUES (23, datetime('now'))",
       ).run();
     }
     assertSchemaMatchesBaseline(db);

--- a/src/db.ts
+++ b/src/db.ts
@@ -722,30 +722,8 @@ function migrate(db: Database, current: number): void {
       ).run();
     }
     if (current < 23) {
-      // listToolCalls orders by (timestamp DESC, id DESC) and takes a page of 50.
-      // Without an index in that order SQLite joins every tool call to session,
-      // project and message, then sorts the whole result in a temp b-tree and
-      // discards all but 50 rows, drawing a random `message` row per call for its
-      // `seq` on the way. With the index it walks tool_call in order and stops
-      // after 50, so the message lookups fall from 20k to 50 and the sort
-      // disappears. test/db.test.ts asserts that plan.
-      //
-      // What this is worth depends on the size of the archive, so the number
-      // moves. On a 20k-call archive the query-level win is 1.6x to 2.8x and
-      // end to end over HTTP it is a wash. On a 57k-call, 3 GB archive it is
-      // not. Without the index the plan sorts every matching row through a
-      // temp b-tree while carrying `t.input`, so dropping and recreating the
-      // index on one copy of that archive measured tens of seconds without it
-      // against single-digit milliseconds with it, and `/api/tools/calls` at
-      // offset 50 went from 0.6-1.4 s to a steady 0.12 s.
-      //
-      // It is kept because the work it removes grows with the table while the
-      // work it adds does not, so the margin widens as an archive does. It is
-      // not the whole fix for a slow first load. listToolCalls also runs its
-      // summary CTE whenever offset is 0, and that aggregates the entire
-      // filtered join through window functions no index on tool_call can
-      // serve, which costs tens of seconds on a 57k-call archive against
-      // milliseconds for the row query beside it.
+      // Serves listToolCalls's ORDER BY so a page of 50 stops sorting the whole
+      // table. test/db.test.ts asserts the plan.
       if (hasTable(db, "tool_call")) {
         db.exec(
           "CREATE INDEX IF NOT EXISTS idx_toolcall_timestamp ON tool_call(timestamp DESC, id DESC)",

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -2,8 +2,7 @@
 -- Effective decant schema (migrations 1..23 applied), frozen as the current
 -- baseline. v22 adds the ingest pipeline revision checkpoint so parser and
 -- enrichment changes can reprocess existing sources automatically once. v23
--- indexes tool_call in the order the tool-call list pages through, so that page
--- stops scanning the whole table to return fifty rows.
+-- indexes tool_call in the order the tool-call list pages through.
 -- Do not edit without updating schema tests.
 CREATE TABLE schema_migrations(
             version INTEGER PRIMARY KEY,

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1,7 +1,9 @@
--- decant:schema_version=22
--- Effective decant schema (migrations 1..22 applied), frozen as the current
+-- decant:schema_version=23
+-- Effective decant schema (migrations 1..23 applied), frozen as the current
 -- baseline. v22 adds the ingest pipeline revision checkpoint so parser and
--- enrichment changes can reprocess existing sources automatically once.
+-- enrichment changes can reprocess existing sources automatically once. v23
+-- indexes tool_call in the order the tool-call list pages through, so that page
+-- stops scanning the whole table to return fifty rows.
 -- Do not edit without updating schema tests.
 CREATE TABLE schema_migrations(
             version INTEGER PRIMARY KEY,
@@ -229,6 +231,7 @@ CREATE INDEX idx_toolcall_result_block ON tool_call(result_block_id);
 CREATE INDEX idx_fileref_message ON file_ref(message_id);
 CREATE INDEX idx_ingest_source_session ON ingest_source(session_id);
 CREATE INDEX idx_ingest_issue_source ON ingest_issue(source_path);
+CREATE INDEX idx_toolcall_timestamp ON tool_call(timestamp DESC, id DESC);
 CREATE VIRTUAL TABLE block_fts USING fts5(
   text, tool_name, tool_input,
   content='block', content_rowid='id',

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -69,16 +69,7 @@ export function previewHeadTail(s: string, max: number): string {
   return `${head}\n[… ${omitted} chars omitted …]\n${tail}`;
 }
 
-/** Recognizes the marker `previewHeadTail` leaves behind, capturing the omitted
- * count.
- *
- * Callers need this to tell a complete value from an elided one. The elision
- * lands in the middle of the string, so an elided JSON payload no longer parses,
- * and a reader offered a "pretty" view of one is being shown raw text with no
- * indication of why. The UI uses this to say so instead.
- *
- * Kept beside the function that writes the marker, and pinned to it by a test,
- * because the two drifting apart fails silently in exactly that direction. */
+/** Must track the marker `previewHeadTail` writes; a drift fails silently. */
 export const PREVIEW_ELISION = /\n\[… (\d+) chars omitted …\]\n/;
 
 /** Scalars omitted from the middle of a preview, or null if it is complete. */

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -68,3 +68,24 @@ export function previewHeadTail(s: string, max: number): string {
   const tail = tailLen === 0 ? "" : [...s.slice(-tailLen * 2)].slice(-tailLen).join("");
   return `${head}\n[… ${omitted} chars omitted …]\n${tail}`;
 }
+
+/** Recognizes the marker `previewHeadTail` leaves behind, capturing the omitted
+ * count.
+ *
+ * Callers need this to tell a complete value from an elided one. The elision
+ * lands in the middle of the string, so an elided JSON payload no longer parses,
+ * and a reader offered a "pretty" view of one is being shown raw text with no
+ * indication of why. The UI uses this to say so instead.
+ *
+ * Kept beside the function that writes the marker, and pinned to it by a test,
+ * because the two drifting apart fails silently in exactly that direction. */
+export const PREVIEW_ELISION = /\n\[… (\d+) chars omitted …\]\n/;
+
+/** Scalars omitted from the middle of a preview, or null if it is complete. */
+export function previewOmittedCount(value: string | null | undefined): number | null {
+  if (value == null) {
+    return null;
+  }
+  const match = PREVIEW_ELISION.exec(value);
+  return match?.[1] == null ? null : Number(match[1]);
+}

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -6844,8 +6844,8 @@ function ToolValueElision({ value }: { value: string | null }) {
     <p className="tool-detail-elision">
       <Icon name="minus" />
       <span>
-        Middle elided, {formatInt(omitted)} characters omitted. Too long to reformat — open the
-        transcript for the whole value.
+        Middle elided, {formatInt(omitted)} characters omitted. Open the transcript for the whole
+        value.
       </span>
     </p>
   );

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -6828,13 +6828,8 @@ function prettyToolValue(value: string | null): string {
   }
 }
 
-/** The note shown above an elided value.
- *
- * Previews are stored head-and-tail with the middle elided, so any value over
- * the preview budget cannot parse as JSON and Preview silently renders the same
- * raw text as Raw. On a real archive that is 3,285 of 20,053 tool calls, and
- * they are the large ones, so it is exactly the calls worth opening that look
- * broken. Saying so beats appearing to have formatted something. */
+/** An elided value cannot parse as JSON, so Preview would silently render the
+ * same raw text as Raw with nothing explaining why. */
 function ToolValueElision({ value }: { value: string | null }) {
   const omitted = previewOmittedCount(value);
   if (omitted == null) {

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -64,6 +64,7 @@ import {
 } from "react";
 import { createPortal, flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
+import { previewOmittedCount } from "../tools.ts";
 import { ApiError, getJson } from "./api.ts";
 import dosuDecantUrl from "./assets/dosu-decant.png";
 import dosuOfficialUrl from "./assets/dosu-official.svg";
@@ -6827,6 +6828,29 @@ function prettyToolValue(value: string | null): string {
   }
 }
 
+/** The note shown above an elided value.
+ *
+ * Previews are stored head-and-tail with the middle elided, so any value over
+ * the preview budget cannot parse as JSON and Preview silently renders the same
+ * raw text as Raw. On a real archive that is 3,285 of 20,053 tool calls, and
+ * they are the large ones, so it is exactly the calls worth opening that look
+ * broken. Saying so beats appearing to have formatted something. */
+function ToolValueElision({ value }: { value: string | null }) {
+  const omitted = previewOmittedCount(value);
+  if (omitted == null) {
+    return null;
+  }
+  return (
+    <p className="tool-detail-elision">
+      <Icon name="minus" />
+      <span>
+        Middle elided, {formatInt(omitted)} characters omitted. Too long to reformat — open the
+        transcript for the whole value.
+      </span>
+    </p>
+  );
+}
+
 function ToolCallStatus({ call }: { call: ToolCallRow }) {
   const status = toolCallStatus(call.is_error);
   const badge = (
@@ -6921,7 +6945,7 @@ function ToolCallDetail({
         tabIndex={-1}
       >
         <header>
-          <div>
+          <div className="tool-detail-heading">
             <span className="section-eyebrow" title={call.mcp_server ?? undefined}>
               {serverLabel || call.tool_kind || "Tool call"}
             </span>
@@ -6974,12 +6998,14 @@ function ToolCallDetail({
         <div className="tool-detail-content">
           <section>
             <h3>Input</h3>
+            <ToolValueElision value={call.input_preview} />
             <pre>
               {tab === "raw" ? (call.input_preview ?? "") : prettyToolValue(call.input_preview)}
             </pre>
           </section>
           <section>
             <h3>{call.is_error === true ? "Error output" : "Output preview"}</h3>
+            <ToolValueElision value={call.output_preview} />
             <pre>
               {tab === "raw" ? (call.output_preview ?? "") : prettyToolValue(call.output_preview)}
             </pre>

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1817,9 +1817,44 @@ table {
   background: var(--surface);
 }
 
+/* A flex item defaults to min-width: auto, so this column refuses to shrink
+ * below its content and pushes the close button out of the panel. MCP tool names
+ * reach 60 characters of underscore-joined text
+ * (mcp__codex_apps__google_drive___get_document_paragraph_range), which is wider
+ * than the 38rem panel at 20px and has no space to wrap at.
+ *
+ * Carries its own class rather than being matched as `header > div`: that form
+ * outranks the plain `> div` rules further down this file and trips
+ * noDescendingSpecificity. */
+.tool-detail-heading {
+  min-width: 0;
+}
+
 .tool-detail-panel > header h2 {
   margin: 3px 0 0;
   font-size: 20px;
+  /* `anywhere` rather than break-word: it also lets the intrinsic minimum
+   * shrink, which is what actually stops the header blowing out. */
+  overflow-wrap: anywhere;
+}
+
+/* Sits between the heading and the value, so the reason the value looks
+ * unformatted is visible before the value is read. */
+.tool-detail-elision {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.tool-detail-elision svg {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+  margin-top: 2px;
 }
 
 .tool-detail-meta {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1817,15 +1817,8 @@ table {
   background: var(--surface);
 }
 
-/* A flex item defaults to min-width: auto, so this column refuses to shrink
- * below its content and pushes the close button out of the panel. MCP tool names
- * reach 60 characters of underscore-joined text
- * (mcp__codex_apps__google_drive___get_document_paragraph_range), which is wider
- * than the 38rem panel at 20px and has no space to wrap at.
- *
- * Carries its own class rather than being matched as `header > div`: that form
- * outranks the plain `> div` rules further down this file and trips
- * noDescendingSpecificity. */
+/* Load-bearing: a flex item defaults to min-width: auto, so without this a long
+ * MCP tool name pushes the close button out of the panel. */
 .tool-detail-heading {
   min-width: 0;
 }
@@ -1833,13 +1826,9 @@ table {
 .tool-detail-panel > header h2 {
   margin: 3px 0 0;
   font-size: 20px;
-  /* `anywhere` rather than break-word: it also lets the intrinsic minimum
-   * shrink, which is what actually stops the header blowing out. */
   overflow-wrap: anywhere;
 }
 
-/* Sits between the heading and the value, so the reason the value looks
- * unformatted is visible before the value is read. */
 .tool-detail-elision {
   display: flex;
   align-items: flex-start;

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -118,7 +118,7 @@ const BASELINE_TABLES = [
   "tool_call",
 ];
 const BASELINE_TRIGGERS = ["block_ad", "block_ai", "block_au"];
-const BASELINE_INDEX_COUNT = 26;
+const BASELINE_INDEX_COUNT = 27;
 
 function inventory(db: Database, type: string): string[] {
   return (
@@ -219,6 +219,54 @@ describe("openDb", () => {
         .get(),
     ).toEqual({ ingest_revision: 0 });
     migrated.close();
+  });
+
+  test("adds the tool-call paging index when upgrading a v22 archive", () => {
+    // listToolCalls orders by (timestamp DESC, id DESC). Without this index
+    // SQLite sorts every tool call in a temp b-tree to return a page of fifty,
+    // drawing a random `message` row per call on the way, which is what made the
+    // first load of the Tools & MCP page take most of a second.
+    const path = freshPath();
+    const legacy = openDb(path);
+    legacy.exec("DROP INDEX IF EXISTS idx_toolcall_timestamp");
+    legacy.exec("DELETE FROM schema_migrations WHERE version > 22");
+    legacy.close();
+
+    const migrated = openDb(path);
+    const index = migrated
+      .query(
+        "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_toolcall_timestamp'",
+      )
+      .get() as { sql: string } | null;
+    expect(index).not.toBeNull();
+    expect(index?.sql).toContain("timestamp DESC");
+    expect(index?.sql).toContain("id DESC");
+    migrated.close();
+  });
+
+  test("serves the tool-call page order from an index rather than a sort", () => {
+    // The point of the index is the query plan, so assert the plan. A rename or a
+    // reordered ORDER BY would leave the index in place and silently stop using
+    // it, which no row-count or timing assertion would catch.
+    const db = openDb(freshPath());
+    const plan = (
+      db
+        .query(
+          `EXPLAIN QUERY PLAN
+           SELECT t.id, m.seq
+           FROM tool_call t
+           JOIN session s ON s.id = t.session_id
+           LEFT JOIN message m ON m.id = t.message_id
+           ORDER BY t.timestamp DESC, t.id DESC
+           LIMIT 50`,
+        )
+        .all() as { detail: string }[]
+    )
+      .map((row) => row.detail)
+      .join("\n");
+    expect(plan).toContain("idx_toolcall_timestamp");
+    expect(plan).not.toContain("TEMP B-TREE");
+    db.close();
   });
 
   test("creates durable user state keyed by source identity", () => {

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -224,13 +224,12 @@ describe("openDb", () => {
   test("adds the tool-call paging index when upgrading a v22 archive", () => {
     // listToolCalls orders by (timestamp DESC, id DESC). Without this index
     // SQLite sorts every tool call in a temp b-tree to return a page of fifty,
-    // drawing a random `message` row per call on the way, which is what made the
-    // first load of the Tools & MCP page take most of a second.
+    // drawing a random `message` row per call on the way.
     const path = freshPath();
     const legacy = openDb(path);
     legacy.exec("DROP INDEX IF EXISTS idx_toolcall_timestamp");
     legacy.exec("DELETE FROM schema_migrations WHERE version > 22");
-    legacy.close();
+    closeDb(legacy);
 
     const migrated = openDb(path);
     const index = migrated
@@ -241,7 +240,7 @@ describe("openDb", () => {
     expect(index).not.toBeNull();
     expect(index?.sql).toContain("timestamp DESC");
     expect(index?.sql).toContain("id DESC");
-    migrated.close();
+    closeDb(migrated);
   });
 
   test("serves the tool-call page order from an index rather than a sort", () => {
@@ -266,7 +265,7 @@ describe("openDb", () => {
       .join("\n");
     expect(plan).toContain("idx_toolcall_timestamp");
     expect(plan).not.toContain("TEMP B-TREE");
-    db.close();
+    closeDb(db);
   });
 
   test("creates durable user state keyed by source identity", () => {

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -254,9 +254,16 @@ describe("openDb", () => {
     // query: an unfiltered SELECT would also pick the index, but listToolCalls
     // never runs one. It always applies the visibility and user-state predicates,
     // and those filter `session` while the ORDER BY reads `tool_call`, which is
-    // exactly the shape that could push SQLite back to a temp b-tree. Asserting
-    // the real shape means a future predicate change cannot regress the plan with
-    // this test still green.
+    // exactly the shape that could push SQLite back to a temp b-tree.
+    //
+    // This covers that shape, not every shape listToolCalls can produce. Adding
+    // `t.tool_name = ?` or `p.path = ?` drops this same index for a temp b-tree
+    // again, in favor of the narrower index those filters can use instead — not a
+    // regression today (idx_toolcall_name narrows first, so it stays fast), but
+    // this test would not catch one there. It also runs against an empty table,
+    // so the planner is choosing from default estimates rather than real
+    // cardinality; that happens to agree with a populated archive, but isn't
+    // guaranteed to in general.
     const db = openDb(freshPath());
     const where = [
       visibleSessionPredicate("s"),

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -246,24 +246,8 @@ describe("openDb", () => {
   });
 
   test("serves the tool-call page order from an index rather than a sort", () => {
-    // The point of the index is the query plan, so assert the plan. A rename or a
-    // reordered ORDER BY would leave the index in place and silently stop using
-    // it, which no row-count or timing assertion would catch.
-    //
-    // Built from the same predicate helpers listToolCalls uses, not a hand-copied
-    // query: an unfiltered SELECT would also pick the index, but listToolCalls
-    // never runs one. It always applies the visibility and user-state predicates,
-    // and those filter `session` while the ORDER BY reads `tool_call`, which is
-    // exactly the shape that could push SQLite back to a temp b-tree.
-    //
-    // This covers that shape, not every shape listToolCalls can produce. Adding
-    // `t.tool_name = ?` or `p.path = ?` drops this same index for a temp b-tree
-    // again, in favor of the narrower index those filters can use instead — not a
-    // regression today (idx_toolcall_name narrows first, so it stays fast), but
-    // this test would not catch one there. It also runs against an empty table,
-    // so the planner is choosing from default estimates rather than real
-    // cardinality; that happens to agree with a populated archive, but isn't
-    // guaranteed to in general.
+    // Covers the unfiltered shape only; a tool_name or project filter picks a
+    // different index.
     const db = openDb(freshPath());
     const where = [
       visibleSessionPredicate("s"),

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -24,6 +24,8 @@ import {
 import { configureLogging } from "../src/logging.ts";
 import schemaSql from "../src/schema.sql" with { type: "text" };
 import { buildSchemaManifest } from "../src/schema-manifest.ts";
+import { sessionUserStatePredicateForDatabase } from "../src/session-user-state.ts";
+import { visibleSessionPredicate } from "../src/session-visibility.ts";
 import schemaV8Sql from "./fixtures/schema-v8.sql" with { type: "text" };
 
 const workDir = mkdtempSync(join(tmpdir(), "decant-db-test-"));
@@ -247,15 +249,29 @@ describe("openDb", () => {
     // The point of the index is the query plan, so assert the plan. A rename or a
     // reordered ORDER BY would leave the index in place and silently stop using
     // it, which no row-count or timing assertion would catch.
+    //
+    // Built from the same predicate helpers listToolCalls uses, not a hand-copied
+    // query: an unfiltered SELECT would also pick the index, but listToolCalls
+    // never runs one. It always applies the visibility and user-state predicates,
+    // and those filter `session` while the ORDER BY reads `tool_call`, which is
+    // exactly the shape that could push SQLite back to a temp b-tree. Asserting
+    // the real shape means a future predicate change cannot regress the plan with
+    // this test still green.
     const db = openDb(freshPath());
+    const where = [
+      visibleSessionPredicate("s"),
+      sessionUserStatePredicateForDatabase(db, "s"),
+    ].join(" AND ");
     const plan = (
       db
         .query(
           `EXPLAIN QUERY PLAN
-           SELECT t.id, m.seq
+           SELECT t.id, s.title, p.path, m.seq
            FROM tool_call t
            JOIN session s ON s.id = t.session_id
+           LEFT JOIN project p ON p.id = s.project_id
            LEFT JOIN message m ON m.id = t.message_id
+           WHERE ${where}
            ORDER BY t.timestamp DESC, t.id DESC
            LIMIT 50`,
         )

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { classifyTool, preview, previewHeadTail } from "../src/tools.ts";
+import { classifyTool, preview, previewHeadTail, previewOmittedCount } from "../src/tools.ts";
 
 // Ports tools.rs tests verbatim.
 describe("classifyTool", () => {
@@ -69,5 +69,42 @@ describe("previewHeadTail", () => {
   });
   test("keeps no tail when max is too small for one, without leaking the whole string", () => {
     expect(previewHeadTail("abcdef", 2)).toBe("ab\n[… 4 chars omitted …]\n");
+  });
+});
+
+describe("previewOmittedCount", () => {
+  test("reads back the count previewHeadTail wrote", () => {
+    // The matcher and the writer live in the same file precisely so they cannot
+    // drift; this is what holds them together. A change to the marker format
+    // that forgot the matcher would leave every elided value looking complete,
+    // which is a silent failure in the UI rather than a loud one here.
+    const s = "a".repeat(5000);
+    const out = previewHeadTail(s, 500);
+    expect(previewOmittedCount(out)).toBe(5000 - 500);
+  });
+
+  test("returns null for a complete value", () => {
+    expect(previewOmittedCount("short")).toBeNull();
+    expect(previewOmittedCount(previewHeadTail("short", 500))).toBeNull();
+    // Real tool inputs are JSON; a complete one has to stay parseable, since
+    // that is what lets the detail panel pretty-print it.
+    const json = JSON.stringify({ command: "ls -la" });
+    expect(previewOmittedCount(previewHeadTail(json, 500))).toBeNull();
+    expect(() => JSON.parse(previewHeadTail(json, 500))).not.toThrow();
+  });
+
+  test("handles null and undefined", () => {
+    expect(previewOmittedCount(null)).toBeNull();
+    expect(previewOmittedCount(undefined)).toBeNull();
+  });
+
+  test("flags the elided JSON the detail panel cannot reformat", () => {
+    // The case that made Preview look broken: an oversized JSON payload elides
+    // mid-structure, so JSON.parse fails and Preview renders the same raw text
+    // as Raw with nothing explaining why.
+    const big = JSON.stringify({ file_text: "x".repeat(4000) });
+    const elided = previewHeadTail(big, 500);
+    expect(() => JSON.parse(elided)).toThrow();
+    expect(previewOmittedCount(elided)).toBeGreaterThan(0);
   });
 });

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -74,10 +74,6 @@ describe("previewHeadTail", () => {
 
 describe("previewOmittedCount", () => {
   test("reads back the count previewHeadTail wrote", () => {
-    // The matcher and the writer live in the same file precisely so they cannot
-    // drift; this is what holds them together. A change to the marker format
-    // that forgot the matcher would leave every elided value looking complete,
-    // which is a silent failure in the UI rather than a loud one here.
     const s = "a".repeat(5000);
     const out = previewHeadTail(s, 500);
     expect(previewOmittedCount(out)).toBe(5000 - 500);
@@ -86,8 +82,6 @@ describe("previewOmittedCount", () => {
   test("returns null for a complete value", () => {
     expect(previewOmittedCount("short")).toBeNull();
     expect(previewOmittedCount(previewHeadTail("short", 500))).toBeNull();
-    // Real tool inputs are JSON; a complete one has to stay parseable, since
-    // that is what lets the detail panel pretty-print it.
     const json = JSON.stringify({ command: "ls -la" });
     expect(previewOmittedCount(previewHeadTail(json, 500))).toBeNull();
     expect(() => JSON.parse(previewHeadTail(json, 500))).not.toThrow();
@@ -99,9 +93,6 @@ describe("previewOmittedCount", () => {
   });
 
   test("flags the elided JSON the detail panel cannot reformat", () => {
-    // The case that made Preview look broken: an oversized JSON payload elides
-    // mid-structure, so JSON.parse fails and Preview renders the same raw text
-    // as Raw with nothing explaining why.
     const big = JSON.stringify({ file_text: "x".repeat(4000) });
     const elided = previewHeadTail(big, 500);
     expect(() => JSON.parse(elided)).toThrow();

--- a/test/ui-tools-presentation.test.ts
+++ b/test/ui-tools-presentation.test.ts
@@ -14,6 +14,33 @@ function sourceBetween(source: string, start: string, end: string): string {
 }
 
 describe("Tools and MCP presentation", () => {
+  test("the detail header can shrink so a long MCP tool name cannot push the close button out", () => {
+    // Tool names reach 60 characters of underscore-joined text in a real archive
+    // (mcp__codey_apps__google_drive___get_document_paragraph_range), wider than
+    // the 38rem panel at 20px and with no space to wrap at. A flex item defaults
+    // to min-width: auto, so without these two rules the text column holds its
+    // intrinsic width and the header overflows.
+    const header = sourceBetween(styles, ".tool-detail-heading {", ".tool-detail-elision {");
+    expect(header).toContain("min-width: 0");
+    expect(header).toMatch(/\.tool-detail-panel > header h2 \{[^}]*overflow-wrap: anywhere/s);
+    // The rule is useless unless the element it names is the one that renders.
+    expect(main).toContain('<div className="tool-detail-heading">');
+  });
+
+  test("an elided value says so instead of appearing unformatted", () => {
+    // Previews are stored head-and-tail, so anything over the budget cannot parse
+    // as JSON and the Preview tab renders the same raw text as Raw. Without the
+    // note there is nothing on screen explaining why.
+    const detail = sourceBetween(main, "function ToolValueElision(", "function ToolCallStatus(");
+    expect(detail).toContain("previewOmittedCount");
+    expect(detail).toContain("tool-detail-elision");
+    // Rendered for both panes, not just the input.
+    const panel = sourceBetween(main, "function ToolCallDetail(", "function ToolsView(");
+    expect(panel).toContain("<ToolValueElision value={call.input_preview} />");
+    expect(panel).toContain("<ToolValueElision value={call.output_preview} />");
+    expect(styles).toContain(".tool-detail-elision {");
+  });
+
   test("renders accessible icon-and-text statuses in the table and detail dialog", () => {
     const status = sourceBetween(main, "function ToolCallStatus(", "function DrilldownTableRow(");
     const detail = sourceBetween(main, "function ToolCallDetail(", "function ToolsView(");

--- a/test/ui-tools-presentation.test.ts
+++ b/test/ui-tools-presentation.test.ts
@@ -15,26 +15,16 @@ function sourceBetween(source: string, start: string, end: string): string {
 
 describe("Tools and MCP presentation", () => {
   test("the detail header can shrink so a long MCP tool name cannot push the close button out", () => {
-    // Tool names reach 60 characters of underscore-joined text in a real archive
-    // (mcp__codex_apps__google_drive___get_document_paragraph_range), wider than
-    // the 38rem panel at 20px and with no space to wrap at. A flex item defaults
-    // to min-width: auto, so without these two rules the text column holds its
-    // intrinsic width and the header overflows.
     const header = sourceBetween(styles, ".tool-detail-heading {", ".tool-detail-elision {");
     expect(header).toContain("min-width: 0");
     expect(header).toMatch(/\.tool-detail-panel > header h2 \{[^}]*overflow-wrap: anywhere/s);
-    // The rule is useless unless the element it names is the one that renders.
     expect(main).toContain('<div className="tool-detail-heading">');
   });
 
   test("an elided value says so instead of appearing unformatted", () => {
-    // Previews are stored head-and-tail, so anything over the budget cannot parse
-    // as JSON and the Preview tab renders the same raw text as Raw. Without the
-    // note there is nothing on screen explaining why.
     const detail = sourceBetween(main, "function ToolValueElision(", "function ToolCallStatus(");
     expect(detail).toContain("previewOmittedCount");
     expect(detail).toContain("tool-detail-elision");
-    // Rendered for both panes, not just the input.
     const panel = sourceBetween(main, "function ToolCallDetail(", "function ToolsView(");
     expect(panel).toContain("<ToolValueElision value={call.input_preview} />");
     expect(panel).toContain("<ToolValueElision value={call.output_preview} />");

--- a/test/ui-tools-presentation.test.ts
+++ b/test/ui-tools-presentation.test.ts
@@ -16,7 +16,7 @@ function sourceBetween(source: string, start: string, end: string): string {
 describe("Tools and MCP presentation", () => {
   test("the detail header can shrink so a long MCP tool name cannot push the close button out", () => {
     // Tool names reach 60 characters of underscore-joined text in a real archive
-    // (mcp__codey_apps__google_drive___get_document_paragraph_range), wider than
+    // (mcp__codex_apps__google_drive___get_document_paragraph_range), wider than
     // the 38rem panel at 20px and with no space to wrap at. A flex item defaults
     // to min-width: auto, so without these two rules the text column holds its
     // intrinsic width and the header overflows.


### PR DESCRIPTION
Taylor reported that the Tools & MCP page takes a while to load, and that tool calls opened from near the bottom of it do not look right. Two of the three findings below are solid fixes. The third is a correction to my own first version of this PR.

## 1. The detail header could not shrink

A flex item defaults to `min-width: auto`, so the heading column held its intrinsic width and pushed the close button out of the panel. Real MCP tool names reach 60 characters of underscore-joined text — `mcp__codex_apps__google_drive___get_document_paragraph_range` — which is wider than the 38rem panel at 20px and has nowhere to wrap. That is exactly why it showed on calls near the bottom of the page: those are the MCP ones.

The column now carries `.tool-detail-heading` with `min-width: 0`, and the heading uses `overflow-wrap: anywhere` so it breaks mid-token. It gets a class rather than being matched as `header > div`, which outranks the plain `> div` rules further down the file and trips `noDescendingSpecificity`.

## 2. The Preview tab was silently showing raw text

`previewHeadTail` stores a value as head + `[… N chars omitted …]` + tail. Anything over the budget therefore cannot parse as JSON, so `prettyToolValue` fell through to returning it unchanged and **Preview rendered exactly what Raw did, with nothing explaining why**.

On a real archive that is **3,285 of 20,053 calls (16%)**, while 81% of inputs are JSON. The elided ones are the large ones, so it was precisely the calls worth opening that looked broken.

An elided value now says so above the value and points at the transcript. `previewOmittedCount` lives beside the function that writes the marker, with a test pinning them together, because the two drifting apart would make every elided value look complete — silent in the UI rather than loud in the suite.

## 3. Schema v23 indexes tool_call in paging order — but not for the reason I first claimed

`listToolCalls` orders by `(timestamp DESC, id DESC)` and takes 50 rows. There was no index in that order, so the plan sorted everything to return a page:

```
|--SCAN s
|--SEARCH t USING INDEX idx_toolcall_session (session_id=?)
|--SEARCH m USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN
`--USE TEMP B-TREE FOR ORDER BY          <-- sorts 20k rows to return 50
```

Each of those 20k rows also drew a random `message` row for its `seq`, the only column needed from it. With the index:

```
|--SCAN t USING INDEX idx_toolcall_timestamp
|--SEARCH s USING INTEGER PRIMARY KEY (rowid=?)
`--SEARCH m USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN
```

**The correction.** My first version of this PR claimed this fixed a 705 ms first load. That number was a cold page cache on a 669 MB file. Every later measurement ran against a warm one, after I had copied the archive around several times, so comparing the two was meaningless. I also managed to invalidate my own control once by letting `openDb` re-run the migration on the "without index" copy, which re-created the index and had me measuring it against itself.

Measured properly — `main`'s code against a de-indexed copy versus this branch against an indexed one, nine server restarts each so every sample is a genuine process cold start, invalid samples rejected:

| | median first hit | p25 | p75 |
|---|---|---|---|
| without index | 0.059s | 0.054s | 0.062s |
| with index | 0.068s | 0.064s | 0.120s |

**End to end it is a wash at this size.** Per-request overhead swamps the query difference.

What does hold up: at the query level, on two copies of one archive with the index present on only one and raw connections on both, `listToolCalls` runs **1.6x to 2.8x faster** (58.5ms → 25.0ms at offset 50, 71.8ms → 26.0ms at offset 1000). And the plan improvement is verified by test rather than by timing, since a reordered `ORDER BY` would leave the index in place and silently stop using it.

So the index is worth keeping — the work it removes grows with the table while the work it adds does not, so the margin widens as an archive does — but it is **not** the fix for the slow first load, and the comments no longer say otherwise. If you would rather not carry an index that pays off only later, say so and I will drop it; the two visual fixes stand on their own.

## Still open: what actually makes the first load slow

Leading suspect is the UI bundle. `main.js` builds to **6.0 MB**, and although echarts is behind `await import("echarts")`, the string `echarts` still appears 531 times in the main chunk — the dynamic import is not being split out, so it ships and parses on first load regardless. That would affect whichever page you land on first, which fits "usually takes a while" better than any query does.

I have not fixed that here because it is a build-configuration change with its own blast radius, and worth its own PR. Happy to take it next.

## Note for whoever reviews the migration

Migration 23 has already been applied to at least one live dogfooding archive — a `bun run dev` server was up while I was editing `src/db.ts` and applied it. So per invariant 5 it is frozen: if this needs a different index, it has to land as v24 rather than an edit to 23.

## Checks

`bun test` 911 pass · `bunx tsc --noEmit` clean · `bunx biome check .` clean, no new warnings · `dist-check` ok. Migration verified both ways: a v22 archive gains the index on upgrade, a fresh archive gets it from `schema.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
