### PR TITLE
fix: refine product copy and report labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ and your transcripts never leave your machine.
 
 Built by
 [Dosu](https://dosu.dev?utm_source=decant&utm_medium=github&utm_campaign=attribution&utm_content=readme),
-Knowledge Infrastructure for Agents. Dosu makes agents faster, cheaper, and
-more effective across every run.
+Knowledge Infrastructure for Agents. Dosu helps make agents faster, cheaper,
+and more effective.
 
 ![Decant analytics dashboard](docs/assets/decant-serve.png)
 
@@ -147,9 +147,9 @@ Report vulnerabilities privately as described in [SECURITY.md](SECURITY.md).
 
 Decant is built and maintained by
 [Dosu](https://dosu.dev?utm_source=decant&utm_medium=github&utm_campaign=attribution&utm_content=about),
-Knowledge Infrastructure for Agents. Dosu makes agents faster, cheaper, and
-more effective across every run. Decant shows what your agents spent, read, and
-touched via your agent logs.
+Knowledge Infrastructure for Agents. Dosu helps make agents faster, cheaper,
+and more effective. Decant shows what your agents spent, read, and touched via
+your agent logs.
 
 ## Acknowledgments
 

--- a/npm/decant/README.md
+++ b/npm/decant/README.md
@@ -12,8 +12,8 @@ and your transcripts never leave your machine.
 
 Built by
 [Dosu](https://dosu.dev?utm_source=decant&utm_medium=npm&utm_campaign=attribution&utm_content=package_readme),
-Knowledge Infrastructure for Agents. Dosu makes agents faster, cheaper, and
-more effective across every run.
+Knowledge Infrastructure for Agents. Dosu helps make agents faster, cheaper,
+and more effective.
 
 ## Run without installing
 

--- a/src/report/charts.ts
+++ b/src/report/charts.ts
@@ -1,7 +1,11 @@
 import * as echarts from "echarts";
 import type { ContextWindowTimeline } from "../context-window.ts";
 import type { DimRow } from "../stats.ts";
-import { layoutContextCurve } from "../ui/context-window-layout.ts";
+import {
+  groupContextMarkers,
+  layoutContextAnnotations,
+  layoutContextCurve,
+} from "../ui/context-window-layout.ts";
 
 export interface ReportChartSize {
   width?: number;
@@ -17,8 +21,13 @@ const SAGE = "#778561";
 const SAGE_LIGHT = "#b4bb91";
 const REPORT_SANS_STACK =
   "'IBM Plex Sans', ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
-const CONTEXT_GRID_HORIZONTAL_PADDING = 80;
+const CONTEXT_GRID_TOP = 24;
+const CONTEXT_GRID_LEFT = 62;
+const CONTEXT_GRID_RIGHT = 18;
+const CONTEXT_GRID_HORIZONTAL_PADDING = CONTEXT_GRID_LEFT + CONTEXT_GRID_RIGHT;
 const CONTEXT_MARKER_GAP_PX = 3;
+const CONTEXT_COMPACTION_LABEL_SEPARATION_PX = 100;
+const CONTEXT_COMPACTION_LABEL_LANE_GAP_PX = 13;
 const REPORT_SVG_TAGS = new Set([
   "svg",
   "g",
@@ -45,6 +54,14 @@ export interface ReportContextWindowGeometry {
   segments: [number, number][][];
   slotWidth: number;
   turnOrder: number[];
+}
+
+export interface ReportCompactionLabel {
+  align: "left" | "right";
+  lane: number;
+  markerIndex: number;
+  offset: [number, number];
+  text: string;
 }
 
 /**
@@ -214,6 +231,12 @@ export function renderContextWindowChart(
   const width = size.width ?? DEFAULT_WIDTH;
   const geometry = reportContextWindowGeometry(timeline, width);
   const windowTokens = timeline.window_tokens;
+  const labelList = reportCompactionLabels(geometry.compactionXs, width);
+  const compactionLabels = new Map(labelList.map((label) => [label.markerIndex, label]));
+  const compactionLabelLanes = labelList.reduce(
+    (highestLane, label) => Math.max(highestLane, label.lane),
+    0,
+  );
   const compactionMarkLine =
     geometry.compactionXs.length === 0
       ? undefined
@@ -223,10 +246,25 @@ export function renderContextWindowChart(
           label: {
             color: MUTED,
             fontSize: 10,
-            formatter: "compaction",
+            position: "end" as const,
+            verticalAlign: "bottom" as const,
           },
           lineStyle: { color: MUTED, type: "dashed" as const, width: 1 },
-          data: geometry.compactionXs.map((x) => ({ xAxis: x })),
+          data: geometry.compactionXs.map((x, index) => {
+            const label = compactionLabels.get(index);
+            return {
+              xAxis: x,
+              label:
+                label == null
+                  ? { show: false }
+                  : {
+                      align: label.align,
+                      formatter: label.text,
+                      offset: label.offset,
+                      show: true,
+                    },
+            };
+          }),
         };
   const lineSeries = geometry.segments.map(
     (segment, index): echarts.LineSeriesOption => ({
@@ -258,7 +296,12 @@ export function renderContextWindowChart(
       : [];
   return renderChartSvg(
     {
-      grid: { top: 24, right: 18, bottom: 44, left: 62 },
+      grid: {
+        top: CONTEXT_GRID_TOP + compactionLabelLanes * CONTEXT_COMPACTION_LABEL_LANE_GAP_PX,
+        right: CONTEXT_GRID_RIGHT,
+        bottom: 44,
+        left: CONTEXT_GRID_LEFT,
+      },
       xAxis: {
         type: "value",
         min: 0,
@@ -288,6 +331,53 @@ export function renderContextWindowChart(
     },
     { width, height: size.height ?? 280 },
   );
+}
+
+/**
+ * Nearby compaction lines share one count label. Repeating the same word above
+ * every line adds no information and makes dense report charts unreadable.
+ * Remaining edge collisions move into additional lanes above the plot.
+ */
+export function reportCompactionLabels(
+  compactionXs: readonly number[],
+  width = DEFAULT_WIDTH,
+): ReportCompactionLabel[] {
+  const plotLeft = CONTEXT_GRID_LEFT;
+  const plotRight = Math.max(plotLeft, width - CONTEXT_GRID_RIGHT);
+  const plotWidth = plotRight - plotLeft;
+  const markerPixels = compactionXs.map((x) => plotLeft + x * plotWidth);
+  const grouped = groupContextMarkers(markerPixels, CONTEXT_COMPACTION_LABEL_SEPARATION_PX).map(
+    (group) => {
+      const markerIndex = group.indexes.reduce((nearest, index) => {
+        const nearestDistance = Math.abs((markerPixels[nearest] ?? group.x) - group.x);
+        const distance = Math.abs((markerPixels[index] ?? group.x) - group.x);
+        return distance < nearestDistance ? index : nearest;
+      }, group.indexes[0] ?? 0);
+      return {
+        markerIndex,
+        text: group.indexes.length === 1 ? "compaction" : `${group.indexes.length} compactions`,
+        x: markerPixels[markerIndex] ?? group.x,
+      };
+    },
+  );
+  const placements = layoutContextAnnotations(grouped, {
+    labelYs: grouped.map((_, lane) =>
+      lane === 0 ? 0 : -lane * CONTEXT_COMPACTION_LABEL_LANE_GAP_PX,
+    ),
+    plotLeft,
+    plotRight,
+  });
+
+  return grouped.map((group, index) => {
+    const placement = placements[index];
+    return {
+      align: placement?.anchor === "end" ? "right" : "left",
+      lane: placement?.lane ?? 0,
+      markerIndex: group.markerIndex,
+      offset: [placement == null ? 0 : placement.textX - group.x, placement?.textY ?? 0],
+      text: group.text,
+    };
+  });
 }
 
 /**

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -8837,7 +8837,7 @@ function SessionDetailView({
                   type="button"
                 >
                   <Icon name="trash" />
-                  <span>Delete session…</span>
+                  <span>Delete session</span>
                 </button>
               </OverflowMenu>
             </div>

--- a/test/report.test.ts
+++ b/test/report.test.ts
@@ -9,6 +9,7 @@ import {
   renderChartSvg,
   renderContextWindowChart,
   renderSessionsByDayChart,
+  reportCompactionLabels,
   reportContextWindowGeometry,
   sanitizeReportSvg,
 } from "../src/report/charts.ts";
@@ -359,6 +360,32 @@ describe("report charts", () => {
     expect(svg).toContain("<svg");
     expect(svg).toContain("compaction");
     expect(svg).not.toContain("NaN");
+
+    const clusteredSvg = renderContextWindowChart({
+      ...timeline,
+      compactions: [
+        {
+          seq: 2,
+          timestamp: "2026-07-28T10:01:00Z",
+          trigger: "auto",
+          pre_tokens: 24_000,
+          post_tokens: 5_000,
+        },
+        ...timeline.compactions,
+      ],
+    });
+    expect(clusteredSvg).toContain("2 compactions");
+  });
+
+  test("groups nearby compaction labels so report annotations cannot collide", () => {
+    expect(reportCompactionLabels([0.4, 0.43, 0.8], 760)).toMatchObject([
+      { markerIndex: 0, text: "2 compactions" },
+      { markerIndex: 2, text: "compaction" },
+    ]);
+    expect(reportCompactionLabels([0.79, 0.94], 760)).toMatchObject([
+      { lane: 0, offset: [6, 0] },
+      { lane: 1, offset: [-6, -13] },
+    ]);
   });
 
   test("report narrative and notices name the bundled font families and licenses", () => {

--- a/test/ui-dosu-copy.test.ts
+++ b/test/ui-dosu-copy.test.ts
@@ -42,7 +42,8 @@ describe("Dosu product copy", () => {
     for (const document of [readme, npmReadme]) {
       const normalized = document.replaceAll("\n", " ");
       expect(normalized).toContain("Knowledge Infrastructure for Agents");
-      expect(normalized).toContain(
+      expect(normalized).toContain("Dosu helps make agents faster, cheaper, and more effective.");
+      expect(normalized).not.toContain(
         "Dosu makes agents faster, cheaper, and more effective across every run.",
       );
       expect(normalized).toContain(

--- a/test/ui-interaction-contracts.test.ts
+++ b/test/ui-interaction-contracts.test.ts
@@ -192,7 +192,8 @@ describe("UI interaction contracts", () => {
     expect(session).toContain("archiveActionFor(detail.summary)");
     expect(session).toContain("Archive session");
     expect(session).toContain("Unarchive session");
-    expect(session).toContain("Delete session…");
+    expect(session).toContain("Delete session");
+    expect(session).not.toContain("Delete session…");
     expect(session).toContain("sessionStateRequest(id, state)");
     expect(session).toContain("sessionStateMutationGenerationRef.current !== mutationGeneration");
   });


### PR DESCRIPTION
## Summary

- update Dosu positioning in the repository and npm READMEs
- remove the unnecessary ellipsis from the session delete menu action
- prevent exported context-window compaction labels from colliding by grouping nearby markers and stacking remaining edge conflicts
- add regression coverage for copy, menu, helper geometry, and rendered SVG output

## Why

The public Dosu description needed updated wording, the delete action does not require ellipsis styling, and adjacent compaction annotations could overlap in exported reports. These changes keep the product copy current and make dense report charts readable.

## Impact

Users see the updated Dosu description, a cleaner delete action label, and non-overlapping compaction annotations in exported context-window reports.

## Validation

- `bunx tsc --noEmit`
- `bunx biome check .`
- focused report and UI contract tests: 27 passed
- full suite: 937 passed in the clean baseline run; later loaded-run timing failures were unrelated and passed when rerun in isolation
