### PR TITLE
fix(ui): stabilize session scrolling and loading

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1680,13 +1680,13 @@ components:
       additionalProperties: false
     ArchiveUpdatedEvent:
       type: object
-      required: [type]
+      required: [type, reason]
       properties:
         type:
           const: archive_updated
         reason:
           type: string
-          enum: [stats, session_state]
+          enum: [startup, watch, sweep, manual, stats, session_state]
         ingested:
           type: integer
           minimum: 0

--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -112,7 +112,9 @@ haystack and intentionally omits transcript content.
 - `ready` — source watcher initialized
 - `sync_progress` — bounded progress snapshot for a running sync
 - `sync` — terminal successful sync report
-- `archive_updated` — archive-derived UI data changed
+- `archive_updated` — archive-derived UI data changed; `reason` distinguishes
+  background watcher activity from manual syncs, statistics rebuilds, and
+  session-state changes
 - `error` — watcher or sync failure
 - `stopped` — source watcher stopped
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -784,6 +784,7 @@ async function syncNow(
       economics?.invalidate();
       publishServerEvent({
         type: "archive_updated",
+        reason: "manual",
         ingested: report.ingested,
         last_sync_at: syncStatus.last_sync_at,
       });
@@ -1234,6 +1235,7 @@ function applyWatchEvent(event: WatchEvent, economics: EconomicsCache): void {
     economics.invalidate();
     publishServerEvent({
       type: "archive_updated",
+      reason: event.reason,
       ingested: event.report.ingested,
       last_sync_at: syncStatus.last_sync_at,
     });

--- a/src/ui/loading-state.ts
+++ b/src/ui/loading-state.ts
@@ -7,19 +7,12 @@ export type SessionLoadPlan = {
 };
 
 export function planSessionPageLoad({
-  loadedRequestKey,
   page,
   pageSize,
-  requestKey,
 }: {
-  loadedRequestKey: string | null;
   page: number;
   pageSize: number;
-  requestKey: string;
-}): SessionLoadPlan | null {
-  if (loadedRequestKey === requestKey) {
-    return null;
-  }
+}): SessionLoadPlan {
   const requestedPage = Number.isSafeInteger(page) && page > 0 ? page : 1;
   const normalizedPageSize = Number.isSafeInteger(pageSize) && pageSize > 0 ? pageSize : 1;
   const candidateOffset = (requestedPage - 1) * normalizedPageSize;

--- a/src/ui/loading-state.ts
+++ b/src/ui/loading-state.ts
@@ -3,31 +3,30 @@ import { SESSION_LIST_MAX_LIMIT } from "../api-limits.ts";
 export type SessionLoadPlan = {
   limit: number;
   offset: number;
-  replace: boolean;
+  page: number;
 };
 
-export function planSessionLoad({
+export function planSessionPageLoad({
   loadedRequestKey,
-  loadedRows,
+  page,
   pageSize,
   requestKey,
-  sessionLimit,
 }: {
   loadedRequestKey: string | null;
-  loadedRows: number;
+  page: number;
   pageSize: number;
   requestKey: string;
-  sessionLimit: number;
 }): SessionLoadPlan | null {
-  const refreshFirstPage = loadedRequestKey !== requestKey;
-  const offset = refreshFirstPage ? 0 : loadedRows;
-  const desiredRows = Math.max(sessionLimit, pageSize);
-  const remainingRows = desiredRows - offset;
-  const limit = Math.min(SESSION_LIST_MAX_LIMIT, Math.max(0, remainingRows));
-  if (limit <= 0) {
+  if (loadedRequestKey === requestKey) {
     return null;
   }
-  return { limit, offset, replace: refreshFirstPage };
+  const requestedPage = Number.isSafeInteger(page) && page > 0 ? page : 1;
+  const normalizedPageSize = Number.isSafeInteger(pageSize) && pageSize > 0 ? pageSize : 1;
+  const candidateOffset = (requestedPage - 1) * normalizedPageSize;
+  const offset = Number.isSafeInteger(candidateOffset) ? candidateOffset : 0;
+  const normalizedPage = offset === candidateOffset ? requestedPage : 1;
+  const limit = Math.min(SESSION_LIST_MAX_LIMIT, normalizedPageSize + 1);
+  return { limit, offset, page: normalizedPage };
 }
 
 export function shouldShowSessionSkeleton({

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -695,7 +695,7 @@ const ANTHROPIC_ICON_PATH =
 const SESSION_PAGE_SIZE = 50;
 const SESSION_DETAIL_MESSAGE_PAGE_SIZE = 160;
 const SESSION_TABLE_SKELETON_KEYS = Array.from(
-  { length: 10 },
+  { length: SESSION_PAGE_SIZE },
   (_, index) => `session-row-skeleton-${index}`,
 );
 type ThemeChoice = "system" | "light" | "dark";
@@ -730,7 +730,9 @@ function App() {
   const [recommendationsLoading, setRecommendationsLoading] = useState(
     () => resolveActiveRoute(locationPath(), navItems) === "Insights",
   );
-  const [sessionsLoading, setSessionsLoading] = useState(false);
+  const [sessionsLoading, setSessionsLoading] = useState(
+    () => resolveActiveRoute(locationPath(), navItems) === "Sessions",
+  );
   const [sessionListExhausted, setSessionListExhausted] = useState(false);
   const [loadedSessionPage, setLoadedSessionPage] = useState<number | null>(null);
   const [dateRangeSelection, setDateRangeSelection] = useState<DateRangeSelection>(ALL_DATE_RANGE);
@@ -807,7 +809,7 @@ function App() {
     );
   }, [activeView, reloadKey]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     void dateQuery;
     void sessionProject;
     void includeArchivedSessions;
@@ -816,6 +818,12 @@ function App() {
     setLoadedSessionPage(null);
     setSessionListExhausted(false);
   }, [dateQuery, includeArchivedSessions, sessionProject]);
+
+  useLayoutEffect(() => {
+    if (showsSessions && loadedSessionKey !== sessionLoadKey) {
+      setSessionsLoading(true);
+    }
+  }, [loadedSessionKey, sessionLoadKey, showsSessions]);
 
   useEffect(() => {
     const sliceKey = (slice: DataSlice): string =>
@@ -1537,8 +1545,6 @@ function SessionsView({
     value: Summary;
   } | null>(null);
   const [expandedSessions, setExpandedSessions] = useState<Set<number>>(() => new Set());
-  const tableTopRef = useRef<HTMLElement | null>(null);
-  const previousLoadedPageRef = useRef<number | null>(null);
   const total = data.summary?.sessions ?? data.sessions.length;
   const filtered = filterSessions(data.sessions, query);
   const project = sessionProjectFilter(path);
@@ -1609,17 +1615,6 @@ function SessionsView({
     setExpandedSessions(new Set());
   }, [sessionFilterKey]);
 
-  useEffect(() => {
-    if (loadedPage == null) {
-      return;
-    }
-    const previousPage = previousLoadedPageRef.current;
-    previousLoadedPageRef.current = loadedPage;
-    if (previousPage != null && previousPage !== loadedPage) {
-      tableTopRef.current?.scrollIntoView({ block: "start" });
-    }
-  }, [loadedPage]);
-
   const toggleSession = useCallback((id: number) => {
     setExpandedSessions((current) => {
       const next = new Set(current);
@@ -1682,7 +1677,7 @@ function SessionsView({
         />
       </div>
 
-      <section aria-busy={pageLoading} className="panel sessions-panel" ref={tableTopRef}>
+      <section aria-busy={pageLoading} className="panel">
         <div className="panel-heading">
           <div>
             <h2>Sessions</h2>

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -481,7 +481,6 @@ type SettingsInfo = {
 
 type DashboardData = {
   summary: Summary | null;
-  sessions: SessionSummary[];
   byModel: DimensionRow[];
   byProject: DimensionRow[];
   byDay: DimensionRow[];
@@ -501,7 +500,6 @@ type DashboardData = {
 
 const emptyData: DashboardData = {
   summary: null,
-  sessions: [],
   byModel: [],
   byProject: [],
   byDay: [],
@@ -519,7 +517,7 @@ const emptyData: DashboardData = {
   dateBounds: null,
 };
 
-type DataSlice = Exclude<keyof DashboardData, "sessions">;
+type DataSlice = keyof DashboardData;
 
 // Each page fetches only the slices it renders; fetching everything for every
 // page made first paint wait on the slowest analytics endpoint. Slices are
@@ -698,6 +696,7 @@ const SESSION_TABLE_SKELETON_KEYS = Array.from(
   { length: SESSION_PAGE_SIZE },
   (_, index) => `session-row-skeleton-${index}`,
 );
+const EMPTY_SESSION_IDS = new Set<number>();
 type ThemeChoice = "system" | "light" | "dark";
 type RangePreset = "7d" | "30d" | "90d" | "all" | "custom";
 type DateRangeSelection = {
@@ -720,21 +719,119 @@ const RANGE_PRESETS = [
 ] as const;
 const ALL_DATE_RANGE: DateRangeSelection = { preset: "all", from: null, to: null };
 
+type LoadedSessionPage = {
+  exhausted: boolean;
+  page: number;
+  requestKey: string;
+  scopeKey: string;
+  sessions: SessionSummary[];
+};
+
+type SessionPageState = {
+  error: unknown;
+  exhausted: boolean;
+  loadedPage: number | null;
+  loading: boolean;
+  sessions: SessionSummary[];
+};
+
+const SESSION_PAGE_CACHE_LIMIT = 12;
+
+function rememberSessionPage(cache: Map<string, LoadedSessionPage>, page: LoadedSessionPage): void {
+  cache.delete(page.requestKey);
+  cache.set(page.requestKey, page);
+  while (cache.size > SESSION_PAGE_CACHE_LIMIT) {
+    const oldest = cache.keys().next().value;
+    if (oldest == null) {
+      return;
+    }
+    cache.delete(oldest);
+  }
+}
+
+function useSessionPage({
+  dateQuery,
+  enabled,
+  includeArchived,
+  page,
+  project,
+  reloadKey,
+}: {
+  dateQuery: string;
+  enabled: boolean;
+  includeArchived: boolean;
+  page: number;
+  project: string | null;
+  reloadKey: number;
+}): SessionPageState {
+  const cacheRef = useRef(new Map<string, LoadedSessionPage>());
+  const [settled, setSettled] = useState<{
+    failed: { error: unknown; requestKey: string } | null;
+    loaded: LoadedSessionPage | null;
+  }>({ failed: null, loaded: null });
+  const scopeKey = JSON.stringify([dateQuery, project, includeArchived, reloadKey]);
+  const requestKey = `${scopeKey}:${page}`;
+  const cached = cacheRef.current.get(requestKey) ?? null;
+  const visible = cached ?? (settled.loaded?.scopeKey === scopeKey ? settled.loaded : null);
+  const currentError = settled.failed?.requestKey === requestKey ? settled.failed.error : null;
+  const loading = enabled && cached == null && currentError == null;
+
+  useEffect(() => {
+    if (!enabled || cacheRef.current.has(requestKey)) {
+      return;
+    }
+    const controller = new AbortController();
+    const plan = planSessionPageLoad({ page, pageSize: SESSION_PAGE_SIZE });
+    const projectParam = project == null ? "" : `&project=${encodeURIComponent(project)}`;
+    const archivedParam = includeArchived ? "&include_archived=true" : "";
+    void getJson<SessionSummary[]>(
+      withDateQuery(
+        `/api/sessions?limit=${plan.limit}&offset=${plan.offset}` +
+          `&with_subagents=true${projectParam}${archivedParam}`,
+        dateQuery,
+      ),
+      { signal: controller.signal },
+    )
+      .then((sessions) => {
+        const loaded: LoadedSessionPage = {
+          exhausted: sessionPageExhausted({
+            receivedRows: sessions.length,
+            requestedRows: plan.limit,
+          }),
+          page: plan.page,
+          requestKey,
+          scopeKey,
+          sessions: sessions.slice(0, SESSION_PAGE_SIZE),
+        };
+        rememberSessionPage(cacheRef.current, loaded);
+        setSettled({ failed: null, loaded });
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setSettled((current) => ({ ...current, failed: { error, requestKey } }));
+      });
+    return () => controller.abort();
+  }, [dateQuery, enabled, includeArchived, page, project, requestKey, scopeKey]);
+
+  return {
+    error: currentError,
+    exhausted: visible?.exhausted ?? false,
+    loadedPage: visible?.page ?? null,
+    loading,
+    sessions: visible?.sessions ?? [],
+  };
+}
+
 function App() {
   const [path, setPath] = useState(locationPath);
   const [data, setData] = useState<DashboardData>(emptyData);
-  const [sessionsError, setSessionsError] = useState<unknown>(null);
   const [failedSlices, setFailedSlices] = useState<DataSlice[]>([]);
   const [reloadKey, setReloadKey] = useState(0);
-  const [loadedSessionKey, setLoadedSessionKey] = useState<string | null>(null);
   const [recommendationsLoading, setRecommendationsLoading] = useState(
     () => resolveActiveRoute(locationPath(), navItems) === "Insights",
   );
-  const [sessionsLoading, setSessionsLoading] = useState(
-    () => resolveActiveRoute(locationPath(), navItems) === "Sessions",
-  );
-  const [sessionListExhausted, setSessionListExhausted] = useState(false);
-  const [loadedSessionPage, setLoadedSessionPage] = useState<number | null>(null);
   const [dateRangeSelection, setDateRangeSelection] = useState<DateRangeSelection>(ALL_DATE_RANGE);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -752,11 +849,18 @@ function App() {
   const sessionProject = sessionProjectFilter(path);
   const includeArchivedSessions = sessionIncludesArchived(path);
   const sessionPage = sessionPageFromPath(path);
-  const sessionLoadKey = `${dateQuery}:${sessionProject ?? ""}:${includeArchivedSessions}:${sessionPage}:${reloadKey}`;
   const refreshTimerRef = useRef<number | null>(null);
   const loadedSlicesRef = useRef(new Map<DataSlice, string>());
   const activeView = resolveActiveRoute(path, navItems);
   const showsSessions = activeView === "Sessions";
+  const sessionPageState = useSessionPage({
+    dateQuery,
+    enabled: showsSessions,
+    includeArchived: includeArchivedSessions,
+    page: sessionPage,
+    project: sessionProject,
+    reloadKey,
+  });
   const [theme, setTheme] = useState<ThemeChoice>(() => {
     const stored = localStorage.getItem("decant-theme");
     return stored === "light" || stored === "dark" ? stored : "system";
@@ -809,22 +913,6 @@ function App() {
     );
   }, [activeView, reloadKey]);
 
-  useLayoutEffect(() => {
-    void dateQuery;
-    void sessionProject;
-    void includeArchivedSessions;
-    setData((current) => ({ ...current, sessions: [] }));
-    setLoadedSessionKey(null);
-    setLoadedSessionPage(null);
-    setSessionListExhausted(false);
-  }, [dateQuery, includeArchivedSessions, sessionProject]);
-
-  useLayoutEffect(() => {
-    if (showsSessions && loadedSessionKey !== sessionLoadKey) {
-      setSessionsLoading(true);
-    }
-  }, [loadedSessionKey, sessionLoadKey, showsSessions]);
-
   useEffect(() => {
     const sliceKey = (slice: DataSlice): string =>
       SLICE_LOADERS[slice].dateScoped ? `${dateQuery}|${reloadKey}` : `${reloadKey}`;
@@ -858,69 +946,6 @@ function App() {
       cancelled = true;
     };
   }, [activeView, dateQuery, reloadKey]);
-
-  useEffect(() => {
-    if (!showsSessions) {
-      return;
-    }
-    let cancelled = false;
-    const plan = planSessionPageLoad({
-      loadedRequestKey: loadedSessionKey,
-      page: sessionPage,
-      pageSize: SESSION_PAGE_SIZE,
-      requestKey: sessionLoadKey,
-    });
-    if (plan == null) {
-      return;
-    }
-    setSessionsLoading(true);
-    const projectParam =
-      sessionProject == null ? "" : `&project=${encodeURIComponent(sessionProject)}`;
-    const archivedParam = includeArchivedSessions ? "&include_archived=true" : "";
-    void getJson<SessionSummary[]>(
-      withDateQuery(
-        `/api/sessions?limit=${plan.limit}&offset=${plan.offset}` +
-          `&with_subagents=true${projectParam}${archivedParam}`,
-        dateQuery,
-      ),
-    )
-      .then((sessions) => {
-        if (cancelled) {
-          return;
-        }
-        setData((current) => ({
-          ...current,
-          sessions: sessions.slice(0, SESSION_PAGE_SIZE),
-        }));
-        setSessionListExhausted(
-          sessionPageExhausted({ receivedRows: sessions.length, requestedRows: plan.limit }),
-        );
-        setLoadedSessionKey(sessionLoadKey);
-        setLoadedSessionPage(plan.page);
-        setSessionsError(null);
-      })
-      .catch((err: unknown) => {
-        if (!cancelled) {
-          setSessionsError(err);
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setSessionsLoading(false);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    dateQuery,
-    includeArchivedSessions,
-    loadedSessionKey,
-    sessionLoadKey,
-    sessionPage,
-    sessionProject,
-    showsSessions,
-  ]);
 
   useEffect(() => {
     // Incrementing this key intentionally replaces the EventSource when the
@@ -1083,10 +1108,8 @@ function App() {
     slicesForView(activeView).includes(slice),
   );
   const metrics = data.summary;
-  // Prefer the loaded (date-filtered) session list, matching the sidebar's
-  // other stats; dateBounds is archive-wide and only a fallback for routes
-  // that never load session rows, so it must never win over an in-range value.
-  const lastActivity = latestSessionDay(data.sessions) ?? formatDay(data.dateBounds?.max ?? null);
+  const lastActivity =
+    latestSessionDay(sessionPageState.sessions) ?? formatDay(data.dateBounds?.max ?? null);
   const syncInProgress = localSyncing;
   const runSync = () => {
     if (syncInProgress) {
@@ -1359,8 +1382,12 @@ function App() {
                 </button>
               </div>
             ) : null}
-            {active === "Sessions" && sessionsError != null ? (
-              <ApiFailureState error={sessionsError} onRetry={requestRefresh} onSync={runSync} />
+            {active === "Sessions" && sessionPageState.error != null ? (
+              <ApiFailureState
+                error={sessionPageState.error}
+                onRetry={requestRefresh}
+                onSync={runSync}
+              />
             ) : (
               renderView(active, path, data, {
                 dateRange: dateRangeSelection,
@@ -1374,10 +1401,8 @@ function App() {
                 reloadKey,
                 runSync,
                 failedSlices,
-                loadedSessionPage,
                 recommendationsLoading,
-                sessionListExhausted,
-                sessionsLoading,
+                sessionPageState,
                 syncing: syncInProgress,
               })
             )}
@@ -1419,10 +1444,8 @@ function renderView(
     reloadKey: number;
     runSync: () => void;
     failedSlices: DataSlice[];
-    loadedSessionPage: number | null;
     recommendationsLoading: boolean;
-    sessionListExhausted: boolean;
-    sessionsLoading: boolean;
+    sessionPageState: SessionPageState;
     syncing: boolean;
   },
 ) {
@@ -1445,12 +1468,10 @@ function renderView(
         <SessionsView
           data={data}
           dateRange={actions.dateRange}
-          loadedPage={actions.loadedSessionPage}
-          loading={actions.sessionsLoading}
           onDateRangeChange={actions.onDateRangeChange}
           path={path}
           reloadKey={actions.reloadKey}
-          sessionListExhausted={actions.sessionListExhausted}
+          sessionPageState={actions.sessionPageState}
         />
       );
     case "Projects":
@@ -1523,37 +1544,39 @@ function NotFoundView({ pathname }: { pathname: string }) {
 function SessionsView({
   data,
   dateRange,
-  loadedPage,
-  loading,
   onDateRangeChange,
   path,
   reloadKey,
-  sessionListExhausted,
+  sessionPageState,
 }: {
   data: DashboardData;
   dateRange: DateRangeSelection;
-  loadedPage: number | null;
-  loading: boolean;
   onDateRangeChange: (range: DateRangeSelection) => void;
   path: string;
   reloadKey: number;
-  sessionListExhausted: boolean;
+  sessionPageState: SessionPageState;
 }) {
   const [query, setQuery] = useState("");
   const [scopedSummary, setScopedSummary] = useState<{
     key: string;
     value: Summary;
   } | null>(null);
-  const [expandedSessions, setExpandedSessions] = useState<Set<number>>(() => new Set());
-  const total = data.summary?.sessions ?? data.sessions.length;
-  const filtered = filterSessions(data.sessions, query);
+  const [expandedSessionState, setExpandedSessionState] = useState<{
+    ids: Set<number>;
+    key: string;
+  }>(() => ({ ids: new Set(), key: "" }));
+  const { exhausted, loadedPage, loading, sessions } = sessionPageState;
+  const total = data.summary?.sessions ?? sessions.length;
+  const filtered = filterSessions(sessions, query);
   const project = sessionProjectFilter(path);
   const includeArchived = sessionIncludesArchived(path);
   const page = sessionPageFromPath(path);
   const displayedPage = loadedPage ?? page;
   const pageLoading = loading || (loadedPage != null && page !== loadedPage);
-  const sessionFilterKey = `${project ?? ""}:${includeArchived}:${page}`;
   const dateQuery = dateRangeQuery(dateRange);
+  const sessionFilterKey = JSON.stringify([dateQuery, project, includeArchived, page]);
+  const expandedSessions =
+    expandedSessionState.key === sessionFilterKey ? expandedSessionState.ids : EMPTY_SESSION_IDS;
   const scopedSummaryRequest =
     project == null && !includeArchived
       ? null
@@ -1568,19 +1591,19 @@ function SessionsView({
     query,
   );
   const visibleTotal =
-    project == null ? total : (currentScopedSummary?.sessions ?? data.sessions.length);
+    project == null ? total : (currentScopedSummary?.sessions ?? sessions.length);
   const listTotal = includeArchived ? null : visibleTotal;
   const pageCount =
     listTotal == null ? null : Math.max(1, Math.ceil(listTotal / SESSION_PAGE_SIZE));
   const hasNextPage =
-    !sessionListExhausted &&
+    !exhausted &&
     (listTotal == null
-      ? data.sessions.length === SESSION_PAGE_SIZE
+      ? sessions.length === SESSION_PAGE_SIZE
       : displayedPage * SESSION_PAGE_SIZE < listTotal);
   const showPagination = displayedPage > 1 || page > 1 || hasNextPage;
   const waitingForSessions = shouldShowSessionSkeleton({
     isLoading: loading,
-    loadedRows: data.sessions.length,
+    loadedRows: sessions.length,
     query,
   });
 
@@ -1610,22 +1633,20 @@ function SessionsView({
     };
   }, [reloadKey, scopedSummaryRequest]);
 
-  useEffect(() => {
-    void sessionFilterKey;
-    setExpandedSessions(new Set());
-  }, [sessionFilterKey]);
-
-  const toggleSession = useCallback((id: number) => {
-    setExpandedSessions((current) => {
-      const next = new Set(current);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
-  }, []);
+  const toggleSession = useCallback(
+    (id: number) => {
+      setExpandedSessionState((current) => {
+        const next = new Set(current.key === sessionFilterKey ? current.ids : EMPTY_SESSION_IDS);
+        if (next.has(id)) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+        return { ids: next, key: sessionFilterKey };
+      });
+    },
+    [sessionFilterKey],
+  );
 
   const renderRows = (session: SessionSummary, depth = 0): ReactNode[] => {
     const expanded = expandedSessions.has(session.id);
@@ -1677,7 +1698,7 @@ function SessionsView({
         />
       </div>
 
-      <section aria-busy={pageLoading} className="panel">
+      <section aria-busy={pageLoading} className="panel sessions-panel">
         <div className="panel-heading">
           <div>
             <h2>Sessions</h2>
@@ -1765,7 +1786,7 @@ function SessionsView({
             {sessionsCaption(
               query,
               filtered.length,
-              data.sessions.length,
+              sessions.length,
               listTotal,
               loading,
               includeArchived,

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -686,6 +686,7 @@ const ANTHROPIC_ICON_PATH =
   "M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z";
 
 const SESSION_PAGE_SIZE = 50;
+const SESSION_AUTO_LOAD_IDLE_MS = 120;
 const SESSION_DETAIL_MESSAGE_PAGE_SIZE = 160;
 const SESSION_TABLE_SKELETON_KEYS = Array.from(
   { length: 10 },
@@ -1571,23 +1572,52 @@ function SessionsView({
     if (sentinel == null || !hasMore) {
       return;
     }
+    let sentinelVisible = false;
+    let loadTimer: number | null = null;
+    const clearLoadTimer = () => {
+      if (loadTimer != null) {
+        window.clearTimeout(loadTimer);
+        loadTimer = null;
+      }
+    };
+    const loadNextPage = () => {
+      loadTimer = null;
+      onLimitChange(
+        listTotal == null
+          ? limit + SESSION_PAGE_SIZE
+          : Math.min(listTotal, limit + SESSION_PAGE_SIZE),
+      );
+    };
+    const scheduleLoad = () => {
+      clearLoadTimer();
+      loadTimer = window.setTimeout(loadNextPage, SESSION_AUTO_LOAD_IDLE_MS);
+    };
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry?.isIntersecting === true) {
-          onLimitChange(
-            listTotal == null
-              ? limit + SESSION_PAGE_SIZE
-              : Math.min(listTotal, limit + SESSION_PAGE_SIZE),
-          );
+        sentinelVisible = entry?.isIntersecting === true;
+        if (sentinelVisible) {
+          scheduleLoad();
+        } else {
+          clearLoadTimer();
         }
       },
       { rootMargin: "320px 0px" },
     );
+    const onScroll = () => {
+      if (sentinelVisible) {
+        scheduleLoad();
+      }
+    };
     observer.observe(sentinel);
-    return () => observer.disconnect();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("scroll", onScroll);
+      clearLoadTimer();
+    };
   }, [hasMore, limit, listTotal, onLimitChange]);
 
-  const toggleSession = (id: number) => {
+  const toggleSession = useCallback((id: number) => {
     setExpandedSessions((current) => {
       const next = new Set(current);
       if (next.has(id)) {
@@ -1597,7 +1627,7 @@ function SessionsView({
       }
       return next;
     });
-  };
+  }, []);
 
   const renderRows = (session: SessionSummary, depth = 0): ReactNode[] => {
     const expanded = expandedSessions.has(session.id);
@@ -2056,7 +2086,7 @@ function sessionsCaption(
   return `Showing ${formatInt(loaded)} of ${formatInt(total)} sessions`;
 }
 
-function SessionTableRow({
+const SessionTableRow = memo(function SessionTableRow({
   depth,
   expanded,
   onToggle,
@@ -2136,7 +2166,7 @@ function SessionTableRow({
       </td>
     </tr>
   );
-}
+});
 
 function DosuProvenanceBadge({ session }: { session: SessionSummary }) {
   if (session.dosu_mcp_tree_calls <= 0) {

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -109,7 +109,7 @@ import {
 } from "./fuzzy.ts";
 import { formatIssueBadge, unknownRecordTypeSummary } from "./ingest-issues.ts";
 import {
-  planSessionLoad,
+  planSessionPageLoad,
   sessionPageExhausted,
   shouldShowSessionSkeleton,
 } from "./loading-state.ts";
@@ -122,8 +122,10 @@ import {
   activeRoute as resolveActiveRoute,
   activeRouteKey as resolveActiveRouteKey,
   sessionIncludesArchived,
+  sessionPageFromPath,
   sessionProjectFilter,
   sessionsArchivedHref,
+  sessionsPageHref,
   titleFor,
 } from "./navigation.ts";
 import { exactSearchRemaining, searchPageMayHaveMore } from "./search-pagination.ts";
@@ -275,10 +277,15 @@ type SyncProgress = {
 };
 
 type SyncEventPayload = {
+  reason?: string;
   status?: {
     in_progress?: boolean;
     last_sync_at?: string | null;
   };
+};
+
+type ArchiveUpdatedPayload = {
+  reason?: string;
 };
 
 const LIVE_DISCONNECT_GRACE_MS = 15_000;
@@ -686,7 +693,6 @@ const ANTHROPIC_ICON_PATH =
   "M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z";
 
 const SESSION_PAGE_SIZE = 50;
-const SESSION_AUTO_LOAD_IDLE_MS = 120;
 const SESSION_DETAIL_MESSAGE_PAGE_SIZE = 160;
 const SESSION_TABLE_SKELETON_KEYS = Array.from(
   { length: 10 },
@@ -726,7 +732,7 @@ function App() {
   );
   const [sessionsLoading, setSessionsLoading] = useState(false);
   const [sessionListExhausted, setSessionListExhausted] = useState(false);
-  const [sessionLimit, setSessionLimit] = useState(SESSION_PAGE_SIZE);
+  const [loadedSessionPage, setLoadedSessionPage] = useState<number | null>(null);
   const [dateRangeSelection, setDateRangeSelection] = useState<DateRangeSelection>(ALL_DATE_RANGE);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -734,6 +740,7 @@ function App() {
   const [syncError, setSyncError] = useState<unknown>(null);
   const [syncComplete, setSyncComplete] = useState(false);
   const [syncProgress, setSyncProgress] = useState<SyncProgress | null>(null);
+  const [archiveUpdateAvailable, setArchiveUpdateAvailable] = useState(false);
   const [liveDisconnected, setLiveDisconnected] = useState(false);
   const [liveConnectionKey, setLiveConnectionKey] = useState(0);
   const syncCompleteTimerRef = useRef<number | null>(null);
@@ -742,7 +749,8 @@ function App() {
   const dateQuery = dateRangeQuery(dateRangeSelection);
   const sessionProject = sessionProjectFilter(path);
   const includeArchivedSessions = sessionIncludesArchived(path);
-  const sessionLoadKey = `${dateQuery}:${sessionProject ?? ""}:${includeArchivedSessions}:${reloadKey}`;
+  const sessionPage = sessionPageFromPath(path);
+  const sessionLoadKey = `${dateQuery}:${sessionProject ?? ""}:${includeArchivedSessions}:${sessionPage}:${reloadKey}`;
   const refreshTimerRef = useRef<number | null>(null);
   const loadedSlicesRef = useRef(new Map<DataSlice, string>());
   const activeView = resolveActiveRoute(path, navItems);
@@ -805,8 +813,8 @@ function App() {
     void includeArchivedSessions;
     setData((current) => ({ ...current, sessions: [] }));
     setLoadedSessionKey(null);
+    setLoadedSessionPage(null);
     setSessionListExhausted(false);
-    setSessionLimit(SESSION_PAGE_SIZE);
   }, [dateQuery, includeArchivedSessions, sessionProject]);
 
   useEffect(() => {
@@ -848,12 +856,11 @@ function App() {
       return;
     }
     let cancelled = false;
-    const plan = planSessionLoad({
+    const plan = planSessionPageLoad({
       loadedRequestKey: loadedSessionKey,
-      loadedRows: data.sessions.length,
+      page: sessionPage,
       pageSize: SESSION_PAGE_SIZE,
       requestKey: sessionLoadKey,
-      sessionLimit,
     });
     if (plan == null) {
       return;
@@ -875,12 +882,13 @@ function App() {
         }
         setData((current) => ({
           ...current,
-          sessions: plan.replace ? sessions : [...current.sessions, ...sessions],
+          sessions: sessions.slice(0, SESSION_PAGE_SIZE),
         }));
         setSessionListExhausted(
           sessionPageExhausted({ receivedRows: sessions.length, requestedRows: plan.limit }),
         );
         setLoadedSessionKey(sessionLoadKey);
+        setLoadedSessionPage(plan.page);
         setSessionsError(null);
       })
       .catch((err: unknown) => {
@@ -897,12 +905,11 @@ function App() {
       cancelled = true;
     };
   }, [
-    data.sessions.length,
     dateQuery,
     includeArchivedSessions,
     loadedSessionKey,
-    sessionLimit,
     sessionLoadKey,
+    sessionPage,
     sessionProject,
     showsSessions,
   ]);
@@ -915,7 +922,7 @@ function App() {
     const markConnected = () => {
       if (liveDroppedRef.current) {
         liveDroppedRef.current = false;
-        requestRefresh();
+        setArchiveUpdateAvailable(true);
       }
       if (liveDisconnectTimerRef.current != null) {
         window.clearTimeout(liveDisconnectTimerRef.current);
@@ -926,7 +933,13 @@ function App() {
     const handleProgress = (event: MessageEvent<string>) => {
       markConnected();
       try {
-        const payload = JSON.parse(event.data) as { progress?: SyncProgress };
+        const payload = JSON.parse(event.data) as {
+          progress?: SyncProgress;
+          reason?: string;
+        };
+        if (payload.reason !== "manual") {
+          return;
+        }
         if (payload.progress != null) {
           setSyncProgress(payload.progress);
           setLocalSyncing(true);
@@ -942,17 +955,20 @@ function App() {
     };
     const handleSync = (event: MessageEvent<string>) => {
       markConnected();
-      setLocalSyncing(false);
-      setSyncError(null);
-      setSyncComplete(true);
       let payload: SyncEventPayload = {};
       try {
         payload = JSON.parse(event.data) as SyncEventPayload;
       } catch {
-        // A terminal sync event is authoritative even if optional metadata is
-        // unavailable. Clear the local status immediately instead of waiting
-        // for the slower grouped dashboard refresh.
+        // Treat malformed events as background updates so a broken optional
+        // payload cannot cause an unexpected page refresh.
       }
+      if (payload.reason !== "manual") {
+        return;
+      }
+      setArchiveUpdateAvailable(false);
+      setLocalSyncing(false);
+      setSyncError(null);
+      setSyncComplete(true);
       setData((current) =>
         current.now == null
           ? current
@@ -974,6 +990,21 @@ function App() {
       }, 1_500);
       requestRefresh();
     };
+    const handleArchiveUpdated = (event: MessageEvent<string>) => {
+      let payload: ArchiveUpdatedPayload = {};
+      try {
+        payload = JSON.parse(event.data) as ArchiveUpdatedPayload;
+      } catch {
+        // Unknown archive updates remain pending until the user asks to load
+        // them, preserving the current page while they scroll or inspect it.
+      }
+      if (payload.reason === "manual" || payload.reason === "session_state") {
+        setArchiveUpdateAvailable(false);
+        requestRefresh();
+        return;
+      }
+      setArchiveUpdateAvailable(true);
+    };
     const handleOpen = () => markConnected();
     const handleError = () => {
       liveDroppedRef.current = true;
@@ -993,7 +1024,7 @@ function App() {
     events.addEventListener("ping", handleHeartbeat);
     events.addEventListener("sync_progress", handleProgress as EventListener);
     events.addEventListener("sync", handleSync);
-    events.addEventListener("archive_updated", requestRefresh);
+    events.addEventListener("archive_updated", handleArchiveUpdated as EventListener);
     events.addEventListener("error", handleError);
     return () => {
       events.removeEventListener("open", handleOpen);
@@ -1001,7 +1032,7 @@ function App() {
       events.removeEventListener("ping", handleHeartbeat);
       events.removeEventListener("sync_progress", handleProgress as EventListener);
       events.removeEventListener("sync", handleSync);
-      events.removeEventListener("archive_updated", requestRefresh);
+      events.removeEventListener("archive_updated", handleArchiveUpdated as EventListener);
       events.removeEventListener("error", handleError);
       events.close();
       if (liveDisconnectTimerRef.current != null) {
@@ -1048,7 +1079,7 @@ function App() {
   // other stats; dateBounds is archive-wide and only a fallback for routes
   // that never load session rows, so it must never win over an in-range value.
   const lastActivity = latestSessionDay(data.sessions) ?? formatDay(data.dateBounds?.max ?? null);
-  const syncInProgress = localSyncing || data.now?.sync_in_progress === true;
+  const syncInProgress = localSyncing;
   const runSync = () => {
     if (syncInProgress) {
       return;
@@ -1056,9 +1087,11 @@ function App() {
     setSyncError(null);
     setSyncComplete(false);
     setSyncProgress(null);
+    setArchiveUpdateAvailable(false);
     setLocalSyncing(true);
     void getJson<unknown>("/api/sync", { method: "POST", body: "{}" })
       .then(() => {
+        setArchiveUpdateAvailable(false);
         setLocalSyncing(false);
         setSyncComplete(true);
         requestRefresh();
@@ -1075,6 +1108,10 @@ function App() {
         setSyncProgress(null);
         setSyncError(err);
       });
+  };
+  const loadArchiveUpdates = () => {
+    setArchiveUpdateAvailable(false);
+    requestRefresh();
   };
   const reconnectLiveUpdates = () => {
     liveDroppedRef.current = false;
@@ -1243,15 +1280,15 @@ function App() {
             <Icon name="search" />
           </button>
           <button
-            aria-label="Sync session logs"
+            aria-label={archiveUpdateAvailable ? "Load new activity" : "Sync session logs"}
             aria-busy={syncInProgress}
-            className={`secondary-button sync-button${syncInProgress ? " is-syncing" : ""}`}
+            className={`secondary-button sync-button${syncInProgress ? " is-syncing" : ""}${archiveUpdateAvailable ? " has-update" : ""}`}
             disabled={syncInProgress}
-            onClick={runSync}
+            onClick={archiveUpdateAvailable ? loadArchiveUpdates : runSync}
             type="button"
           >
             <Icon name="refresh" />
-            {syncInProgress ? null : "Sync"}
+            {syncInProgress ? null : archiveUpdateAvailable ? "Update" : "Sync"}
           </button>
           <span aria-live="polite" className="sr-only" role="status">
             {syncInProgress
@@ -1320,18 +1357,19 @@ function App() {
               renderView(active, path, data, {
                 dateRange: dateRangeSelection,
                 onDateRangeChange: (next) => {
-                  setSessionLimit(SESSION_PAGE_SIZE);
+                  if (sessionPageFromPath(path) > 1) {
+                    visit(sessionsPageHref(path, 1), setPath);
+                  }
                   setDateRangeSelection(next);
                 },
                 refresh: requestRefresh,
                 reloadKey,
                 runSync,
                 failedSlices,
+                loadedSessionPage,
                 recommendationsLoading,
                 sessionListExhausted,
-                sessionLimit,
                 sessionsLoading,
-                setSessionLimit,
                 syncing: syncInProgress,
               })
             )}
@@ -1373,11 +1411,10 @@ function renderView(
     reloadKey: number;
     runSync: () => void;
     failedSlices: DataSlice[];
+    loadedSessionPage: number | null;
     recommendationsLoading: boolean;
     sessionListExhausted: boolean;
-    sessionLimit: number;
     sessionsLoading: boolean;
-    setSessionLimit: (limit: number) => void;
     syncing: boolean;
   },
 ) {
@@ -1400,10 +1437,9 @@ function renderView(
         <SessionsView
           data={data}
           dateRange={actions.dateRange}
-          limit={actions.sessionLimit}
+          loadedPage={actions.loadedSessionPage}
           loading={actions.sessionsLoading}
           onDateRangeChange={actions.onDateRangeChange}
-          onLimitChange={actions.setSessionLimit}
           path={path}
           reloadKey={actions.reloadKey}
           sessionListExhausted={actions.sessionListExhausted}
@@ -1479,20 +1515,18 @@ function NotFoundView({ pathname }: { pathname: string }) {
 function SessionsView({
   data,
   dateRange,
-  limit,
+  loadedPage,
   loading,
   onDateRangeChange,
-  onLimitChange,
   path,
   reloadKey,
   sessionListExhausted,
 }: {
   data: DashboardData;
   dateRange: DateRangeSelection;
-  limit: number;
+  loadedPage: number | null;
   loading: boolean;
   onDateRangeChange: (range: DateRangeSelection) => void;
-  onLimitChange: (limit: number) => void;
   path: string;
   reloadKey: number;
   sessionListExhausted: boolean;
@@ -1503,12 +1537,16 @@ function SessionsView({
     value: Summary;
   } | null>(null);
   const [expandedSessions, setExpandedSessions] = useState<Set<number>>(() => new Set());
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const tableTopRef = useRef<HTMLElement | null>(null);
+  const previousLoadedPageRef = useRef<number | null>(null);
   const total = data.summary?.sessions ?? data.sessions.length;
   const filtered = filterSessions(data.sessions, query);
   const project = sessionProjectFilter(path);
   const includeArchived = sessionIncludesArchived(path);
-  const sessionFilterKey = `${project ?? ""}:${includeArchived}`;
+  const page = sessionPageFromPath(path);
+  const displayedPage = loadedPage ?? page;
+  const pageLoading = loading || (loadedPage != null && page !== loadedPage);
+  const sessionFilterKey = `${project ?? ""}:${includeArchived}:${page}`;
   const dateQuery = dateRangeQuery(dateRange);
   const scopedSummaryRequest =
     project == null && !includeArchived
@@ -1526,10 +1564,14 @@ function SessionsView({
   const visibleTotal =
     project == null ? total : (currentScopedSummary?.sessions ?? data.sessions.length);
   const listTotal = includeArchived ? null : visibleTotal;
-  const hasMore =
-    !loading &&
+  const pageCount =
+    listTotal == null ? null : Math.max(1, Math.ceil(listTotal / SESSION_PAGE_SIZE));
+  const hasNextPage =
     !sessionListExhausted &&
-    (project == null && !includeArchived ? data.sessions.length < visibleTotal : true);
+    (listTotal == null
+      ? data.sessions.length === SESSION_PAGE_SIZE
+      : displayedPage * SESSION_PAGE_SIZE < listTotal);
+  const showPagination = displayedPage > 1 || page > 1 || hasNextPage;
   const waitingForSessions = shouldShowSessionSkeleton({
     isLoading: loading,
     loadedRows: data.sessions.length,
@@ -1568,54 +1610,15 @@ function SessionsView({
   }, [sessionFilterKey]);
 
   useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (sentinel == null || !hasMore) {
+    if (loadedPage == null) {
       return;
     }
-    let sentinelVisible = false;
-    let loadTimer: number | null = null;
-    const clearLoadTimer = () => {
-      if (loadTimer != null) {
-        window.clearTimeout(loadTimer);
-        loadTimer = null;
-      }
-    };
-    const loadNextPage = () => {
-      loadTimer = null;
-      onLimitChange(
-        listTotal == null
-          ? limit + SESSION_PAGE_SIZE
-          : Math.min(listTotal, limit + SESSION_PAGE_SIZE),
-      );
-    };
-    const scheduleLoad = () => {
-      clearLoadTimer();
-      loadTimer = window.setTimeout(loadNextPage, SESSION_AUTO_LOAD_IDLE_MS);
-    };
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        sentinelVisible = entry?.isIntersecting === true;
-        if (sentinelVisible) {
-          scheduleLoad();
-        } else {
-          clearLoadTimer();
-        }
-      },
-      { rootMargin: "320px 0px" },
-    );
-    const onScroll = () => {
-      if (sentinelVisible) {
-        scheduleLoad();
-      }
-    };
-    observer.observe(sentinel);
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => {
-      observer.disconnect();
-      window.removeEventListener("scroll", onScroll);
-      clearLoadTimer();
-    };
-  }, [hasMore, limit, listTotal, onLimitChange]);
+    const previousPage = previousLoadedPageRef.current;
+    previousLoadedPageRef.current = loadedPage;
+    if (previousPage != null && previousPage !== loadedPage) {
+      tableTopRef.current?.scrollIntoView({ block: "start" });
+    }
+  }, [loadedPage]);
 
   const toggleSession = useCallback((id: number) => {
     setExpandedSessions((current) => {
@@ -1679,7 +1682,7 @@ function SessionsView({
         />
       </div>
 
-      <section className="panel">
+      <section aria-busy={pageLoading} className="panel sessions-panel" ref={tableTopRef}>
         <div className="panel-heading">
           <div>
             <h2>Sessions</h2>
@@ -1771,9 +1774,40 @@ function SessionsView({
               listTotal,
               loading,
               includeArchived,
+              displayedPage,
             )}
           </span>
-          <div aria-hidden="true" className="infinite-sentinel" ref={sentinelRef} />
+          {showPagination ? (
+            <nav aria-label="Sessions pagination" className="session-pagination">
+              <button
+                aria-label={`Go to page ${Math.max(1, displayedPage - 1)}`}
+                className="secondary-button"
+                disabled={pageLoading || displayedPage <= 1}
+                onClick={() => visit(sessionsPageHref(path, displayedPage - 1))}
+                type="button"
+              >
+                <Icon name="chevronLeft" />
+                Previous
+              </button>
+              <span aria-live="polite">
+                {pageLoading && page !== displayedPage
+                  ? `Loading page ${formatInt(page)}…`
+                  : pageCount == null
+                    ? `Page ${formatInt(displayedPage)}`
+                    : `Page ${formatInt(displayedPage)} of ${formatInt(pageCount)}`}
+              </span>
+              <button
+                aria-label={`Go to page ${displayedPage + 1}`}
+                className="secondary-button"
+                disabled={pageLoading || !hasNextPage}
+                onClick={() => visit(sessionsPageHref(path, displayedPage + 1))}
+                type="button"
+              >
+                Next
+                <Icon name="chevronRight" />
+              </button>
+            </nav>
+          ) : null}
         </div>
       </section>
     </div>
@@ -2066,24 +2100,25 @@ function sessionsCaption(
   total: number | null,
   loading: boolean,
   includeArchived: boolean,
+  page: number,
 ): string {
-  if (loading && query.trim() === "") {
-    if (loaded === 0) {
-      return total != null && total > 0
-        ? `Loading ${formatInt(total)} sessions...`
-        : "Loading sessions...";
-    }
-    return total != null && loaded < total
-      ? `Refreshing ${formatInt(loaded)} of ${formatInt(total)} sessions`
-      : `Refreshing ${formatInt(loaded)} sessions`;
+  if (loading && loaded === 0 && query.trim() === "") {
+    return `Loading page ${formatInt(page)}…`;
   }
   if (query.trim() !== "") {
-    return `Showing ${formatInt(visible)} matching ${visible === 1 ? "row" : "rows"} from ${formatInt(loaded)} available sessions`;
+    return `Showing ${formatInt(visible)} matching ${visible === 1 ? "row" : "rows"} on page ${formatInt(page)}`;
   }
+  if (loaded === 0) {
+    return total == null
+      ? `No sessions${includeArchived ? ", including archived" : ""}`
+      : `Showing 0 of ${formatInt(total)} sessions`;
+  }
+  const start = (page - 1) * SESSION_PAGE_SIZE + 1;
+  const end = start + Math.max(0, loaded - 1);
   if (total == null) {
-    return `Showing ${formatInt(loaded)} sessions${includeArchived ? ", including archived" : ""}`;
+    return `Showing ${formatInt(start)}–${formatInt(end)} sessions${includeArchived ? ", including archived" : ""}`;
   }
-  return `Showing ${formatInt(loaded)} of ${formatInt(total)} sessions`;
+  return `Showing ${formatInt(start)}–${formatInt(Math.min(end, total))} of ${formatInt(total)} sessions`;
 }
 
 const SessionTableRow = memo(function SessionTableRow({

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -276,15 +276,7 @@ type SyncProgress = {
   total: number;
 };
 
-type SyncEventPayload = {
-  reason?: string;
-  status?: {
-    in_progress?: boolean;
-    last_sync_at?: string | null;
-  };
-};
-
-type ArchiveUpdatedPayload = {
+type ServerEventPayload = {
   reason?: string;
 };
 
@@ -306,13 +298,6 @@ type ModelSparklines = {
 type DateBounds = {
   min: string | null;
   max: string | null;
-};
-
-type NowView = {
-  today: Summary;
-  active_sessions: unknown[];
-  last_sync_at: string | null;
-  sync_in_progress: boolean;
 };
 
 type ActivityBucket = "context" | "planning" | "code" | "communicating";
@@ -494,7 +479,6 @@ type DashboardData = {
   activity: Activity | null;
   modelSparklines: ModelSparklines | null;
   tokenEconomics: TokenEconomics | null;
-  now: NowView | null;
   dateBounds: DateBounds | null;
 };
 
@@ -513,7 +497,6 @@ const emptyData: DashboardData = {
   activity: null,
   modelSparklines: null,
   tokenEconomics: null,
-  now: null,
   dateBounds: null,
 };
 
@@ -613,10 +596,6 @@ const SLICE_LOADERS: Record<
       ),
     }),
   },
-  now: {
-    dateScoped: false,
-    load: async () => ({ now: await getJson<NowView>("/api/analytics/now") }),
-  },
   dateBounds: {
     dateScoped: false,
     load: async () => ({ dateBounds: await getJson<DateBounds>("/api/date-bounds") }),
@@ -624,7 +603,7 @@ const SLICE_LOADERS: Record<
 };
 
 // Slices the app shell itself renders (sidebar stats, sync button, pickers).
-const SHELL_SLICES: DataSlice[] = ["summary", "now", "dateBounds", "config"];
+const SHELL_SLICES: DataSlice[] = ["summary", "dateBounds", "config"];
 
 const ROUTE_SLICES: Record<string, DataSlice[]> = {
   Sessions: [],
@@ -976,11 +955,6 @@ function App() {
         if (payload.progress != null) {
           setSyncProgress(payload.progress);
           setLocalSyncing(true);
-          setData((current) =>
-            current.now == null
-              ? current
-              : { ...current, now: { ...current.now, sync_in_progress: true } },
-          );
         }
       } catch {
         // A malformed progress event must not interrupt the live channel.
@@ -988,9 +962,9 @@ function App() {
     };
     const handleSync = (event: MessageEvent<string>) => {
       markConnected();
-      let payload: SyncEventPayload = {};
+      let payload: ServerEventPayload = {};
       try {
-        payload = JSON.parse(event.data) as SyncEventPayload;
+        payload = JSON.parse(event.data) as ServerEventPayload;
       } catch {
         // Treat malformed events as background updates so a broken optional
         // payload cannot cause an unexpected page refresh.
@@ -1002,18 +976,6 @@ function App() {
       setLocalSyncing(false);
       setSyncError(null);
       setSyncComplete(true);
-      setData((current) =>
-        current.now == null
-          ? current
-          : {
-              ...current,
-              now: {
-                ...current.now,
-                last_sync_at: payload.status?.last_sync_at ?? current.now.last_sync_at,
-                sync_in_progress: false,
-              },
-            },
-      );
       if (syncCompleteTimerRef.current != null) {
         window.clearTimeout(syncCompleteTimerRef.current);
       }
@@ -1024,9 +986,9 @@ function App() {
       requestRefresh();
     };
     const handleArchiveUpdated = (event: MessageEvent<string>) => {
-      let payload: ArchiveUpdatedPayload = {};
+      let payload: ServerEventPayload = {};
       try {
-        payload = JSON.parse(event.data) as ArchiveUpdatedPayload;
+        payload = JSON.parse(event.data) as ServerEventPayload;
       } catch {
         // Unknown archive updates remain pending until the user asks to load
         // them, preserving the current page while they scroll or inspect it.
@@ -1108,8 +1070,11 @@ function App() {
     slicesForView(activeView).includes(slice),
   );
   const metrics = data.summary;
+  // Only page one begins at the newest row, so a later page's first row is not
+  // the latest activity and the archive-wide bounds are the better fallback.
   const lastActivity =
-    latestSessionDay(sessionPageState.sessions) ?? formatDay(data.dateBounds?.max ?? null);
+    (sessionPageState.loadedPage === 1 ? latestSessionDay(sessionPageState.sessions) : null) ??
+    formatDay(data.dateBounds?.max ?? null);
   const syncInProgress = localSyncing;
   const runSync = () => {
     if (syncInProgress) {
@@ -1566,7 +1531,6 @@ function SessionsView({
     key: string;
   }>(() => ({ ids: new Set(), key: "" }));
   const { exhausted, loadedPage, loading, sessions } = sessionPageState;
-  const total = data.summary?.sessions ?? sessions.length;
   const filtered = filterSessions(sessions, query);
   const project = sessionProjectFilter(path);
   const includeArchived = sessionIncludesArchived(path);
@@ -1591,15 +1555,14 @@ function SessionsView({
     query,
   );
   const visibleTotal =
-    project == null ? total : (currentScopedSummary?.sessions ?? sessions.length);
+    project == null ? (data.summary?.sessions ?? null) : (currentScopedSummary?.sessions ?? null);
   const listTotal = includeArchived ? null : visibleTotal;
   const pageCount =
     listTotal == null ? null : Math.max(1, Math.ceil(listTotal / SESSION_PAGE_SIZE));
-  const hasNextPage =
-    !exhausted &&
-    (listTotal == null
-      ? sessions.length === SESSION_PAGE_SIZE
-      : displayedPage * SESSION_PAGE_SIZE < listTotal);
+  // The page request asks for one row past the page, so a full response is the
+  // only signal a next page needs. Deriving it from a total instead would hide
+  // Next while a scoped summary is still in flight.
+  const hasNextPage = !exhausted;
   const showPagination = displayedPage > 1 || page > 1 || hasNextPage;
   const waitingForSessions = shouldShowSessionSkeleton({
     isLoading: loading,
@@ -1771,9 +1734,11 @@ function SessionsView({
               {!waitingForSessions && filtered.length === 0 ? (
                 <tr>
                   <td colSpan={11}>
-                    {query.trim() === ""
-                      ? "No sessions ingested yet."
-                      : "No sessions match that filter."}
+                    {query.trim() !== ""
+                      ? "No sessions match that filter."
+                      : displayedPage > 1
+                        ? "No sessions on this page."
+                        : "No sessions ingested yet."}
                   </td>
                 </tr>
               ) : null}

--- a/src/ui/navigation.ts
+++ b/src/ui/navigation.ts
@@ -49,8 +49,29 @@ export function sessionIncludesArchived(path: string): boolean {
   return pathOnly(path) === "/sessions" && sessionParams(path).get("include_archived") === "true";
 }
 
+export function sessionPageFromPath(path: string): number {
+  if (pathOnly(path) !== "/sessions") {
+    return 1;
+  }
+  const page = Number(sessionParams(path).get("page") ?? "1");
+  return Number.isSafeInteger(page) && page > 0 ? page : 1;
+}
+
+export function sessionsPageHref(path: string, page: number): string {
+  const params = pathOnly(path) === "/sessions" ? sessionParams(path) : new URLSearchParams();
+  const normalizedPage = Number.isSafeInteger(page) && page > 1 ? page : 1;
+  if (normalizedPage === 1) {
+    params.delete("page");
+  } else {
+    params.set("page", String(normalizedPage));
+  }
+  const query = params.toString();
+  return query === "" ? "/sessions" : `/sessions?${query}`;
+}
+
 export function sessionsArchivedHref(path: string, includeArchived: boolean): string {
   const params = pathOnly(path) === "/sessions" ? sessionParams(path) : new URLSearchParams();
+  params.delete("page");
   if (includeArchived) {
     params.set("include_archived", "true");
   } else {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1935,6 +1935,11 @@ table {
   min-width: 1280px;
 }
 
+.sessions-panel {
+  contain: layout paint;
+  overflow-anchor: none;
+}
+
 .sessions-table .col-session-tool {
   width: 9%;
 }
@@ -2087,6 +2092,10 @@ tr:last-child td {
 
 tbody tr {
   transition: background var(--duration-hover) ease;
+}
+
+.sessions-table tbody tr {
+  transition: none;
 }
 
 @media (hover: hover) and (pointer: fine) {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -3279,8 +3279,7 @@ mark {
   top: 0;
   z-index: 2;
   border-bottom: 1px solid var(--line);
-  background: color-mix(in oklab, var(--surface) 92%, transparent);
-  backdrop-filter: blur(12px);
+  background: var(--surface);
 }
 
 .share-review-sheet > header span {
@@ -3374,8 +3373,7 @@ mark {
   bottom: 0;
   align-items: flex-end;
   border-top: 1px solid var(--line);
-  background: color-mix(in oklab, var(--surface) 92%, transparent);
-  backdrop-filter: blur(12px);
+  background: var(--surface);
 }
 
 .share-actions {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1567,6 +1567,24 @@ nav a[aria-current="page"] svg {
   padding: 12px 16px;
 }
 
+.session-pagination {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0;
+}
+
+.session-pagination > span {
+  min-width: 7.5rem;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.sessions-panel {
+  scroll-margin-top: 68px;
+}
+
 .stat-grid {
   display: grid;
   gap: 1px;
@@ -2523,11 +2541,6 @@ select {
   padding: 0;
 }
 
-.infinite-sentinel {
-  width: 1px;
-  height: 1px;
-}
-
 input::placeholder {
   color: var(--faint);
 }
@@ -2709,6 +2722,12 @@ select {
 
 .sync-button.is-syncing svg {
   animation: sync-spin 0.9s linear infinite;
+}
+
+.sync-button.has-update:not(:disabled) {
+  border-color: color-mix(in oklab, var(--accent) 35%, var(--line));
+  background: var(--accent-soft);
+  color: var(--accent-text);
 }
 
 @keyframes sync-spin {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -904,9 +904,8 @@ nav a[aria-current="page"] svg {
   gap: 12px;
   height: 56px;
   border-bottom: 1px solid var(--line);
-  background: color-mix(in oklab, var(--canvas) 84%, transparent);
+  background: var(--canvas);
   padding: 0 24px;
-  backdrop-filter: blur(14px);
 }
 
 .topbar h1 {
@@ -4501,9 +4500,8 @@ mark {
   z-index: 10;
   margin: -24px -32px 0;
   border-bottom: 1px solid var(--line);
-  background: color-mix(in oklab, var(--canvas) 86%, transparent);
+  background: var(--canvas);
   padding: 12px 32px;
-  backdrop-filter: blur(14px);
 }
 
 .thread-header-inner {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1581,10 +1581,6 @@ nav a[aria-current="page"] svg {
   text-align: center;
 }
 
-.sessions-panel {
-  scroll-margin-top: 68px;
-}
-
 .stat-grid {
   display: grid;
   gap: 1px;

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -257,6 +257,7 @@ describe("server routes", () => {
     await reader.cancel();
     const frame = new TextDecoder().decode(update.value);
     expect(frame).toContain("event: sync_progress");
+    expect(frame).toContain('"reason":"manual"');
     expect(frame).toContain('"scanned":0');
     expect(frame).toContain('"total":0');
   });

--- a/test/ui-dosu-copy.test.ts
+++ b/test/ui-dosu-copy.test.ts
@@ -23,7 +23,7 @@ describe("Dosu product copy", () => {
     expect(main).toContain("localStorage.getItem(DOSU_ANALYTICS_DISMISSAL_KEY)");
     expect(main).toContain('localStorage.setItem(DOSU_ANALYTICS_DISMISSAL_KEY, "1")');
     expect(badge).toContain('"Optimized"');
-    expect(main).toContain('["summary", "now", "dateBounds", "config"]');
+    expect(main).toContain('["summary", "dateBounds", "config"]');
     expect(main).toContain("Decant {versionLabel(data.config?.version)}");
     expect(main).not.toContain("Decant {versionLabel(data.config?.version)} ↗");
     expect(main).toContain('context.fillText("Decant", 114, 83)');

--- a/test/ui-interaction-contracts.test.ts
+++ b/test/ui-interaction-contracts.test.ts
@@ -153,13 +153,14 @@ describe("UI interaction contracts", () => {
     const sessions = sourceBetween("function SessionsView(", "function SessionTableSkeletonRows(");
     const row = sourceBetween("function SessionTableRow(", "function DosuProvenanceBadge(");
 
-    expect(app).toContain("sessionLoadKey");
+    expect(app).toContain("useSessionPage({");
     expect(app).toContain("includeArchivedSessions");
     expect(app).toContain("reloadKey");
     expect(app).toContain("reloadKey,");
     expect(render).toContain("reloadKey={actions.reloadKey}");
-    expect(app).toContain('"&include_archived=true"');
-    expect(app).toContain("sessionPageExhausted({");
+    expect(main).toContain('"&include_archived=true"');
+    expect(app).toContain("sessionPageState,");
+    expect(main).toContain("sessionPageExhausted({");
     expect(sessions).toContain("scopedSessionSummaryKey(scopedSummaryRequest, reloadKey)");
     expect(sessions).toContain("<span>Show archived</span>");
     expect(sessions).toContain("sessionsArchivedHref(path, event.target.checked)");

--- a/test/ui-loading-state.test.ts
+++ b/test/ui-loading-state.test.ts
@@ -76,11 +76,18 @@ describe("session loading state", () => {
     expect(sessionsView).toContain("sessionsPageHref(path, displayedPage + 1)");
     expect(sessionsView).not.toContain("IntersectionObserver");
     expect(sessionsView).not.toContain("infinite-sentinel");
+    expect(sessionsView).not.toContain("scrollIntoView");
     expect(main).toContain("const SessionTableRow = memo(function SessionTableRow(");
   });
 });
 
 describe("session table skeleton", () => {
+  test("reserves all fifty row slots before the first page settles", () => {
+    expect(main).toContain("{ length: SESSION_PAGE_SIZE }");
+    expect(main).toContain('() => resolveActiveRoute(locationPath(), navItems) === "Sessions"');
+    expect(main).toContain("if (showsSessions && loadedSessionKey !== sessionLoadKey)");
+  });
+
   test("keeps one placeholder aligned with each of the eleven session columns", () => {
     const start = main.indexOf("function SessionTableSkeletonRows()");
     const end = main.indexOf("function ProjectsView(", start);

--- a/test/ui-loading-state.test.ts
+++ b/test/ui-loading-state.test.ts
@@ -8,45 +8,38 @@ import {
 } from "../src/ui/loading-state.ts";
 
 const main = readFileSync(join(import.meta.dir, "..", "src", "ui", "main.tsx"), "utf8");
+const styles = readFileSync(join(import.meta.dir, "..", "src", "ui", "styles.css"), "utf8");
 
 describe("session loading state", () => {
   test("loads one explicit page plus a bounded next-page probe", () => {
     expect(
       planSessionPageLoad({
-        loadedRequestKey: "all:1",
         page: 1,
         pageSize: 50,
-        requestKey: "all:2",
       }),
     ).toEqual({ limit: 51, offset: 0, page: 1 });
     expect(
       planSessionPageLoad({
-        loadedRequestKey: "all:2:2",
         page: 3,
         pageSize: 50,
-        requestKey: "all:2:3",
       }),
     ).toEqual({ limit: 51, offset: 100, page: 3 });
   });
 
-  test("does not refetch the page represented by the active request key", () => {
+  test("returns the same plan independently of request lifecycle state", () => {
     expect(
       planSessionPageLoad({
-        loadedRequestKey: "all:2",
         page: 2,
         pageSize: 50,
-        requestKey: "all:2",
       }),
-    ).toBeNull();
+    ).toEqual({ limit: 51, offset: 50, page: 2 });
   });
 
   test("normalizes invalid page offsets without issuing an unsafe request", () => {
     expect(
       planSessionPageLoad({
-        loadedRequestKey: null,
         page: Number.MAX_SAFE_INTEGER,
         pageSize: 50,
-        requestKey: "all:huge",
       }),
     ).toEqual({ limit: 51, offset: 0, page: 1 });
   });
@@ -77,15 +70,24 @@ describe("session loading state", () => {
     expect(sessionsView).not.toContain("IntersectionObserver");
     expect(sessionsView).not.toContain("infinite-sentinel");
     expect(sessionsView).not.toContain("scrollIntoView");
+    expect(sessionsView).not.toContain("setExpandedSessions");
     expect(main).toContain("const SessionTableRow = memo(function SessionTableRow(");
+  });
+
+  test("isolates page swaps from document paint and scroll anchoring", () => {
+    expect(styles).toContain(".sessions-panel {");
+    expect(styles).toContain("contain: layout paint;");
+    expect(styles).toContain("overflow-anchor: none;");
+    expect(styles).toContain(".sessions-table tbody tr {\n  transition: none;");
   });
 });
 
 describe("session table skeleton", () => {
   test("reserves all fifty row slots before the first page settles", () => {
     expect(main).toContain("{ length: SESSION_PAGE_SIZE }");
-    expect(main).toContain('() => resolveActiveRoute(locationPath(), navItems) === "Sessions"');
-    expect(main).toContain("if (showsSessions && loadedSessionKey !== sessionLoadKey)");
+    expect(main).toContain("const loading = enabled && cached == null && currentError == null");
+    expect(main).not.toContain("setSessionsLoading");
+    expect(main).not.toContain("loadedSessionKey");
   });
 
   test("keeps one placeholder aligned with each of the eleven session columns", () => {

--- a/test/ui-loading-state.test.ts
+++ b/test/ui-loading-state.test.ts
@@ -10,6 +10,14 @@ import {
 const main = readFileSync(join(import.meta.dir, "..", "src", "ui", "main.tsx"), "utf8");
 const styles = readFileSync(join(import.meta.dir, "..", "src", "ui", "styles.css"), "utf8");
 
+function sessionsViewSource(): string {
+  const start = main.indexOf("function SessionsView(");
+  const end = main.indexOf("function SessionTableSkeletonRows()", start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return main.slice(start, end);
+}
+
 describe("session loading state", () => {
   test("loads one explicit page plus a bounded next-page probe", () => {
     expect(
@@ -59,11 +67,7 @@ describe("session loading state", () => {
   });
 
   test("uses explicit pagination without observing scroll position", () => {
-    const sessionsViewStart = main.indexOf("function SessionsView(");
-    const sessionsViewEnd = main.indexOf("function SessionTableSkeletonRows()", sessionsViewStart);
-    expect(sessionsViewStart).toBeGreaterThanOrEqual(0);
-    expect(sessionsViewEnd).toBeGreaterThan(sessionsViewStart);
-    const sessionsView = main.slice(sessionsViewStart, sessionsViewEnd);
+    const sessionsView = sessionsViewSource();
     expect(sessionsView).toContain("const toggleSession = useCallback(");
     expect(sessionsView).toContain('aria-label="Sessions pagination"');
     expect(sessionsView).toContain("sessionsPageHref(path, displayedPage + 1)");
@@ -72,6 +76,18 @@ describe("session loading state", () => {
     expect(sessionsView).not.toContain("scrollIntoView");
     expect(sessionsView).not.toContain("setExpandedSessions");
     expect(main).toContain("const SessionTableRow = memo(function SessionTableRow(");
+  });
+
+  test("derives the next page from the row probe rather than a pending total", () => {
+    const sessionsView = sessionsViewSource();
+    expect(sessionsView).toContain("const hasNextPage = !exhausted;");
+    expect(sessionsView).not.toContain("SESSION_PAGE_SIZE < listTotal");
+    expect(sessionsView).not.toContain("?? sessions.length");
+    expect(sessionsView).toContain('"No sessions on this page."');
+  });
+
+  test("reports archive-wide latest activity from page one only", () => {
+    expect(main).toMatch(/loadedPage === 1\s*\?\s*latestSessionDay\(/);
   });
 
   test("isolates page swaps from document paint and scroll anchoring", () => {

--- a/test/ui-loading-state.test.ts
+++ b/test/ui-loading-state.test.ts
@@ -86,6 +86,24 @@ describe("session loading state", () => {
     expect(sessionPageExhausted({ receivedRows: 50, requestedRows: 50 })).toBe(false);
     expect(sessionPageExhausted({ receivedRows: 0, requestedRows: 50 })).toBe(true);
   });
+
+  test("waits for scroll idle before auto-loading and keeps existing rows stable", () => {
+    const sessionsViewStart = main.indexOf("function SessionsView(");
+    const sessionsViewEnd = main.indexOf("function SessionTableSkeletonRows()", sessionsViewStart);
+    expect(sessionsViewStart).toBeGreaterThanOrEqual(0);
+    expect(sessionsViewEnd).toBeGreaterThan(sessionsViewStart);
+    const sessionsView = main.slice(sessionsViewStart, sessionsViewEnd);
+    expect(sessionsView).toContain("const toggleSession = useCallback(");
+    expect(sessionsView).toContain(
+      "loadTimer = window.setTimeout(loadNextPage, SESSION_AUTO_LOAD_IDLE_MS)",
+    );
+    expect(sessionsView).toContain(
+      'window.addEventListener("scroll", onScroll, { passive: true })',
+    );
+    expect(sessionsView).toContain('window.removeEventListener("scroll", onScroll)');
+    expect(sessionsView).toContain("clearLoadTimer()");
+    expect(main).toContain("const SessionTableRow = memo(function SessionTableRow(");
+  });
 });
 
 describe("session table skeleton", () => {

--- a/test/ui-loading-state.test.ts
+++ b/test/ui-loading-state.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
-  planSessionLoad,
+  planSessionPageLoad,
   sessionPageExhausted,
   shouldShowSessionSkeleton,
 } from "../src/ui/loading-state.ts";
@@ -10,67 +10,45 @@ import {
 const main = readFileSync(join(import.meta.dir, "..", "src", "ui", "main.tsx"), "utf8");
 
 describe("session loading state", () => {
-  test("refreshes the first page without depending on currently rendered rows", () => {
+  test("loads one explicit page plus a bounded next-page probe", () => {
     expect(
-      planSessionLoad({
+      planSessionPageLoad({
         loadedRequestKey: "all:1",
-        loadedRows: 100,
-        pageSize: 100,
+        page: 1,
+        pageSize: 50,
         requestKey: "all:2",
-        sessionLimit: 100,
       }),
-    ).toEqual({ limit: 100, offset: 0, replace: true });
+    ).toEqual({ limit: 51, offset: 0, page: 1 });
+    expect(
+      planSessionPageLoad({
+        loadedRequestKey: "all:2:2",
+        page: 3,
+        pageSize: 50,
+        requestKey: "all:2:3",
+      }),
+    ).toEqual({ limit: 51, offset: 100, page: 3 });
   });
 
-  test("preserves expanded refresh depth through successive bounded pages", () => {
+  test("does not refetch the page represented by the active request key", () => {
     expect(
-      planSessionLoad({
-        loadedRequestKey: "all:1",
-        loadedRows: 300,
-        pageSize: 100,
-        requestKey: "all:2",
-        sessionLimit: 300,
-      }),
-    ).toEqual({ limit: 100, offset: 0, replace: true });
-    expect(
-      planSessionLoad({
+      planSessionPageLoad({
         loadedRequestKey: "all:2",
-        loadedRows: 100,
-        pageSize: 100,
+        page: 2,
+        pageSize: 50,
         requestKey: "all:2",
-        sessionLimit: 300,
-      }),
-    ).toEqual({ limit: 100, offset: 100, replace: false });
-    expect(
-      planSessionLoad({
-        loadedRequestKey: "all:2",
-        loadedRows: 200,
-        pageSize: 100,
-        requestKey: "all:2",
-        sessionLimit: 300,
-      }),
-    ).toEqual({ limit: 100, offset: 200, replace: false });
-    expect(
-      planSessionLoad({
-        loadedRequestKey: "all:2",
-        loadedRows: 300,
-        pageSize: 100,
-        requestKey: "all:2",
-        sessionLimit: 300,
       }),
     ).toBeNull();
   });
 
-  test("loads the next page only after the active request key is current", () => {
+  test("normalizes invalid page offsets without issuing an unsafe request", () => {
     expect(
-      planSessionLoad({
-        loadedRequestKey: "all:2",
-        loadedRows: 100,
-        pageSize: 100,
-        requestKey: "all:2",
-        sessionLimit: 200,
+      planSessionPageLoad({
+        loadedRequestKey: null,
+        page: Number.MAX_SAFE_INTEGER,
+        pageSize: 50,
+        requestKey: "all:huge",
       }),
-    ).toEqual({ limit: 100, offset: 100, replace: false });
+    ).toEqual({ limit: 51, offset: 0, page: 1 });
   });
 
   test("does not fake a loading skeleton when rows are already visible", () => {
@@ -81,27 +59,23 @@ describe("session loading state", () => {
     expect(shouldShowSessionSkeleton({ isLoading: true, loadedRows: 0, query: "" })).toBe(true);
   });
 
-  test("marks only short pages as exhausted so exact page multiples get one final probe", () => {
-    expect(sessionPageExhausted({ receivedRows: 49, requestedRows: 50 })).toBe(true);
-    expect(sessionPageExhausted({ receivedRows: 50, requestedRows: 50 })).toBe(false);
-    expect(sessionPageExhausted({ receivedRows: 0, requestedRows: 50 })).toBe(true);
+  test("uses the extra row probe to stop at an exact page boundary", () => {
+    expect(sessionPageExhausted({ receivedRows: 50, requestedRows: 51 })).toBe(true);
+    expect(sessionPageExhausted({ receivedRows: 51, requestedRows: 51 })).toBe(false);
+    expect(sessionPageExhausted({ receivedRows: 0, requestedRows: 51 })).toBe(true);
   });
 
-  test("waits for scroll idle before auto-loading and keeps existing rows stable", () => {
+  test("uses explicit pagination without observing scroll position", () => {
     const sessionsViewStart = main.indexOf("function SessionsView(");
     const sessionsViewEnd = main.indexOf("function SessionTableSkeletonRows()", sessionsViewStart);
     expect(sessionsViewStart).toBeGreaterThanOrEqual(0);
     expect(sessionsViewEnd).toBeGreaterThan(sessionsViewStart);
     const sessionsView = main.slice(sessionsViewStart, sessionsViewEnd);
     expect(sessionsView).toContain("const toggleSession = useCallback(");
-    expect(sessionsView).toContain(
-      "loadTimer = window.setTimeout(loadNextPage, SESSION_AUTO_LOAD_IDLE_MS)",
-    );
-    expect(sessionsView).toContain(
-      'window.addEventListener("scroll", onScroll, { passive: true })',
-    );
-    expect(sessionsView).toContain('window.removeEventListener("scroll", onScroll)');
-    expect(sessionsView).toContain("clearLoadTimer()");
+    expect(sessionsView).toContain('aria-label="Sessions pagination"');
+    expect(sessionsView).toContain("sessionsPageHref(path, displayedPage + 1)");
+    expect(sessionsView).not.toContain("IntersectionObserver");
+    expect(sessionsView).not.toContain("infinite-sentinel");
     expect(main).toContain("const SessionTableRow = memo(function SessionTableRow(");
   });
 });

--- a/test/ui-navigation.test.ts
+++ b/test/ui-navigation.test.ts
@@ -8,8 +8,10 @@ import {
   pathOnly,
   projectSessionsHref,
   sessionIncludesArchived,
+  sessionPageFromPath,
   sessionProjectFilter,
   sessionsArchivedHref,
+  sessionsPageHref,
   titleFor,
 } from "../src/ui/navigation.ts";
 
@@ -128,6 +130,25 @@ describe("archived session filters", () => {
     expect(sessionIncludesArchived("/sessions?include_archived=true")).toBe(true);
     expect(sessionIncludesArchived("/projects?include_archived=true")).toBe(false);
     expect(sessionsArchivedHref("/sessions", false)).toBe("/sessions");
+  });
+});
+
+describe("session pagination", () => {
+  test("round-trips pages while preserving filters and keeping page one canonical", () => {
+    const filtered = sessionsArchivedHref(projectSessionsHref("/Users/dev/My Project"), true);
+    const secondPage = sessionsPageHref(filtered, 2);
+
+    expect(sessionPageFromPath(secondPage)).toBe(2);
+    expect(sessionProjectFilter(secondPage)).toBe("/Users/dev/My Project");
+    expect(sessionIncludesArchived(secondPage)).toBe(true);
+    expect(sessionsPageHref(secondPage, 1)).toBe(filtered);
+  });
+
+  test("normalizes invalid pages and resets pagination when archive visibility changes", () => {
+    expect(sessionPageFromPath("/sessions?page=0")).toBe(1);
+    expect(sessionPageFromPath("/sessions?page=1.5")).toBe(1);
+    expect(sessionPageFromPath("/projects?page=3")).toBe(1);
+    expect(sessionsArchivedHref("/sessions?page=3", true)).toBe("/sessions?include_archived=true");
   });
 });
 

--- a/test/ui-recovery-report.test.ts
+++ b/test/ui-recovery-report.test.ts
@@ -62,12 +62,17 @@ describe("coded UI recovery", () => {
     expect(main).toContain('active === "Sessions" && sessionsError != null');
   });
 
-  test("refreshes dashboard slices after a dropped live connection recovers", () => {
+  test("queues an explicit refresh after a dropped live connection recovers", () => {
     expect(main).toContain("const liveDroppedRef = useRef(false)");
     expect(main).toMatch(
-      /if \(liveDroppedRef\.current\) \{\s*liveDroppedRef\.current = false;\s*requestRefresh\(\);/,
+      /if \(liveDroppedRef\.current\) \{\s*liveDroppedRef\.current = false;\s*setArchiveUpdateAvailable\(true\);/,
     );
     expect(main).toContain("liveDroppedRef.current = true");
+  });
+
+  test("preserves the archive update reason in server events", () => {
+    expect(server).toMatch(/type: "archive_updated",\s*reason: "manual"/);
+    expect(server).toMatch(/type: "archive_updated",\s*reason: event\.reason/);
   });
 
   test("adds recovery actions to empty Projects and Analytics states", () => {

--- a/test/ui-recovery-report.test.ts
+++ b/test/ui-recovery-report.test.ts
@@ -58,8 +58,8 @@ describe("coded UI recovery", () => {
     expect(main).toContain(
       "setFailedSlices((current) => current.filter((slice) => needed.includes(slice)))",
     );
-    expect(main).toContain("const [sessionsError, setSessionsError]");
-    expect(main).toContain('active === "Sessions" && sessionsError != null');
+    expect(main).toContain("failed: { error: unknown; requestKey: string } | null");
+    expect(main).toContain('active === "Sessions" && sessionPageState.error != null');
   });
 
   test("queues an explicit refresh after a dropped live connection recovers", () => {

--- a/test/ui-restyle-contract.test.ts
+++ b/test/ui-restyle-contract.test.ts
@@ -68,6 +68,18 @@ describe("restyle contract", () => {
       expect(block).toContain("background: var(--canvas)");
       expect(block).not.toContain("backdrop-filter");
     }
+
+    for (const selector of ["header", "footer"]) {
+      const blocks = [
+        ...styles.matchAll(
+          new RegExp(`^\\s*\\.share-review-sheet\\s*>\\s*${selector}\\s*\\{([^}]*)\\}`, "gm"),
+        ),
+      ];
+      const block = blocks.find((match) => match[1]?.includes("position: sticky"))?.[1] ?? "";
+      expect(block).toContain("position: sticky");
+      expect(block).toContain("background: var(--surface)");
+      expect(block).not.toContain("backdrop-filter");
+    }
   });
 
   test("the display serif is only asked for a weight that ships", () => {

--- a/test/ui-restyle-contract.test.ts
+++ b/test/ui-restyle-contract.test.ts
@@ -61,6 +61,15 @@ describe("restyle contract", () => {
     expect(th).not.toContain("var(--font-mono)");
   });
 
+  test("persistent sticky headers stay opaque during scrolling", () => {
+    for (const selector of ["topbar", "thread-header"]) {
+      const block = new RegExp(`^\\.${selector} \\{([^}]*)\\}`, "m").exec(styles)?.[1] ?? "";
+      expect(block).toContain("position: sticky");
+      expect(block).toContain("background: var(--canvas)");
+      expect(block).not.toContain("backdrop-filter");
+    }
+  });
+
   test("the display serif is only asked for a weight that ships", () => {
     const weightTokens = new Map(
       [...styles.matchAll(/--font-weight-(\w+):\s*(\d+);/g)].map((match) => [

--- a/test/ui-restyle-contract.test.ts
+++ b/test/ui-restyle-contract.test.ts
@@ -63,7 +63,7 @@ describe("restyle contract", () => {
 
   test("persistent sticky headers stay opaque during scrolling", () => {
     for (const selector of ["topbar", "thread-header"]) {
-      const block = new RegExp(`^\\.${selector} \\{([^}]*)\\}`, "m").exec(styles)?.[1] ?? "";
+      const block = new RegExp(`^\\s*\\.${selector}\\s*\\{([^}]*)\\}`, "m").exec(styles)?.[1] ?? "";
       expect(block).toContain("position: sticky");
       expect(block).toContain("background: var(--canvas)");
       expect(block).not.toContain("backdrop-filter");

--- a/test/ui-sync-copy.test.ts
+++ b/test/ui-sync-copy.test.ts
@@ -7,7 +7,7 @@ const main = readFileSync(join(root, "src", "ui", "main.tsx"), "utf8");
 const styles = readFileSync(join(root, "src", "ui", "styles.css"), "utf8");
 
 test("sync stays visually icon-led while retaining a hidden live announcement", () => {
-  expect(main).toContain('aria-label="Sync session logs"');
+  expect(main).toContain('archiveUpdateAvailable ? "Load new activity" : "Sync session logs"');
   expect(main).toContain('"Syncing session logs"');
   expect(main).not.toContain("Sync in progress");
   expect(main).not.toContain("Syncing…");
@@ -17,4 +17,15 @@ test("sync stays visually icon-led while retaining a hidden live announcement", 
   expect(main).toContain("sync_in_progress: false");
   expect(styles).toContain(".sr-only {");
   expect(styles).toContain("clip-path: inset(50%)");
+});
+
+test("background archive activity waits for an explicit update", () => {
+  expect(main).toContain("const [archiveUpdateAvailable, setArchiveUpdateAvailable]");
+  expect(main).toContain('if (payload.reason !== "manual")');
+  expect(main.match(/if \(payload\.reason !== "manual"\) \{\s*return;\s*\}/g)).toHaveLength(2);
+  expect(main).toContain('payload.reason === "manual" || payload.reason === "session_state"');
+  expect(main).toContain('events.addEventListener("archive_updated", handleArchiveUpdated');
+  expect(main).not.toContain('events.addEventListener("archive_updated", requestRefresh)');
+  expect(main).toContain('archiveUpdateAvailable ? "Update" : "Sync"');
+  expect(main).toContain("archiveUpdateAvailable ? loadArchiveUpdates : runSync");
 });

--- a/test/ui-sync-copy.test.ts
+++ b/test/ui-sync-copy.test.ts
@@ -14,7 +14,9 @@ test("sync stays visually icon-led while retaining a hidden live announcement", 
   expect(main).not.toContain("Synced ·");
   expect(main).not.toContain('? "Synced" : "Sync"');
   expect(main).toContain("const LIVE_DISCONNECT_GRACE_MS = 15_000");
-  expect(main).toContain("sync_in_progress: false");
+  expect(main).toMatch(
+    /setArchiveUpdateAvailable\(false\);\s*setLocalSyncing\(false\);\s*setSyncError\(null\);\s*setSyncComplete\(true\);/,
+  );
   expect(styles).toContain(".sr-only {");
   expect(styles).toContain("clip-path: inset(50%)");
 });
@@ -28,4 +30,7 @@ test("background archive activity waits for an explicit update", () => {
   expect(main).not.toContain('events.addEventListener("archive_updated", requestRefresh)');
   expect(main).toContain('archiveUpdateAvailable ? "Update" : "Sync"');
   expect(main).toContain("archiveUpdateAvailable ? loadArchiveUpdates : runSync");
+  // The shell stopped rendering server-wide sync status, so the slice that
+  // carried it must not be fetched on every route either.
+  expect(main).not.toContain("/api/analytics/now");
 });


### PR DESCRIPTION
## Summary

- keep persistent headers opaque in light and dark mode
- replace scroll-triggered session auto-loading with explicit, URL-backed 50-row pagination
- reserve the complete 50-row table footprint before first paint, avoiding empty or partial loading frames
- keep the current 50 rows visible while another page loads and preserve the viewport when using Previous or Next
- consolidate page fetching into one abortable, bounded-cache hook without effect-derived loading state
- isolate session row swaps from document layout, paint, and browser scroll anchoring
- stop row hover transitions from scheduling continuous paint work during scrolling
- stop background watcher syncs from refreshing active views; collapse new archive activity into one explicit **Update** action
- preserve event reasons in the local SSE API and document the expanded contract

## Root cause

The visible churn had several compounding causes. Translucent sticky headers forced Chrome to re-rasterize content behind them. Infinite-scroll observers and watcher-driven archive events changed the table during scrolling. The pagination follow-up then split one request across several independent state values and effects, including a layout effect that blocked paint and a fetch effect that updated its own dependency. Pages after the first also preserved a deep scroll offset while replacing every row that Chrome could select as its scroll anchor. Finally, the row hover transition kept scheduling paint work as rows moved underneath a stationary pointer.

## UX decision

Sessions now uses explicit pagination so scrolling is display-only and users control when navigation or newly ingested activity changes the table. Filters are preserved in the URL, page one remains canonical, and background updates are represented by the existing topbar control without shifting the current rows. Previous and Next replace a fully loaded 50-row set in place without changing scroll position. Settled pages are cached for immediate return navigation, while new requests are abortable and stale responses cannot replace the active page.

## Checks

- 940 tests passed
- `bunx tsc --noEmit` passed
- `bunx biome check .` passed
- distribution staging smoke passed
- live browser verification confirmed 50 rows and a constant document height across pages 2 and 3 while rapidly scrolling in both directions
- cached Previous navigation remained settled with the same `scrollY`
- all review threads are resolved
