### PR TITLE
feat: surface the orientation and implementation split

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ decant ls                      # list sessions
 decant show 1                  # render a transcript
 decant search "auth bug"       # full-text search
 decant stats --by model        # usage and cost rollups
-decant economics               # token, cost, and time breakdowns
+decant economics               # cost and time by activity, orientation vs implementation
 decant files --group ext       # file hotspots
 decant tool stats              # tool usage
 decant mcp stats               # MCP server usage

--- a/docs/analytics-methodology.md
+++ b/docs/analytics-methodology.md
@@ -99,7 +99,10 @@ Each phase carries a `cost_share`: its fraction of the enclosing object's
 `estimated_cost_usd`, on a 0-1 scale like `TokenEconomicsBucket.cost_share`.
 Inside a bucket it is that phase's share of that bucket; inside `totals` it is
 that phase's share of the archive or session total. An edit-free session
-reports an orientation share of 1.
+reports an orientation share of 1. Where there is no cost to divide -- an empty
+archive, or a bucket that recorded no spend -- both shares are 0 rather than
+summing to 1, so read the pair as a split of a total, not as a partition that
+always adds up.
 
 The split is reported by `decant economics`, which appends `orientation` and
 `implementation` rows after the bucket rows, by the generated report's

--- a/docs/analytics-methodology.md
+++ b/docs/analytics-methodology.md
@@ -95,6 +95,17 @@ high-confidence patterns such as `git apply`, `sed -i`, and explicit file-write
 APIs. The classifier prefers missing a weak signal over moving the boundary
 forward on a false positive.
 
+Each phase carries a `cost_share`: its fraction of the enclosing object's
+`estimated_cost_usd`, on a 0-1 scale like `TokenEconomicsBucket.cost_share`.
+Inside a bucket it is that phase's share of that bucket; inside `totals` it is
+that phase's share of the archive or session total. An edit-free session
+reports an orientation share of 1.
+
+The split is reported by `decant economics`, which appends `orientation` and
+`implementation` rows after the bucket rows, by the generated report's
+"Orientation vs implementation" table, and by the Activity breakdown panel in
+the local UI.
+
 ## Active time and user wait
 
 Active time is an attribution from message timestamps, not stopwatch time. The

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2318,7 +2318,12 @@ components:
       additionalProperties: false
     PhaseAmounts:
       type: object
-      required: [generation_tokens, context_window_tokens, estimated_cost_usd, active_ms]
+      required:
+        - generation_tokens
+        - context_window_tokens
+        - estimated_cost_usd
+        - active_ms
+        - cost_share
       properties:
         generation_tokens:
           type: number
@@ -2330,6 +2335,9 @@ components:
           type: number
           minimum: 0
         active_ms:
