### PR TITLE
fix(ui): keep keyboard focus when a button disables itself

### DIFF
--- a/src/ui/focus-rescue.ts
+++ b/src/ui/focus-rescue.ts
@@ -1,0 +1,33 @@
+/**
+ * Where keyboard focus lands when the control holding it disables itself.
+ *
+ * Buttons across the UI disable on click while their work runs or once it makes
+ * them redundant: Sync while a sync is in flight, Next once the last page
+ * arrives. Browsers unfocus an element the instant it becomes disabled, so a
+ * pointer user notices nothing while a keyboard user is dropped to the document
+ * body, losing their place. Handing focus to the nearest still-usable control in
+ * the same group keeps the reader where they were working.
+ */
+
+/**
+ * The index of the control focus should move to, or null when the group has
+ * nothing usable left. `enabled[index]` is ignored: the control at `index` is
+ * the one that just became disabled.
+ */
+export function nearestUsableIndex(index: number, enabled: readonly boolean[]): number | null {
+  if (index < 0 || index >= enabled.length) {
+    return null;
+  }
+  for (let offset = 1; offset < enabled.length; offset += 1) {
+    // Backwards first. A control that disables itself at the end of its work is
+    // usually the trailing one in the group, and the control before it is the
+    // one the reader would tab back to anyway.
+    if (enabled[index - offset] === true) {
+      return index - offset;
+    }
+    if (enabled[index + offset] === true) {
+      return index + offset;
+    }
+  }
+  return null;
+}

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -3617,7 +3617,14 @@ function useDisabledFocusRescue() {
     const remember = (event: FocusEvent) => {
       lastFocused = event.target instanceof HTMLElement ? event.target : null;
     };
+    const onTheFloor = () => {
+      const landed = document.activeElement;
+      return landed === null || landed === document.body || landed === document.documentElement;
+    };
     const rescue = (control: HTMLElement) => {
+      // Landing outside the region the reader was working in, or outside an open
+      // dialog, is more disorienting than leaving focus where it fell.
+      const boundary = control.closest('dialog, [role="dialog"], main, nav, form');
       for (let scope = control.parentElement; scope != null; scope = scope.parentElement) {
         const candidates = Array.from(
           scope.querySelectorAll<HTMLElement>(FOCUS_CANDIDATE_SELECTOR),
@@ -3628,33 +3635,66 @@ function useDisabledFocusRescue() {
           next.focus();
           return;
         }
+        if (scope === boundary) {
+          return;
+        }
+      }
+    };
+    // A control usually disables as one render of an async transition, while the
+    // rest of its group is still disabled and the outgoing rows are still
+    // mounted, so the first pick can be unmounted a frame later. Keep re-picking
+    // while focus is on the floor until the transition settles.
+    const settleWindowMs = 600;
+    let disposed = false;
+    const settle = (control: HTMLElement, deadline: number) => {
+      if (disposed) {
+        return;
+      }
+      if (onTheFloor() && control.isConnected) {
+        rescue(control);
+      }
+      if (performance.now() < deadline) {
+        requestAnimationFrame(() => settle(control, deadline));
       }
     };
     const observer = new MutationObserver((records) => {
       for (const record of records) {
         const control = record.target;
-        const active = document.activeElement;
         if (
           control !== lastFocused ||
           !(control instanceof HTMLElement) ||
           !control.matches(":disabled") ||
-          (active !== null && active !== document.body && active !== document.documentElement)
+          !onTheFloor()
         ) {
           continue;
         }
         lastFocused = null;
-        rescue(control);
+        settle(control, performance.now() + settleWindowMs);
         return;
       }
     });
+    // Focus leaving a control that is still enabled means the reader moved on,
+    // so a later disable on that control is not ours to rescue.
+    const forget = (event: FocusEvent) => {
+      if (
+        event.target === lastFocused &&
+        event.target instanceof HTMLElement &&
+        !event.target.matches(":disabled")
+      ) {
+        lastFocused = null;
+      }
+    };
     document.addEventListener("focusin", remember);
+    document.addEventListener("focusout", forget);
     observer.observe(document.body, {
       attributeFilter: ["disabled"],
       attributes: true,
       subtree: true,
     });
     return () => {
+      disposed = true;
       document.removeEventListener("focusin", remember);
+      document.removeEventListener("focusout", forget);
       observer.disconnect();
     };
   }, []);

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -99,6 +99,7 @@ import { DOSU_ANALYTICS_DISMISSAL_KEY, shouldShowDosuCta } from "./dosu-cta.ts";
 import { dosuLink } from "./dosu-links.ts";
 import { dosuToolDisplayName, isDosuToolName } from "./dosu-tool.ts";
 import { effortDisplayLabel, effortTooltip } from "./effort.ts";
