### PR TITLE
fix(ui): keep report controls visible in dark mode

### DIFF
--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -3862,6 +3862,7 @@ function ReportRouteView({
 
   return (
     <div
+      className="report-route-theme"
       style={{
         background: "#eef0ec",
         color: "#24302a",

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -262,7 +262,8 @@
   --blur-dropdown: 18px;
 }
 
-:root {
+:root,
+.report-route-theme {
   color-scheme: light;
   /* Light semantic tokens */
   --bg-primary: #e6e3d7;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2699,6 +2699,15 @@ select {
   height: 15px;
 }
 
+.report-route-toolbar :where(.primary-button, .secondary-button) {
+  min-height: 34px;
+  box-shadow: none;
+}
+
+.report-route-toolbar :where(.primary-button, .secondary-button):focus-visible {
+  box-shadow: var(--shadow-focus-ring);
+}
+
 .sync-button.is-syncing svg {
   animation: sync-spin 0.9s linear infinite;
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2699,12 +2699,12 @@ select {
   height: 15px;
 }
 
-.report-route-toolbar :where(.primary-button, .secondary-button) {
+.report-route-toolbar :is(.primary-button, .secondary-button) {
   min-height: 34px;
   box-shadow: none;
 }
 
-.report-route-toolbar :where(.primary-button, .secondary-button):focus-visible {
+.report-route-toolbar :is(.primary-button, .secondary-button):focus-visible {
   box-shadow: var(--shadow-focus-ring);
 }
 

--- a/test/ui-theme-tokens.test.ts
+++ b/test/ui-theme-tokens.test.ts
@@ -55,13 +55,13 @@ describe("theme tokens", () => {
 
   test("report toolbar actions share a flat height and retain their focus ring", () => {
     expect(styles).toContain(
-      ".report-route-toolbar :where(.primary-button, .secondary-button) {\n" +
+      ".report-route-toolbar :is(.primary-button, .secondary-button) {\n" +
         "  min-height: 34px;\n" +
         "  box-shadow: none;\n" +
         "}",
     );
     expect(styles).toContain(
-      ".report-route-toolbar :where(.primary-button, .secondary-button):focus-visible {\n" +
+      ".report-route-toolbar :is(.primary-button, .secondary-button):focus-visible {\n" +
         "  box-shadow: var(--shadow-focus-ring);\n" +
         "}",
     );

--- a/test/ui-theme-tokens.test.ts
+++ b/test/ui-theme-tokens.test.ts
@@ -53,6 +53,20 @@ describe("theme tokens", () => {
     expect(reportRoute).toContain('className="report-route-toolbar"');
   });
 
+  test("report toolbar actions share a flat height and retain their focus ring", () => {
+    expect(styles).toContain(
+      ".report-route-toolbar :where(.primary-button, .secondary-button) {\n" +
+        "  min-height: 34px;\n" +
+        "  box-shadow: none;\n" +
+        "}",
+    );
+    expect(styles).toContain(
+      ".report-route-toolbar :where(.primary-button, .secondary-button):focus-visible {\n" +
+        "  box-shadow: var(--shadow-focus-ring);\n" +
+        "}",
+    );
+  });
+
   test("the two dark blocks stay identical", () => {
     const fromMedia = declarations(darkMediaBlock);
     const fromAttribute = declarations(darkAttrBlock);

--- a/test/ui-theme-tokens.test.ts
+++ b/test/ui-theme-tokens.test.ts
@@ -36,11 +36,23 @@ function blockAfter(marker: string, closer: string): string {
   return styles.slice(start, end);
 }
 
-const rootBlock = blockAfter(":root {\n  color-scheme: light;", "\n}");
+const rootBlock = blockAfter(":root,\n.report-route-theme {\n  color-scheme: light;", "\n}");
 const darkMediaBlock = blockAfter(":root:not([data-theme]) {\n    color-scheme: dark;", "\n  }");
 const darkAttrBlock = blockAfter('[data-theme="dark"] {\n  color-scheme: dark;', "\n}");
 
 describe("theme tokens", () => {
+  test("the report preview scopes the complete light theme in every app mode", () => {
+    const start = main.indexOf("function ReportRouteView(");
+    const end = main.indexOf("async function waitForReportFonts(");
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const reportRoute = main.slice(start, end);
+
+    expect(styles).toContain(":root,\n.report-route-theme {");
+    expect(reportRoute).toContain('className="report-route-theme"');
+    expect(reportRoute).toContain('className="report-route-toolbar"');
+  });
+
   test("the two dark blocks stay identical", () => {
     const fromMedia = declarations(darkMediaBlock);
     const fromAttribute = declarations(darkAttrBlock);

--- a/test/ui-token-parity.test.ts
+++ b/test/ui-token-parity.test.ts
@@ -64,7 +64,7 @@ function blockAfter(marker: string, closer: string): string {
   return styles.slice(start, end);
 }
 
-const lightBlock = blockAfter(":root {\n  color-scheme: light;", "\n}");
+const lightBlock = blockAfter(":root,\n.report-route-theme {\n  color-scheme: light;", "\n}");
 const darkBlock = blockAfter('[data-theme="dark"] {\n  color-scheme: dark;', "\n}");
 
 function tokenValue(name: string, block: string): string | undefined {


### PR DESCRIPTION
## Summary

- scope the print-ready report route to the complete light semantic token set
- keep Back, Download HTML, and Save as PDF controls legible and interactive when the surrounding app uses light, dark, or system mode
- flatten the compact toolbar actions to one 34px height while retaining the standard focus ring
- add a regression contract for the report theme boundary and retain light/dark token parity coverage

## Root cause

The report toolbar always renders on a white surface, but its secondary buttons inherited the app-level dark tokens in dark or system-dark mode. That made their white text and icons disappear against the white toolbar even though the controls were still present.

## Checks

- `just check` — 931 tests passed, TypeScript clean, Biome clean, native distribution smoke passed
- visually verified the report toolbar in Chrome against a separate local Decant server