+          type: number
+          minimum: 0
+        cost_share:
           type: number
           minimum: 0
       additionalProperties: false

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -906,7 +906,8 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
     .command("tokens")
     .alias("economics")
     .description(
-      "break tokens, cost, agent time, and user wait into context, planning, code, and communicating",
+      "break tokens, cost, agent time, and user wait into context, planning, code, and " +
+        "communicating, then into orientation and implementation",
     )
     .action(() =>
       run(() => {
@@ -926,6 +927,27 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
               .concat(row.buckets.length > 0 ? "\n" : "")
               .concat(
                 `waiting_on_user\t-\t-\t-\t${formatDuration(row.totals.waiting_on_user_ms)}\n`,
+              )
+              // Phases are orthogonal to the buckets above, so they append as
+              // their own rows with the cost share the buckets do not carry.
+              .concat(
+                row.totals.phases == null
+                  ? ""
+                  : (["orientation", "implementation"] as const)
+                      .map((phase) => {
+                        const amounts = row.totals.phases?.[phase];
+                        if (amounts == null) {
+                          return "";
+                        }
+                        return (
+                          `${phase}\t${formatNumber(amounts.generation_tokens)}\t` +
+                          `${formatNumber(amounts.context_window_tokens)}\t` +
+                          `${amounts.estimated_cost_usd.toFixed(4)}\t` +
+                          `${formatDuration(amounts.active_ms)}\t` +
+                          `${formatPercent(amounts.cost_share)}\n`
+                        );
+                      })
+                      .join(""),
               ),
           );
         } finally {
@@ -1237,6 +1259,10 @@ function trustedPeers(values: string[] | undefined): string[] {
 
 function formatNumber(value: number): string {
   return String(Math.round(value));
+}
+
+function formatPercent(share: number): string {
+  return `${(share * 100).toFixed(1)}%`;
 }
 
 function formatDuration(ms: number): string {

--- a/src/report/render.tsx
+++ b/src/report/render.tsx
@@ -382,7 +382,7 @@ function PhaseRow({ amounts, label }: { amounts: PhaseAmounts; label: string }) 
   return (
     <tr>
       <td>{label}</td>
-      <td className="number">{formatShare(amounts.cost_share)}</td>
+      <td className="number">{formatPercent(amounts.cost_share, 1)}</td>
       <td className="number">{formatCurrency(amounts.estimated_cost_usd)}</td>
       <td className="number">{formatDuration(Math.round(amounts.active_ms / 1000))}</td>
       <td className="number">{formatCompact(amounts.generation_tokens)}</td>
@@ -521,17 +521,14 @@ function formatCurrency(value: number): string {
   }).format(value);
 }
 
-function formatPercent(value: number): string {
+/** Whole percent by default. The phase table passes 1, because rounding a near-even
+ * split to whole percent reads as a tie; `decant economics` prints it the same way. */
+function formatPercent(value: number, digits = 0): string {
   return new Intl.NumberFormat("en-US", {
     style: "percent",
-    maximumFractionDigits: 0,
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
   }).format(value);
-}
-
-/** A 0-1 share at the CLI's precision. `formatPercent` rounds to whole percent,
- * which reads as a tie for any split near even. */
-function formatShare(share: number): string {
-  return `${(share * 100).toFixed(1)}%`;
 }
 
 function formatDuration(seconds: number | null): string {

--- a/src/report/render.tsx
+++ b/src/report/render.tsx
@@ -1,6 +1,6 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { mcpServerLabel, mcpServerLabels } from "../mcp-names.ts";
-import type { TokenEconomics, TokenEconomicsBucket } from "../token-economics.ts";
+import type { PhaseAmounts, TokenEconomics, TokenEconomicsBucket } from "../token-economics.ts";
 import { DECANT_VERSION } from "../version.ts";
 import {
   renderContextWindowChart,
@@ -317,6 +317,9 @@ function DimensionTable({
 }
 
 function EconomicsSection({ economics }: { economics: TokenEconomics }) {
+  // Older archives and the session fixtures can arrive without a phase split,
+  // so the second table is opt-in rather than assumed.
+  const phases = economics.totals.phases;
   return (
     <section className="section">
       <h2>Token economics</h2>
@@ -337,6 +340,27 @@ function EconomicsSection({ economics }: { economics: TokenEconomics }) {
           ))}
         </tbody>
       </table>
+      {phases == null ? null : (
+        <>
+          <h3>Orientation vs implementation</h3>
+          <table className="compact">
+            <thead>
+              <tr>
+                <th>Phase</th>
+                <th className="number">Share of cost</th>
+                <th className="number">Cost</th>
+                <th className="number">Active time</th>
+                <th className="number">Generation</th>
+                <th className="number">Context</th>
+              </tr>
+            </thead>
+            <tbody>
+              <PhaseRow amounts={phases.orientation} label="Orientation" />
+              <PhaseRow amounts={phases.implementation} label="Implementation" />
+            </tbody>
+          </table>
+        </>
+      )}
     </section>
   );
 }
@@ -350,6 +374,19 @@ function EconomicsRow({ bucket }: { bucket: TokenEconomicsBucket }) {
       <td className="number">{formatInteger(bucket.tool_calls)}</td>
       <td className="number">{formatDuration(Math.round(bucket.active_ms / 1000))}</td>
       <td className="number">{formatCurrency(bucket.estimated_cost_usd)}</td>
+    </tr>
+  );
+}
+
+function PhaseRow({ amounts, label }: { amounts: PhaseAmounts; label: string }) {
+  return (
+    <tr>
+      <td>{label}</td>
+      <td className="number">{formatShare(amounts.cost_share)}</td>
+      <td className="number">{formatCurrency(amounts.estimated_cost_usd)}</td>
+      <td className="number">{formatDuration(Math.round(amounts.active_ms / 1000))}</td>
+      <td className="number">{formatCompact(amounts.generation_tokens)}</td>
+      <td className="number">{formatCompact(amounts.context_window_tokens)}</td>
     </tr>
   );
 }
@@ -489,6 +526,12 @@ function formatPercent(value: number): string {
     style: "percent",
     maximumFractionDigits: 0,
   }).format(value);
+}
+
+/** A 0-1 share at the CLI's precision. `formatPercent` rounds to whole percent,
+ * which reads as a tie for any split near even. */
+function formatShare(share: number): string {
+  return `${(share * 100).toFixed(1)}%`;
 }
 
 function formatDuration(seconds: number | null): string {

--- a/src/token-economics.ts
+++ b/src/token-economics.ts
@@ -35,6 +35,8 @@ export interface PhaseAmounts {
   estimated_cost_usd: number;
   // Wall-clock time attributed to this phase, from capped inter-message gaps.
   active_ms: number;
+  // This phase's share of the enclosing object's estimated_cost_usd, 0-1.
+  cost_share: number;
 }
 
 export interface TokenEconomicsBucket {
@@ -1042,12 +1044,14 @@ function phasesFor(entry: MutableBucket | undefined): Record<Phase, PhaseAmounts
       context_window_tokens: Math.round(winO),
       estimated_cost_usd: costO,
       active_ms: Math.round(activeO),
+      cost_share: share(costO, cost),
     },
     implementation: {
       generation_tokens: Math.round(gen - genO),
       context_window_tokens: Math.round(win - winO),
       estimated_cost_usd: cost - costO,
       active_ms: Math.round(active - activeO),
+      cost_share: share(cost - costO, cost),
     },
   };
 }
@@ -1086,10 +1090,13 @@ function finish(
     waiting_on_user_ms: waitingMs,
     attributed_ms: activeMs + waitingMs,
   };
-  totals.phases = {
-    orientation: sumPhase(rows, "orientation"),
-    implementation: sumPhase(rows, "implementation"),
-  };
+  const orientationTotal = sumPhase(rows, "orientation");
+  const implementationTotal = sumPhase(rows, "implementation");
+  // sumPhase cannot see the grand total, so the shares it accumulated are
+  // per-bucket fractions. Rescale them against the archive/session total.
+  orientationTotal.cost_share = share(orientationTotal.estimated_cost_usd, totalCost);
+  implementationTotal.cost_share = share(implementationTotal.estimated_cost_usd, totalCost);
+  totals.phases = { orientation: orientationTotal, implementation: implementationTotal };
   return { buckets: rows, totals };
 }
 