+import { nearestUsableIndex } from "./focus-rescue.ts";
 import { isFramed } from "./frame-guard.ts";
 import {
   createSessionSearchIndex,
@@ -861,6 +862,8 @@ function App() {
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);
   }, []);
+
+  useDisabledFocusRescue();
 
   useEffect(() => {
     document.title = documentTitleFor(path, navItems);
@@ -3535,15 +3538,16 @@ const SESSION_REPORT_NEVER_INCLUDES = [
   "Remote scripts, fonts, or tracking pixels",
 ] as const;
 
+const FOCUS_CANDIDATE_SELECTOR =
+  'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
 function dialogFocusTargets(dialog: HTMLElement | null): HTMLElement[] {
   if (dialog == null) {
     return [];
   }
-  return Array.from(
-    dialog.querySelectorAll<HTMLElement>(
-      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-    ),
-  ).filter((element) => element.getClientRects().length > 0);
+  return Array.from(dialog.querySelectorAll<HTMLElement>(FOCUS_CANDIDATE_SELECTOR)).filter(
+    (element) => !element.matches(":disabled") && element.getClientRects().length > 0,
+  );
 }
 
 function useDialogFocusTrap(
@@ -3600,6 +3604,60 @@ function useDialogFocusTrap(
       }
     };
   }, [dialogRef, onClose, open]);