@@ -1099,6 +1106,7 @@ function sumPhase(rows: TokenEconomicsBucket[], phase: Phase): PhaseAmounts {
     context_window_tokens: 0,
     estimated_cost_usd: 0,
     active_ms: 0,
+    cost_share: 0,
   };
   for (const row of rows) {
     const p = row.phases?.[phase];

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -315,7 +315,7 @@ type PhaseAmounts = {
   cost_share: number;
 };
 
-export type TokenEconomics = {
+type TokenEconomics = {
   buckets: {
     bucket: ActivityBucket;
     generation_tokens: number;
@@ -4725,8 +4725,10 @@ function TokenEconomicsPanel({
           {phaseRows.length === 0 ? null : (
             <div className="activity-table-wrap">
               <table className="activity-table" aria-label="Orientation and implementation split">
-                {/* Same column shape as the activity table minus agent runs, so the
-                  two line up under the shared min-width instead of stretching. */}
+                {/* `table-layout: fixed` scales the declared widths up to fill the
+                  table, so a colgroup summing to 91% would offset every column from
+                  its namesake above. The trailing spacer mirrors the activity
+                  table's own conditional Agent runs column to reach 100%. */}
                 <colgroup>
                   <col className="col-activity" />
                   <col className="col-share" />
@@ -4735,6 +4737,7 @@ function TokenEconomicsPanel({
                   <col className="col-activity-number" />
                   <col className="col-activity-number" />
                   <col className="col-activity-number" />
+                  {showAgentRuns ? <col className="col-activity-number" /> : null}
                 </colgroup>
                 <thead>
                   <tr className="activity-table-head">

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -129,6 +129,7 @@ import {
   sessionsPageHref,
   titleFor,
 } from "./navigation.ts";
+import { phaseSplitRows } from "./phase-split.ts";
 import { exactSearchRemaining, searchPageMayHaveMore } from "./search-pagination.ts";
 import { searchRequestScope, searchRouteHref } from "./search-request.ts";
 import { searchSnippetParts, visuallyOrderedSearchHits } from "./search-results.ts";
@@ -304,7 +305,17 @@ type DateBounds = {
 
 type ActivityBucket = "context" | "planning" | "code" | "communicating";
 
-type TokenEconomics = {
+// The server always sends `phases`, but `getJson` casts rather than validates,
+// so an older archive would leave the field absent with no runtime error.
+type PhaseAmounts = {
+  generation_tokens: number;
+  context_window_tokens: number;
+  estimated_cost_usd: number;
+  active_ms: number;
+  cost_share: number;
+};
+
+export type TokenEconomics = {
   buckets: {
     bucket: ActivityBucket;
     generation_tokens: number;
@@ -314,6 +325,7 @@ type TokenEconomics = {
     sessions: number;
     cost_share: number;
     active_ms: number;
+    phases?: Record<"orientation" | "implementation", PhaseAmounts>;
   }[];
   totals: {
     generation_tokens: number;
@@ -324,6 +336,7 @@ type TokenEconomics = {
     active_ms: number;
     waiting_on_user_ms: number;
     attributed_ms: number;
+    phases?: Record<"orientation" | "implementation", PhaseAmounts>;
   };
 };
 
@@ -4552,6 +4565,8 @@ function TokenEconomicsPanel({
   const totalCost = economics?.totals.estimated_cost_usd ?? 0;
   const totalActiveMs = economics?.totals.active_ms ?? 0;
   const showAgentRuns = !isCompact;
+  const phaseRows = phaseSplitRows(economics);
+  const orientationShare = phaseRows[0]?.costShare ?? 0;
   return (
     <section className={`panel token-economics-panel${isCompact ? " is-compact" : ""}`}>
       <div className="panel-heading">
@@ -4577,6 +4592,12 @@ function TokenEconomicsPanel({
               <strong>{duration(economics.totals.waiting_on_user_ms)}</strong>
               waiting
             </span>
+            {phaseRows.length === 0 ? null : (
+              <span>
+                <strong>{Math.round(orientationShare * 100)}%</strong>
+                orientation
+              </span>
+            )}
             {isCompact && subagentRuns > 0 ? (
               <span>
                 <strong>1 root + {formatInt(subagentRuns)}</strong>
@@ -4595,111 +4616,208 @@ function TokenEconomicsPanel({
           />
         </div>
       ) : (
-        <div className="activity-table-wrap">
-          <table className="activity-table" aria-label="Activity token economics">
-            <colgroup>
-              <col className="col-activity" />
-              <col className="col-share" />
-              <col className="col-activity-number" />
-              <col className="col-share" />
-              <col className="col-activity-number" />
-              <col className="col-activity-number" />
-              <col className="col-activity-number" />
-              {showAgentRuns ? <col className="col-activity-number" /> : null}
-            </colgroup>
-            <thead>
-              <tr className="activity-table-head">
-                <th scope="col">Activity</th>
-                <th scope="col">Cost share</th>
-                <th className="numeric activity-number" scope="col">
-                  Cost
-                </th>
-                <th scope="col">Time spent</th>
-                <th className="numeric activity-number" scope="col">
-                  Time
-                </th>
-                <th className="numeric activity-number" scope="col">
-                  Generated
-                </th>
-                <th className="numeric activity-number" scope="col">
-                  Window
-                </th>
-                {showAgentRuns ? (
+        <>
+          <div className="activity-table-wrap">
+            <table className="activity-table" aria-label="Activity token economics">
+              <colgroup>
+                <col className="col-activity" />
+                <col className="col-share" />
+                <col className="col-activity-number" />
+                <col className="col-share" />
+                <col className="col-activity-number" />
+                <col className="col-activity-number" />
+                <col className="col-activity-number" />
+                {showAgentRuns ? <col className="col-activity-number" /> : null}
+              </colgroup>
+              <thead>
+                <tr className="activity-table-head">
+                  <th scope="col">Activity</th>
+                  <th scope="col">Cost share</th>
                   <th className="numeric activity-number" scope="col">
-                    <span title="Root sessions and nested subagent runs contributing to this activity">
-                      Agent runs
-                    </span>
+                    Cost
                   </th>
-                ) : null}
-              </tr>
-            </thead>
-            <tbody>
-              {buckets.map((bucket) => {
-                const tone = activityTone(bucket.bucket);
-                const share = Math.max(0, Math.min(1, bucket.cost_share));
-                const timeShare = totalActiveMs > 0 ? bucket.active_ms / totalActiveMs : 0;
-                return (
-                  <Tooltip content={activityDescription(bucket.bucket)} key={bucket.bucket}>
-                    {(tooltipProps) => (
-                      <tr className="activity-table-row" {...tooltipProps}>
-                        <td className="activity-name">
-                          <span className="activity-name-inner">
-                            <span className={`activity-swatch tone-${tone}`} />
-                            <span className="activity-label-text">
-                              {activityLabel(bucket.bucket)}
-                              <span aria-hidden="true" className="info-tooltip">
-                                <Icon name="info" />
+                  <th scope="col">Time spent</th>
+                  <th className="numeric activity-number" scope="col">
+                    Time
+                  </th>
+                  <th className="numeric activity-number" scope="col">
+                    Generated
+                  </th>
+                  <th className="numeric activity-number" scope="col">
+                    Window
+                  </th>
+                  {showAgentRuns ? (
+                    <th className="numeric activity-number" scope="col">
+                      <span title="Root sessions and nested subagent runs contributing to this activity">
+                        Agent runs
+                      </span>
+                    </th>
+                  ) : null}
+                </tr>
+              </thead>
+              <tbody>
+                {buckets.map((bucket) => {
+                  const tone = activityTone(bucket.bucket);
+                  const share = Math.max(0, Math.min(1, bucket.cost_share));
+                  const timeShare = totalActiveMs > 0 ? bucket.active_ms / totalActiveMs : 0;
+                  return (
+                    <Tooltip content={activityDescription(bucket.bucket)} key={bucket.bucket}>
+                      {(tooltipProps) => (
+                        <tr className="activity-table-row" {...tooltipProps}>
+                          <td className="activity-name">
+                            <span className="activity-name-inner">
+                              <span className={`activity-swatch tone-${tone}`} />
+                              <span className="activity-label-text">
+                                {activityLabel(bucket.bucket)}
+                                <span aria-hidden="true" className="info-tooltip">
+                                  <Icon name="info" />
+                                </span>
                               </span>
                             </span>
-                          </span>
-                        </td>
-                        <td className="activity-share">
-                          <span className="activity-share-inner">
-                            <span className="activity-bar">
-                              <span
-                                className={`tone-${tone}`}
-                                style={{ width: `${share * 100}%` }}
-                              />
-                            </span>
-                            <small>{Math.round(share * 100)}%</small>
-                          </span>
-                        </td>
-                        <td className="numeric activity-number">
-                          {money(bucket.estimated_cost_usd)}
-                        </td>
-                        <td className="activity-share">
-                          <span className="activity-share-inner">
-                            <span className="activity-bar">
-                              <span
-                                className={`tone-${tone}`}
-                                style={{ width: `${timeShare * 100}%` }}
-                              />
-                            </span>
-                            <small>{Math.round(timeShare * 100)}%</small>
-                          </span>
-                        </td>
-                        <td className="numeric muted activity-number">
-                          {duration(bucket.active_ms)}
-                        </td>
-                        <td className="numeric muted activity-number">
-                          {compact(bucket.generation_tokens)}
-                        </td>
-                        <td className="numeric muted activity-number">
-                          {compact(bucket.context_window_tokens)}
-                        </td>
-                        {showAgentRuns ? (
-                          <td className="numeric muted activity-number">
-                            {formatInt(bucket.sessions)}
                           </td>
-                        ) : null}
-                      </tr>
-                    )}
-                  </Tooltip>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+                          <td className="activity-share">
+                            <span className="activity-share-inner">
+                              <span className="activity-bar">
+                                <span
+                                  className={`tone-${tone}`}
+                                  style={{ width: `${share * 100}%` }}
+                                />
+                              </span>
+                              <small>{Math.round(share * 100)}%</small>
+                            </span>
+                          </td>
+                          <td className="numeric activity-number">
+                            {money(bucket.estimated_cost_usd)}
+                          </td>
+                          <td className="activity-share">
+                            <span className="activity-share-inner">
+                              <span className="activity-bar">
+                                <span
+                                  className={`tone-${tone}`}
+                                  style={{ width: `${timeShare * 100}%` }}
+                                />
+                              </span>
+                              <small>{Math.round(timeShare * 100)}%</small>
+                            </span>
+                          </td>
+                          <td className="numeric muted activity-number">
+                            {duration(bucket.active_ms)}
+                          </td>
+                          <td className="numeric muted activity-number">
+                            {compact(bucket.generation_tokens)}
+                          </td>
+                          <td className="numeric muted activity-number">
+                            {compact(bucket.context_window_tokens)}
+                          </td>
+                          {showAgentRuns ? (
+                            <td className="numeric muted activity-number">
+                              {formatInt(bucket.sessions)}
+                            </td>
+                          ) : null}
+                        </tr>
+                      )}
+                    </Tooltip>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          {phaseRows.length === 0 ? null : (
+            <div className="activity-table-wrap">
+              <table className="activity-table" aria-label="Orientation and implementation split">
+                {/* Same column shape as the activity table minus agent runs, so the
+                  two line up under the shared min-width instead of stretching. */}
+                <colgroup>
+                  <col className="col-activity" />
+                  <col className="col-share" />
+                  <col className="col-activity-number" />
+                  <col className="col-share" />
+                  <col className="col-activity-number" />
+                  <col className="col-activity-number" />
+                  <col className="col-activity-number" />
+                </colgroup>
+                <thead>
+                  <tr className="activity-table-head">
+                    <th scope="col">Phase</th>
+                    <th scope="col">Cost share</th>
+                    <th className="numeric activity-number" scope="col">
+                      Cost
+                    </th>
+                    <th scope="col">Time spent</th>
+                    <th className="numeric activity-number" scope="col">
+                      Time
+                    </th>
+                    <th className="numeric activity-number" scope="col">
+                      Generated
+                    </th>
+                    <th className="numeric activity-number" scope="col">
+                      Window
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {phaseRows.map((row) => {
+                    const costShare = Math.max(0, Math.min(1, row.costShare));
+                    const timeShare = Math.max(0, Math.min(1, row.timeShare));
+                    return (
+                      <Tooltip content={phaseDescription(row.phase)} key={row.phase}>
+                        {(tooltipProps) => (
+                          <tr className="activity-table-row" {...tooltipProps}>
+                            <td className="activity-name">
+                              <span className="activity-name-inner">
+                                <span className={`activity-swatch tone-${row.tone}`} />
+                                <span className="activity-label-text">
+                                  {row.label}
+                                  <span aria-hidden="true" className="info-tooltip">
+                                    <Icon name="info" />
+                                  </span>
+                                </span>
+                              </span>
+                            </td>
+                            <td className="activity-share">
+                              <span className="activity-share-inner">
+                                <span className="activity-bar">
+                                  <span
+                                    className={`tone-${row.tone}`}
+                                    style={{ width: `${costShare * 100}%` }}
+                                  />
+                                </span>
+                                <small>{Math.round(costShare * 100)}%</small>
+                              </span>
+                            </td>
+                            <td className="numeric activity-number">
+                              {money(row.estimated_cost_usd)}
+                            </td>
+                            <td className="activity-share">
+                              <span className="activity-share-inner">
+                                <span className="activity-bar">
+                                  <span
+                                    className={`tone-${row.tone}`}
+                                    style={{ width: `${timeShare * 100}%` }}
+                                  />
+                                </span>
+                                <small>{Math.round(timeShare * 100)}%</small>
+                              </span>
+                            </td>
+                            <td className="numeric muted activity-number">
+                              {duration(row.active_ms)}
+                            </td>
+                            <td className="numeric muted activity-number">
+                              {compact(row.generation_tokens)}
+                            </td>
+                            <td className="numeric muted activity-number">
+                              {compact(row.context_window_tokens)}
+                            </td>
+                          </tr>
+                        )}
+                      </Tooltip>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
       )}
     </section>
   );
@@ -5589,6 +5707,12 @@ function activityLabel(bucket: ActivityBucket): string {
     case "code":
       return "Code";
   }
+}
+
+function phaseDescription(phase: "orientation" | "implementation"): string {
+  return phase === "orientation"
+    ? "Everything before the first detected file edit: reading, searching, and planning how to change the code."
+    : "The first detected file edit and everything after it.";
 }
 
 function activityDescription(bucket: ActivityBucket): string {

--- a/src/ui/phase-split.ts
+++ b/src/ui/phase-split.ts
@@ -1,4 +1,21 @@
-import type { TokenEconomics } from "./main.tsx";
+/** Structural input, declared locally like every other `src/ui/*.ts` helper, so
+ * this module does not depend on the entry file. `phases` is optional because an
+ * older server omits it. */
+export interface PhaseSplitEconomics {
+  totals: {
+    active_ms: number;
+    phases?: Record<
+      "orientation" | "implementation",
+      {
+        generation_tokens: number;
+        context_window_tokens: number;
+        estimated_cost_usd: number;
+        active_ms: number;
+        cost_share: number;
+      }
+    >;
+  };
+}
 
 export interface PhaseSplitRow {
   phase: "orientation" | "implementation";
@@ -15,7 +32,7 @@ export interface PhaseSplitRow {
 /** Flattens the phase split into table rows. Returning `[]` when the server
  * omits `phases` lets the panel degrade to today's rendering against an older
  * archive rather than throwing on a missing field. */
-export function phaseSplitRows(economics: TokenEconomics | null): PhaseSplitRow[] {
+export function phaseSplitRows(economics: PhaseSplitEconomics | null): PhaseSplitRow[] {
   const phases = economics?.totals.phases;
   if (economics == null || phases == null) {
     return [];

--- a/src/ui/phase-split.ts
+++ b/src/ui/phase-split.ts
@@ -1,0 +1,41 @@
+import type { TokenEconomics } from "./main.tsx";
+
+export interface PhaseSplitRow {
+  phase: "orientation" | "implementation";
+  label: string;
+  tone: "info" | "success";
+  costShare: number;
+  timeShare: number;
+  estimated_cost_usd: number;
+  active_ms: number;
+  generation_tokens: number;
+  context_window_tokens: number;
+}
+
+/** Flattens the phase split into table rows. Returning `[]` when the server
+ * omits `phases` lets the panel degrade to today's rendering against an older
+ * archive rather than throwing on a missing field. */
+export function phaseSplitRows(economics: TokenEconomics | null): PhaseSplitRow[] {
+  const phases = economics?.totals.phases;
+  if (economics == null || phases == null) {
+    return [];
+  }
+  const totalActiveMs = economics.totals.active_ms;
+  return [
+    // Orientation echoes the context bucket's tone and implementation the code
+    // bucket's, because each phase is dominated by that activity.
+    { phase: "orientation", label: "Orientation", tone: "info" } as const,
+    { phase: "implementation", label: "Implementation", tone: "success" } as const,
+  ].map((row) => {
+    const amounts = phases[row.phase];
+    return {
+      ...row,
+      costShare: amounts.cost_share,
+      timeShare: totalActiveMs > 0 ? amounts.active_ms / totalActiveMs : 0,
+      estimated_cost_usd: amounts.estimated_cost_usd,
+      active_ms: amounts.active_ms,
+      generation_tokens: amounts.generation_tokens,
+      context_window_tokens: amounts.context_window_tokens,
+    };
+  });
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -135,7 +135,13 @@ describe("runCli", () => {
 
     const tokens = await runCli([...base, "tokens"]);
     expect(tokens.code).toBe(0);
-    expect(JSON.parse(tokens.stdout)).toMatchObject({
+    const jsonTokens = JSON.parse(tokens.stdout) as {
+      totals: { phases: { orientation: { cost_share: number } } };
+    };
+    expect(jsonTokens.totals.phases.orientation.cost_share).toBeTypeOf("number");
+    // Asserted first: toMatchObject substitutes asymmetric matchers into the
+    // received value, so `totals` is no longer readable after the next call.
+    expect(jsonTokens).toMatchObject({
       buckets: expect.arrayContaining([
         expect.objectContaining({ bucket: "context", active_ms: expect.any(Number) }),
       ]),
@@ -148,6 +154,8 @@ describe("runCli", () => {
     const humanTokens = await runCli(["--db", dbPath, "--no-sync", "tokens"]);
     expect(humanTokens).toMatchObject({ code: 0, stderr: "" });
     expect(humanTokens.stdout).toContain("waiting_on_user\t-\t-\t-");
+    expect(humanTokens.stdout).toContain("orientation\t");
+    expect(humanTokens.stdout).toMatch(/^implementation\t.*%$/m);
 
     const search = await runCli([...base, "search", "auth", "--limit", "5"]);
     expect(search.code).toBe(0);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -139,6 +139,9 @@ describe("runCli", () => {
       totals: { phases: { orientation: { cost_share: number } } };
     };
     expect(jsonTokens.totals.phases.orientation.cost_share).toBeTypeOf("number");
+    // The wire value is a 0-1 fraction, permanently. NaN fails both bounds.
+    expect(jsonTokens.totals.phases.orientation.cost_share).toBeGreaterThan(0);
+    expect(jsonTokens.totals.phases.orientation.cost_share).toBeLessThanOrEqual(1);
     // Asserted first: toMatchObject substitutes asymmetric matchers into the
     // received value, so `totals` is no longer readable after the next call.
     expect(jsonTokens).toMatchObject({
@@ -156,6 +159,14 @@ describe("runCli", () => {
     expect(humanTokens.stdout).toContain("waiting_on_user\t-\t-\t-");
     expect(humanTokens.stdout).toContain("orientation\t");
     expect(humanTokens.stdout).toMatch(/^implementation\t.*%$/m);
+    const phasePercents = [
+      ...humanTokens.stdout.matchAll(/^(?:orientation|implementation)\t.*\t([\d.]+)%$/gm),
+    ].map((match) => Number(match[1]));
+    expect(phasePercents).toHaveLength(2);
+    // Pins the 0-100 display scale against the 0-1 wire value. Dropping the x100
+    // in formatPercent still prints a plausible "0.7%", so only the magnitude of
+    // the sum catches it.
+    expect((phasePercents[0] ?? 0) + (phasePercents[1] ?? 0)).toBeCloseTo(100, 1);
 
     const search = await runCli([...base, "search", "auth", "--limit", "5"]);
     expect(search.code).toBe(0);

--- a/test/report.test.ts
+++ b/test/report.test.ts
@@ -62,6 +62,36 @@ const economics = {
   },
 };
 
+/** The module-level `economics` fixture deliberately carries no `phases`, so the
+ * phase table has to be opted into by the tests that assert on it. */
+function analyticsWithPhases(): AnalyticsReportData {
+  return {
+    ...analytics,
+    economics: {
+      ...economics,
+      totals: {
+        ...economics.totals,
+        phases: {
+          orientation: {
+            generation_tokens: 60,
+            context_window_tokens: 180,
+            estimated_cost_usd: 0.0481,
+            active_ms: 9_000,
+            cost_share: 0.481,
+          },
+          implementation: {
+            generation_tokens: 40,
+            context_window_tokens: 120,
+            estimated_cost_usd: 0.0519,
+            active_ms: 6_000,
+            cost_share: 0.519,
+          },
+        },
+      },
+    },
+  };
+}
+
 const firstDay = {
   key: "2026-07-27",
   sessions: 1,
@@ -507,6 +537,18 @@ describe("static report rendering", () => {
     expect(html.indexOf("<h2>Token economics</h2>")).toBeLessThan(
       html.indexOf("<h2>Activity over time</h2>"),
     );
+  });
+
+  test("reports the orientation and implementation split", () => {
+    const html = renderAnalyticsReport(analyticsWithPhases());
+    expect(html).toContain("<h3>Orientation vs implementation</h3>");
+    expect(html).toContain("48.1%");
+    expect(html).toContain("51.9%");
+  });
+
+  test("omits the phase split when economics carry no phases", () => {
+    const html = renderAnalyticsReport(analytics);
+    expect(html).not.toContain("Orientation vs implementation");
   });
 });
 

--- a/test/token-economics.test.ts
+++ b/test/token-economics.test.ts
@@ -138,6 +138,105 @@ describe("token economics", () => {
     db.close();
   });
 
+  test("reports a cost share for each phase that sums to one", () => {
+    const db = freshDb();
+    upsertSession(
+      db,
+      parseClaudeSession("sess-enr-claude", fixture("claude", "enriched.jsonl")),
+      "/x/claude.jsonl",
+      1,
+      2,
+      "claude",
+    );
+
+    const economics = tokenEconomics(db);
+    const phases = economics.totals.phases;
+    expect(phases).toBeDefined();
+    const orientation = phases?.orientation.cost_share ?? 0;
+    const implementation = phases?.implementation.cost_share ?? 0;
+    expect(orientation + implementation).toBeCloseTo(1, 12);
+    // Totals carry the archive-wide share, not the sum of the per-bucket ones.
+    expect(orientation).toBeLessThanOrEqual(1);
+    for (const row of economics.buckets) {
+      const bucketShares =
+        (row.phases?.orientation.cost_share ?? 0) + (row.phases?.implementation.cost_share ?? 0);
+      // A bucket with no spend has no share to divide, so it stays at zero.
+      expect(bucketShares).toBeCloseTo(row.estimated_cost_usd > 0 ? 1 : 0, 12);
+    }
+    db.close();
+  });
+
+  test("gives an edit-free session a full orientation share", () => {
+    const db = freshDb();
+    // Hand-written: a session that only reads, so the first-edit boundary is
+    // never crossed and every dollar stays in orientation.
+    const content = [
+      JSON.stringify({
+        type: "user",
+        uuid: "u1",
+        parentUuid: null,
+        timestamp: "2026-05-06T09:00:00.000Z",
+        message: { role: "user", content: "Explain the auth module" },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        uuid: "a1",
+        parentUuid: "u1",
+        timestamp: "2026-05-06T09:00:30.000Z",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-7",
+          stop_reason: "tool_use",
+          usage: { input_tokens: 800, output_tokens: 120 },
+          content: [
+            { type: "text", text: "Reading the module." },
+            {
+              type: "tool_use",
+              id: "toolu_read",
+              name: "Read",
+              input: { file_path: "/Users/dev/proj/src/auth.rs" },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        uuid: "u2",
+        parentUuid: "a1",
+        timestamp: "2026-05-06T09:00:50.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_read", content: "fn auth() {}" }],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        uuid: "a2",
+        parentUuid: "u2",
+        timestamp: "2026-05-06T09:01:20.000Z",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-7",
+          usage: { input_tokens: 950, output_tokens: 300 },
+          content: [{ type: "text", text: "It authenticates the caller and returns a bool." }],
+        },
+      }),
+    ].join("\n");
+    upsertSession(
+      db,
+      parseClaudeSession("sess-no-edit", `${content}\n`),
+      "/x/no-edit.jsonl",
+      1,
+      2,
+      "claude",
+    );
+
+    const phases = tokenEconomics(db).totals.phases;
+    expect(phases?.orientation.cost_share).toBeCloseTo(1, 12);
+    expect(phases?.implementation.cost_share).toBeCloseTo(0, 12);
+    db.close();
+  });
+
   test("attributes wall-clock time to activity buckets and phases", () => {
     const db = freshDb();
     const sessionId = upsertSession(

--- a/test/ui-phase-split.test.ts
+++ b/test/ui-phase-split.test.ts
@@ -15,12 +15,11 @@ const totals = {
 };
 
 function economicsWithoutPhases(): Economics {
-  return { buckets: [], totals };
+  return { totals };
 }
 
 function economicsWithPhases(): Economics {
   return {
-    buckets: [],
     totals: {
       ...totals,
       phases: {
@@ -45,7 +44,6 @@ function economicsWithPhases(): Economics {
 
 function editFreeEconomics(): Economics {
   return {
-    buckets: [],
     totals: {
       ...totals,
       phases: {

--- a/test/ui-phase-split.test.ts
+++ b/test/ui-phase-split.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { phaseSplitRows } from "../src/ui/phase-split.ts";
+
+type Economics = NonNullable<Parameters<typeof phaseSplitRows>[0]>;
+
+const totals = {
+  generation_tokens: 100,
+  context_window_tokens: 300,
+  estimated_cost_usd: 0.1,
+  input_cost_usd: 0.08,
+  output_cost_usd: 0.02,
+  active_ms: 15_000,
+  waiting_on_user_ms: 0,
+  attributed_ms: 15_000,
+};
+
+function economicsWithoutPhases(): Economics {
+  return { buckets: [], totals };
+}
+
+function economicsWithPhases(): Economics {
+  return {
+    buckets: [],
+    totals: {
+      ...totals,
+      phases: {
+        orientation: {
+          generation_tokens: 60,
+          context_window_tokens: 180,
+          estimated_cost_usd: 0.048,
+          active_ms: 9_000,
+          cost_share: 0.48,
+        },
+        implementation: {
+          generation_tokens: 40,
+          context_window_tokens: 120,
+          estimated_cost_usd: 0.052,
+          active_ms: 6_000,
+          cost_share: 0.52,
+        },
+      },
+    },
+  };
+}
+
+function editFreeEconomics(): Economics {
+  return {
+    buckets: [],
+    totals: {
+      ...totals,
+      phases: {
+        orientation: {
+          generation_tokens: 100,
+          context_window_tokens: 300,
+          estimated_cost_usd: 0.1,
+          active_ms: 15_000,
+          cost_share: 1,
+        },
+        implementation: {
+          generation_tokens: 0,
+          context_window_tokens: 0,
+          estimated_cost_usd: 0,
+          active_ms: 0,
+          cost_share: 0,
+        },
+      },
+    },
+  };
+}
+
+describe("phase split rows", () => {
+  test("derives cost and time shares for both phases", () => {
+    const rows = phaseSplitRows(economicsWithPhases());
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.phase).toBe("orientation");
+    expect(rows[0]?.tone).toBe("info");
+    expect(rows[1]?.tone).toBe("success");
+    expect(rows[0]?.costShare).toBeCloseTo(0.48, 12);
+    expect(rows[0]?.timeShare).toBeCloseTo(0.6, 12);
+    expect(rows[1]?.timeShare).toBeCloseTo(0.4, 12);
+  });
+
+  test("returns no rows when the server omits phases", () => {
+    expect(phaseSplitRows(economicsWithoutPhases())).toEqual([]);
+    expect(phaseSplitRows(null)).toEqual([]);
+  });
+
+  test("reports a full orientation share for an edit-free session", () => {
+    const rows = phaseSplitRows(editFreeEconomics());
+    expect(rows[0]?.costShare).toBeCloseTo(1, 12);
+    expect(rows[1]?.costShare).toBeCloseTo(0, 12);
+  });
+
+  test("leaves both time shares at zero when no active time was attributed", () => {
+    const base = economicsWithPhases();
+    const rows = phaseSplitRows({ ...base, totals: { ...base.totals, active_ms: 0 } });
+    expect(rows.map((row) => row.timeShare)).toEqual([0, 0]);
+  });
+});


### PR DESCRIPTION
## What

Decant computes an orientation/implementation phase split — the share of agent spend that happens before the first file edit. It is the most commercially significant metric in the product, and it rendered on **zero human surfaces**.

```
$ grep -rn orientation src/ui/
(no matches)
```

It existed in `src/token-economics.ts` and the API, but was absent from `decant economics`, the web UI, and the generated report. A user wanting the number had to pipe `--json` through `jq` and divide two floats.

## How

- `PhaseAmounts` gains `cost_share`, a **0–1 fraction** matching the existing `TokenEconomicsBucket.cost_share`. One definition — "share of the enclosing object's `estimated_cost_usd`" — covers both bucket and totals scope.
- Phase rows in `decant economics`, matching the existing tab-separated shape (`waiting_on_user` already set the precedent for a non-bucket row).
- An "Orientation vs implementation" table in the generated report, reusing existing `table.compact` styling — no CSS added.
- A summary stat and second table in the UI, extracted into `src/ui/phase-split.ts` so the logic is unit-tested (JSX in `main.tsx` is only ever tested by source-text assertions).

Pure read-time derivation: **no format-version bump, no migration, no archive rebuild, no golden regeneration.**

## Verification

961 tests pass; `tsc` and `biome` clean. Review ran an 8-way mutation harness against an isolated copy; 7 of 8 mutations caught. The survivor — dropping the `×100` from the CLI formatter, which printed `0.7%` for `69.9%` with 19 tests green — was closed by pinning the invariant that the two phase percentages sum to **100, not 1**.

The UI table alignment was measured in a browser rather than asserted: the phase table's `colgroup` summed to 91%, and with `table-layout: fixed` that drifted columns up to 92px from their namesakes above. Fixed and re-measured at 0.00px on all seven columns in both compact and non-compact modes.

## Note for reviewers

`totals.phases` keeps meaning **all** orientation spend. A stacked follow-up (`teedole/retrieval-split`) decomposes retrieval cost out of it by adding sibling fields — it never narrows this one. All three surfaces read `phases.orientation.cost_share` directly, so a narrowing there would change every surface at once with no type error and no failing test.

## Known, deferred

`share()`'s zero-denominator guard (`src/token-economics.ts:1136`) is itself untested — removing `total > 0 ?` returns `NaN` for zero-cost buckets and nothing fails. Pre-existing, predates this branch.