+}
+
+/**
+ * One rescue for every button that disables itself while focused. React writes
+ * `disabled` as an attribute, so a single observer sees all of them and the fix
+ * does not have to be repeated at each `disabled={...ing}` call site.
+ */
+function useDisabledFocusRescue() {
+  useEffect(() => {
+    let lastFocused: HTMLElement | null = null;
+    const remember = (event: FocusEvent) => {
+      lastFocused = event.target instanceof HTMLElement ? event.target : null;
+    };
+    const rescue = (control: HTMLElement) => {
+      for (let scope = control.parentElement; scope != null; scope = scope.parentElement) {
+        const candidates = Array.from(
+          scope.querySelectorAll<HTMLElement>(FOCUS_CANDIDATE_SELECTOR),
+        ).filter((element) => element === control || element.getClientRects().length > 0);
+        const enabled = candidates.map((element) => !element.matches(":disabled"));
+        const next = candidates[nearestUsableIndex(candidates.indexOf(control), enabled) ?? -1];
+        if (next != null) {
+          next.focus();
+          return;
+        }
+      }
+    };
+    const observer = new MutationObserver((records) => {
+      for (const record of records) {
+        const control = record.target;
+        const active = document.activeElement;
+        if (
+          control !== lastFocused ||
+          !(control instanceof HTMLElement) ||
+          !control.matches(":disabled") ||
+          (active !== null && active !== document.body)
+        ) {
+          continue;
+        }
+        lastFocused = null;
+        rescue(control);
+        return;
+      }
+    });
+    document.addEventListener("focusin", remember);
+    observer.observe(document.body, {
+      attributeFilter: ["disabled"],
+      attributes: true,
+      subtree: true,
+    });
+    return () => {
+      document.removeEventListener("focusin", remember);
+      observer.disconnect();
+    };
+  }, []);
 }
 
 function PrivacyReviewLists({

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -3614,14 +3614,21 @@ function useDialogFocusTrap(
 function useDisabledFocusRescue() {
   useEffect(() => {
     let lastFocused: HTMLElement | null = null;
+    let pendingControl: WeakRef<HTMLElement> | null = null;
     const remember = (event: FocusEvent) => {
+      pendingControl = null;
       lastFocused = event.target instanceof HTMLElement ? event.target : null;
     };
-    const onTheFloor = () => {
+    const focusNeedsRescue = (control: HTMLElement) => {
       const landed = document.activeElement;
-      return landed === null || landed === document.body || landed === document.documentElement;
+      return (
+        landed === null ||
+        (landed === control && control.matches(":disabled")) ||
+        landed === document.body ||
+        landed === document.documentElement
+      );
     };
-    const rescue = (control: HTMLElement) => {
+    const rescueTarget = (control: HTMLElement) => {
       // Landing outside the region the reader was working in, or outside an open
       // dialog, is more disorienting than leaving focus where it fell.
       const boundary = control.closest('dialog, [role="dialog"], main, nav, form');
@@ -3632,29 +3639,24 @@ function useDisabledFocusRescue() {
         const enabled = candidates.map((element) => !element.matches(":disabled"));
         const next = candidates[nearestUsableIndex(candidates.indexOf(control), enabled) ?? -1];
         if (next != null) {
-          next.focus();
-          return;
+          return next;
         }
         if (scope === boundary) {
-          return;
+          return null;
         }
       }
+      return null;
     };
-    // A control usually disables as one render of an async transition, while the
-    // rest of its group is still disabled and the outgoing rows are still
-    // mounted, so the first pick can be unmounted a frame later. Keep re-picking
-    // while focus is on the floor until the transition settles.
-    const settleWindowMs = 600;
-    let disposed = false;
-    const settle = (control: HTMLElement, deadline: number) => {
-      if (disposed) {
+    const retryPending = () => {
+      const control = pendingControl?.deref();
+      if (control == null || !control.isConnected || !focusNeedsRescue(control)) {
+        pendingControl = null;
         return;
       }
-      if (onTheFloor() && control.isConnected) {
-        rescue(control);
-      }
-      if (performance.now() < deadline) {
-        requestAnimationFrame(() => settle(control, deadline));
+      const next = rescueTarget(control);
+      if (next != null) {
+        pendingControl = null;
+        next.focus();
       }
     };
     const observer = new MutationObserver((records) => {
@@ -3664,14 +3666,18 @@ function useDisabledFocusRescue() {
           control !== lastFocused ||
           !(control instanceof HTMLElement) ||
           !control.matches(":disabled") ||
-          !onTheFloor()
+          !focusNeedsRescue(control)
         ) {
           continue;
         }
         lastFocused = null;
-        settle(control, performance.now() + settleWindowMs);
-        return;
+        pendingControl = new WeakRef(control);
+        break;
       }
+      // A pagination group can remain entirely disabled for longer than any
+      // safe timer. Every relevant control becoming usable changes its disabled
+      // attribute, so retry from that mutation instead of racing the request.
+      retryPending();
     });
     // Focus leaving a control that is still enabled means the reader moved on,
     // so a later disable on that control is not ours to rescue.
@@ -3684,17 +3690,23 @@ function useDisabledFocusRescue() {
         lastFocused = null;
       }
     };
+    const cancelPending = () => {
+      pendingControl = null;
+    };
     document.addEventListener("focusin", remember);
     document.addEventListener("focusout", forget);
+    document.addEventListener("keydown", cancelPending, true);
+    document.addEventListener("pointerdown", cancelPending, true);
     observer.observe(document.body, {
       attributeFilter: ["disabled"],
       attributes: true,
       subtree: true,
     });
     return () => {
-      disposed = true;
       document.removeEventListener("focusin", remember);
       document.removeEventListener("focusout", forget);
+      document.removeEventListener("keydown", cancelPending, true);
+      document.removeEventListener("pointerdown", cancelPending, true);
       observer.disconnect();
     };
   }, []);

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -3638,7 +3638,7 @@ function useDisabledFocusRescue() {
           control !== lastFocused ||
           !(control instanceof HTMLElement) ||
           !control.matches(":disabled") ||
-          (active !== null && active !== document.body)
+          (active !== null && active !== document.body && active !== document.documentElement)
         ) {
           continue;
         }

--- a/test/ui-focus-rescue.test.ts
+++ b/test/ui-focus-rescue.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { nearestUsableIndex } from "../src/ui/focus-rescue.ts";
+
+describe("nearestUsableIndex", () => {
+  test("prefers the control before the one that just disabled itself", () => {
+    // Previous, Next: Next disables on the last page and focus lands on Previous.
+    expect(nearestUsableIndex(1, [true, false])).toBe(0);
+  });
+
+  test("falls forward when nothing before the control is usable", () => {
+    expect(nearestUsableIndex(1, [false, false, true])).toBe(2);
+  });
+
+  test("takes the nearest usable control on either side", () => {
+    expect(nearestUsableIndex(3, [true, false, false, false, true])).toBe(4);
+    expect(nearestUsableIndex(3, [true, false, true, false, false])).toBe(2);
+  });
+
+  test("ignores whether the disabled control itself reads as enabled", () => {
+    expect(nearestUsableIndex(1, [true, true])).toBe(0);
+  });
+
+  test("returns null when the group has nothing usable left", () => {
+    expect(nearestUsableIndex(0, [false])).toBeNull();
+    expect(nearestUsableIndex(1, [false, false, false])).toBeNull();
+  });
+
+  test("returns null for an index outside the group", () => {
+    expect(nearestUsableIndex(-1, [true, true])).toBeNull();
+    expect(nearestUsableIndex(2, [true, true])).toBeNull();
+  });
+});
+
+describe("disabled focus rescue wiring", () => {
+  const main = readFileSync(join(import.meta.dir, "..", "src", "ui", "main.tsx"), "utf8");
+  const hook = main.slice(
+    main.indexOf("function useDisabledFocusRescue("),
+    main.indexOf("function PrivacyReviewLists("),
+  );
+
+  test("App installs the rescue once, not per button", () => {
+    expect(main).toContain("useDisabledFocusRescue();");
+    expect(main.split("useDisabledFocusRescue();")).toHaveLength(2);
+  });
+
+  test("watches disabled attributes across the whole tree", () => {
+    expect(hook).toContain("new MutationObserver(");
+    expect(hook).toContain('attributeFilter: ["disabled"]');
+    expect(hook).toContain("subtree: true");
+    expect(hook).toContain("observer.disconnect()");
+  });
+
+  test("only rescues the control that held focus, and never steals it back", () => {
+    expect(hook).toContain("control !== lastFocused");
+    expect(hook).toContain('control.matches(":disabled")');
+    expect(hook).toContain("active !== null && active !== document.body");
+  });
+
+  test("searches widening scopes with the shared focus selector", () => {
+    expect(hook).toContain("FOCUS_CANDIDATE_SELECTOR");
+    expect(hook).toContain("scope = scope.parentElement");
+    expect(hook).toContain("nearestUsableIndex(");
+  });
+});

--- a/test/ui-focus-rescue.test.ts
+++ b/test/ui-focus-rescue.test.ts
@@ -55,10 +55,11 @@ describe("disabled focus rescue wiring", () => {
   test("only rescues the control that held focus, and never steals it back", () => {
     expect(hook).toContain("control !== lastFocused");
     expect(hook).toContain('control.matches(":disabled")');
-    expect(hook).toContain(
-      "landed === null || landed === document.body || landed === document.documentElement",
-    );
-    expect(hook).toContain("!onTheFloor()");
+    expect(hook).toContain("landed === null");
+    expect(hook).toContain('landed === control && control.matches(":disabled")');
+    expect(hook).toContain("landed === document.body");
+    expect(hook).toContain("landed === document.documentElement");
+    expect(hook).toContain("!focusNeedsRescue(control)");
   });
 
   test("forgets a control the reader left while it was still enabled", () => {
@@ -68,11 +69,20 @@ describe("disabled focus rescue wiring", () => {
     expect(hook).toContain('!event.target.matches(":disabled")');
   });
 
-  test("re-picks while focus is on the floor until the transition settles", () => {
-    expect(hook).toContain("requestAnimationFrame(() => settle(control, deadline))");
+  test("retries from later disabled mutations instead of racing a fixed timer", () => {
+    expect(hook).toContain("let pendingControl: WeakRef<HTMLElement> | null = null");
+    expect(hook).toContain("pendingControl = new WeakRef(control)");
+    expect(hook).toContain("const control = pendingControl?.deref()");
     expect(hook).toContain("control.isConnected");
-    expect(hook).toContain("performance.now() + settleWindowMs");
-    expect(hook).toContain("disposed = true");
+    expect(hook).toContain("retryPending();");
+    expect(hook).not.toContain("settleWindowMs");
+  });
+
+  test("abandons a pending rescue when the reader takes another action", () => {
+    expect(hook).toContain('document.addEventListener("keydown", cancelPending, true)');
+    expect(hook).toContain('document.addEventListener("pointerdown", cancelPending, true)');
+    expect(hook).toContain('document.removeEventListener("keydown", cancelPending, true)');
+    expect(hook).toContain('document.removeEventListener("pointerdown", cancelPending, true)');
   });
 
   test("searches widening scopes with the shared focus selector, up to a landmark", () => {

--- a/test/ui-focus-rescue.test.ts
+++ b/test/ui-focus-rescue.test.ts
@@ -56,13 +56,30 @@ describe("disabled focus rescue wiring", () => {
     expect(hook).toContain("control !== lastFocused");
     expect(hook).toContain('control.matches(":disabled")');
     expect(hook).toContain(
-      "active !== null && active !== document.body && active !== document.documentElement",
+      "landed === null || landed === document.body || landed === document.documentElement",
     );
+    expect(hook).toContain("!onTheFloor()");
   });
 
-  test("searches widening scopes with the shared focus selector", () => {
+  test("forgets a control the reader left while it was still enabled", () => {
+    expect(hook).toContain('document.addEventListener("focusout", forget)');
+    expect(hook).toContain('document.removeEventListener("focusout", forget)');
+    expect(hook).toContain("event.target === lastFocused");
+    expect(hook).toContain('!event.target.matches(":disabled")');
+  });
+
+  test("re-picks while focus is on the floor until the transition settles", () => {
+    expect(hook).toContain("requestAnimationFrame(() => settle(control, deadline))");
+    expect(hook).toContain("control.isConnected");
+    expect(hook).toContain("performance.now() + settleWindowMs");
+    expect(hook).toContain("disposed = true");
+  });
+
+  test("searches widening scopes with the shared focus selector, up to a landmark", () => {
     expect(hook).toContain("FOCUS_CANDIDATE_SELECTOR");
     expect(hook).toContain("scope = scope.parentElement");
     expect(hook).toContain("nearestUsableIndex(");
+    expect(hook).toContain("control.closest('dialog, [role=\"dialog\"], main, nav, form')");
+    expect(hook).toContain("scope === boundary");
   });
 });

--- a/test/ui-focus-rescue.test.ts
+++ b/test/ui-focus-rescue.test.ts
@@ -55,7 +55,9 @@ describe("disabled focus rescue wiring", () => {
   test("only rescues the control that held focus, and never steals it back", () => {
     expect(hook).toContain("control !== lastFocused");
     expect(hook).toContain('control.matches(":disabled")');
-    expect(hook).toContain("active !== null && active !== document.body");
+    expect(hook).toContain(
+      "active !== null && active !== document.body && active !== document.documentElement",
+    );
   });
 
   test("searches widening scopes with the shared focus selector", () => {


### PR DESCRIPTION
## What

Clicking **Next** on the second-to-last page silently dropped keyboard focus: the button disables itself once the last page loads, and browsers unfocus an element the instant it becomes disabled, so focus fell back to the document body. `Sync` and roughly eight other `disabled={...ing}` buttons across `main.tsx` had the same gap.

Rather than patch each call site, this adds one rescue. React 19 writes `disabled` via `setAttribute`, so a single `MutationObserver` in `App` catches every instance:

- `src/ui/focus-rescue.ts` — `nearestUsableIndex`, the pure pick: nearest still-enabled control in the group, searching backwards first (a trailing control like Next hands focus to Previous).
- `useDisabledFocusRescue` in `main.tsx` — tracks the last focused element, and when that element becomes disabled while focus has fallen to the body, walks widening ancestor scopes for a usable control and focuses it. Bails if the app already moved focus somewhere itself.
- `dialogFocusTargets` now shares the same `FOCUS_CANDIDATE_SELECTOR` instead of carrying its own copy.

## Testing

- `bun test` — 951 pass, 1 skip (shellcheck not on PATH). New `test/ui-focus-rescue.test.ts` covers the pick logic directly and the wiring as a source contract, matching how the other `test/ui-*` suites work.
- `bunx tsc --noEmit`, `bunx biome check .` — clean.
- Smoke: `decant serve` boots, the UI bundle builds, and the observer ships in the served bundle.

The pick logic and wiring are covered by tests, but there is no DOM test environment in this repo, so the browser-level focus move itself is not machine-verified — worth a manual keyboard pass on `/sessions` pagination and the Sync button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)