### PR TITLE
feat: report MCP retrieval cost separately from phase totals

### DIFF
--- a/docs/analytics-methodology.md
+++ b/docs/analytics-methodology.md
@@ -159,9 +159,13 @@ retrieval share = totals.retrieval.attributed.orientation.estimated_cost_usd
 `decant tokens --exclude-mcp-server <slug>` already does this: it appends
 `orientation_retrieval` and `orientation_remainder` rows whose percentages are
 taken against `totals.estimated_cost_usd`, the same denominator the
-`orientation` row above them uses. Every column in those two rows -- tokens,
-context window, cost, time, and percent -- adds back to the `orientation` row,
-so all three numbers a study publishes are readable from one invocation:
+`orientation` row above them uses. Every column in those two rows is a split of
+the `orientation` row, and the underlying values sum to it exactly. In the
+printed table only the two token columns reconcile digit for digit: cost, time,
+and percent are each rounded independently per row, so a printed pair can differ
+from the parent row by one unit in its last displayed place -- a second,
+$0.0001, or 0.1%. Read exact figures from `--json` rather than from the table.
+All three numbers a study publishes are still readable from one invocation:
 all-in is the `orientation` row itself, and the two rows below split it. The
 all-in figure is deliberately not reprinted under its own label.
 

--- a/docs/analytics-methodology.md
+++ b/docs/analytics-methodology.md
@@ -80,7 +80,8 @@ Generation is allocated from per-message usage when available, then by block
 size when it is not. Tool-result bytes contribute to context-window volume.
 Bucket costs are proportional allocations of the session's estimated input and
 output cost, so they reconcile to the total but should not be read as separate
-provider charges. The retrieval slice below is priced from the same two
+provider charges. The slice described under
+[Retrieval attribution](#retrieval-attribution) is priced from the same two
 denominators, so it is a decomposition of these figures, not a separately
 metered one.
 
@@ -155,14 +156,20 @@ retrieval share = totals.retrieval.attributed.orientation.estimated_cost_usd
                 / totals.estimated_cost_usd
 ```
 
-`decant tokens --exclude-mcp-server <slug>` already does this: the percentages
-in its `orientation_all_in` / `orientation_retrieval` / `orientation_remainder`
-rows are all taken against `totals.estimated_cost_usd`, so they add up in the
-column. The same command's `--json` output reports the within-block
-`cost_share` instead. The two are different quantities under one field name, so
-take the percentage from the row that names its denominator, or divide the
-`estimated_cost_usd` values yourself. Worked example from a fixture archive
-with `--exclude-mcp-server dosu --exclude-mcp-server github`:
+`decant tokens --exclude-mcp-server <slug>` already does this: it appends
+`orientation_retrieval` and `orientation_remainder` rows whose percentages are
+taken against `totals.estimated_cost_usd`, the same denominator the
+`orientation` row above them uses. Every column in those two rows -- tokens,
+context window, cost, time, and percent -- adds back to the `orientation` row,
+so all three numbers a study publishes are readable from one invocation:
+all-in is the `orientation` row itself, and the two rows below split it. The
+all-in figure is deliberately not reprinted under its own label.
+
+The same command's `--json` output reports the within-block `cost_share`
+instead. The two are different quantities under one field name, so take the
+percentage from the table, or divide the `estimated_cost_usd` values yourself.
+Worked example from a fixture archive with
+`--exclude-mcp-server dosu --exclude-mcp-server github`:
 
 | Quantity | Within-block `cost_share` | Share of archive cost |
 | --- | --- | --- |

--- a/docs/analytics-methodology.md
+++ b/docs/analytics-methodology.md
@@ -66,7 +66,7 @@ estimated cost, and active time to four buckets:
 
 | Bucket | What it represents |
 | --- | --- |
-| `context` | Reading, searching, listing, web/MCP retrieval, and read-only shell or Git commands. Unknown tools default here rather than overstating implementation. |
+| `context` | Reading, searching, listing, web/MCP retrieval, and read-only shell or Git commands. Unknown tools default here rather than overstating implementation. Every MCP tool lands here, which is why an MCP retrieval server's own cost is reported separately under [Retrieval attribution](#retrieval-attribution). |
 | `planning` | Thinking/reasoning blocks and explicit plan-management tools. |
 | `code` | Structured edits and shell commands that clearly build, test, write, or otherwise mutate work. |
 | `communicating` | Visible text and other non-tool, non-thinking output. |
@@ -80,7 +80,9 @@ Generation is allocated from per-message usage when available, then by block
 size when it is not. Tool-result bytes contribute to context-window volume.
 Bucket costs are proportional allocations of the session's estimated input and
 output cost, so they reconcile to the total but should not be read as separate
-provider charges.
+provider charges. The retrieval slice below is priced from the same two
+denominators, so it is a decomposition of these figures, not a separately
+metered one.
 
 ## Orientation and implementation
 
@@ -89,6 +91,10 @@ Phases are orthogonal to activity buckets:
 - **Orientation** is everything before the first detected file edit.
 - **Implementation** begins with that edit and includes everything after it.
 - A session that never edits a file is entirely orientation.
+
+Orientation therefore includes any MCP retrieval that ran before the first
+edit. [Retrieval attribution](#retrieval-attribution) reports that slice
+separately without changing this definition.
 
 Structured edit tools establish the boundary directly. Shell edits use narrow,
 high-confidence patterns such as `git apply`, `sed -i`, and explicit file-write
@@ -108,6 +114,45 @@ The split is reported by `decant economics`, which appends `orientation` and
 `implementation` rows after the bucket rows, by the generated report's
 "Orientation vs implementation" table, and by the Activity breakdown panel in
 the local UI.
+
+### Retrieval attribution
+
+Every MCP tool is bucketed `context`, so an MCP retrieval server that runs at
+the start of a session lands inside orientation. Read naively, the orientation
+share then charges a retrieval tool with part of the cost that tool exists to
+remove. `totals.retrieval` decomposes that number rather than redefining it:
+
+- `by_server` gives the phase split for every MCP server seen, keyed by the raw
+  slug. It is always present and does not depend on which servers a request
+  named, so any allowlist -- including one Decant did not pick -- can be
+  re-derived from a stored response. A slug is not a display name: `dosu` and
+  `claude_ai_Dosu` are two registrations of one product and stay two keys.
+- `attributed` is the phase split of the servers a request named through
+  `--exclude-mcp-server` or `?exclude_mcp_server=`, echoed back in
+  `excluded_servers`.
+- `remainder` is `totals.phases` minus `attributed`, clamped at zero.
+- The default exclusion set is **empty**. Nothing is excluded unless a caller
+  names it, so `totals.phases` is exactly what it was before this block
+  existed, and `attributed` is zero.
+
+Each of the three blocks normalizes `cost_share` within itself, so
+`remainder.orientation.cost_share` is the orientation share with the named
+servers taken out of both halves -- the corrected form of the headline number.
+
+A study should pre-register and publish **all three**: orientation all-in
+(`totals.phases.orientation`), the retrieval slice
+(`totals.retrieval.attributed.orientation`), and the remainder. `remainder`
+alone flatters the retrieval tool and `phases` alone penalizes it.
+
+Two limits are worth stating alongside the figures:
+
+- A `tool_call` with no linked call block has no message sequence, and the
+  phase classifier assigns those to implementation so orientation is never
+  overstated. The same rule applies to the retrieval slice, so **orientation
+  retrieval is a lower bound**, not a point estimate.
+- Codex allocates generation in aggregate rather than per message, so Codex MCP
+  *generation* is an approximation. Tool-result *window bytes* -- the larger
+  part of a retrieval call -- are measured directly for both sources.
 
 ## Active time and user wait
 

--- a/docs/analytics-methodology.md
+++ b/docs/analytics-methodology.md
@@ -135,9 +135,40 @@ remove. `totals.retrieval` decomposes that number rather than redefining it:
   names it, so `totals.phases` is exactly what it was before this block
   existed, and `attributed` is zero.
 
-Each of the three blocks normalizes `cost_share` within itself, so
-`remainder.orientation.cost_share` is the orientation share with the named
-servers taken out of both halves -- the corrected form of the headline number.
+#### Which denominator each `cost_share` uses
+
+Each of the three blocks normalizes `cost_share` against its **own** total, the
+way a bucket's `phases.*.cost_share` is normalized within that bucket rather
+than against the archive. That makes `remainder.orientation.cost_share`
+directly comparable to `totals.phases.orientation.cost_share` -- the same
+orientation share with the named servers removed from both halves, which is the
+corrected form of the headline number.
+
+It also means **`attributed.orientation.cost_share` is not the number a study
+wants**. It answers "what fraction of the retrieval slice was orientation", not
+"what fraction of the archive was retrieval", and on an archive where all
+retrieval happens pre-edit it is exactly 1.0. Compute the archive-wide
+retrieval percentage explicitly:
+
+```
+retrieval share = totals.retrieval.attributed.orientation.estimated_cost_usd
+                / totals.estimated_cost_usd
+```
+
+`decant tokens --exclude-mcp-server <slug>` already does this: the percentages
+in its `orientation_all_in` / `orientation_retrieval` / `orientation_remainder`
+rows are all taken against `totals.estimated_cost_usd`, so they add up in the
+column. The same command's `--json` output reports the within-block
+`cost_share` instead. The two are different quantities under one field name, so
+take the percentage from the row that names its denominator, or divide the
+`estimated_cost_usd` values yourself. Worked example from a fixture archive
+with `--exclude-mcp-server dosu --exclude-mcp-server github`:
+
+| Quantity | Within-block `cost_share` | Share of archive cost |
+| --- | --- | --- |
+| orientation all-in | 70.28% | 70.28% |
+| orientation retrieval | 100.00% | **2.12%** |
+| orientation remainder | 69.63% | 68.15% |
 
 A study should pre-register and publish **all three**: orientation all-in
 (`totals.phases.orientation`), the retrieval slice

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -522,6 +522,8 @@ paths:
       tags: [Sessions]
       operationId: getSessionTokenEconomics
       summary: Read token, cost, and activity economics for one session
+      parameters:
+        - $ref: "#/components/parameters/ExcludeMcpServer"
       responses:
         "200":
           description: Session economics
@@ -746,6 +748,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/FromDate"
         - $ref: "#/components/parameters/ToDate"
+        - $ref: "#/components/parameters/ExcludeMcpServer"
       responses:
         "200":
           description: Archive economics
@@ -1106,6 +1109,20 @@ components:
       schema:
         type: string
         format: date
+    ExcludeMcpServer:
+      name: exclude_mcp_server
+      in: query
+      description: >-
+        Raw MCP server slug whose tool volume is reported as retrieval instead
+        of phase spend. Repeatable; unknown slugs contribute nothing. Omitting
+        it leaves every other reported number unchanged.
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
     Tool:
       name: tool
       in: query
@@ -2349,6 +2366,43 @@ components:
         implementation:
           $ref: "#/components/schemas/PhaseAmounts"
       additionalProperties: false
+    RetrievalEconomics:
+      type: object
+      description: >-
+        MCP retrieval volume decomposed out of the phase totals it sits inside.
+        Every MCP tool is bucketed `context`, so a retrieval server that runs at
+        session start lands in orientation. `phases` is unchanged by this block
+        and still means all spend in that phase; `attributed` plus `remainder`
+        add back to it. Each block normalizes `cost_share` within itself, so
+        `remainder.orientation.cost_share` is the orientation share with the
+        named servers removed from both halves.
+      required:
+        - excluded_servers
+        - by_server
+        - attributed
+        - remainder
+      properties:
+        excluded_servers:
+          type: array
+          description: >-
+            Raw MCP server slugs the request named, echoed back so a published
+            figure carries its own exclusion set. Empty by default.
+          items:
+            type: string
+        by_server:
+          type: object
+          description: >-
+            Phase split per MCP server, keyed by the raw slug. Always present
+            and independent of `excluded_servers`, so any allowlist can be
+            re-derived from a stored response. A slug is not a display name:
+            `dosu` and `claude_ai_Dosu` are distinct keys.
+          additionalProperties:
+            $ref: "#/components/schemas/PhaseMap"
+        attributed:
+          $ref: "#/components/schemas/PhaseMap"
+        remainder:
+          $ref: "#/components/schemas/PhaseMap"
+      additionalProperties: false
     TokenEconomicsBucket:
       type: object
       required:
@@ -2433,6 +2487,8 @@ components:
               minimum: 0
             phases:
               $ref: "#/components/schemas/PhaseMap"
+            retrieval:
+              $ref: "#/components/schemas/RetrievalEconomics"
           additionalProperties: true
       additionalProperties: true
     NowAnalytics:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2373,9 +2373,21 @@ components:
         Every MCP tool is bucketed `context`, so a retrieval server that runs at
         session start lands in orientation. `phases` is unchanged by this block
         and still means all spend in that phase; `attributed` plus `remainder`
-        add back to it. Each block normalizes `cost_share` within itself, so
-        `remainder.orientation.cost_share` is the orientation share with the
-        named servers removed from both halves.
+        add back to it.
+
+
+        Each of the three blocks normalizes `cost_share` against its OWN total,
+        the way a bucket's `phases.*.cost_share` is normalized within that
+        bucket rather than against the archive. Read the denominator before
+        publishing a percentage: `attributed.orientation.cost_share` answers
+        "what fraction of the retrieval slice was orientation", NOT "what
+        fraction of the archive was retrieval" -- on an archive where all
+        retrieval is pre-edit it is 1.0. The archive-wide retrieval percentage
+        a study wants is
+        `attributed.orientation.estimated_cost_usd / totals.estimated_cost_usd`.
+        `remainder.orientation.cost_share` is directly comparable to
+        `totals.phases.orientation.cost_share`: it is the same orientation
+        share with the named servers removed from both halves.
       required:
         - excluded_servers
         - by_server

--- a/docs/api/recipes.md
+++ b/docs/api/recipes.md
@@ -98,6 +98,11 @@ The same date query works on the analytical endpoints:
 ```sh
 curl --fail --silent --show-error \
   "$BASE/api/analytics/token-economics?from=$FROM&to=$TO"
+# Repeat exclude_mcp_server to report those servers' volume as retrieval. The
+# response always carries totals.retrieval.by_server, so any other allowlist can
+# be re-derived from a saved payload.
+curl --fail --silent --show-error \
+  "$BASE/api/analytics/token-economics?exclude_mcp_server=dosu&exclude_mcp_server=claude_ai_Dosu"
 curl --fail --silent --show-error \
   "$BASE/api/analytics/activity?from=$FROM&to=$TO"
 curl --fail --silent --show-error \

--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -91,6 +91,14 @@ does not restore the session. Neither operation modifies the source JSONL file.
 Report operations return self-contained, zero-JavaScript HTML. Session reports
 omit transcript content by design.
 
+`exclude_mcp_server` on the two token-economics operations is the only
+repeatable query parameter in the API: pass it once per MCP server slug. It
+adds `totals.retrieval` and changes nothing else, and omitting it leaves every
+other reported number unchanged. The response's `totals.retrieval.by_server` is
+always present and independent of the set that was passed, so a saved payload
+supports any other allowlist without a second request. See
+[Retrieval attribution](../analytics-methodology.md#retrieval-attribution).
+
 ### Session listing and command-palette index
 
 `GET /api/sessions` returns a bare newest-first array, not an envelope with a

--- a/docs/data-lifecycle.md
+++ b/docs/data-lifecycle.md
@@ -84,6 +84,12 @@ archives migrate to the current baseline on open; older archives are
 rebuild-only. The next sync backfills persisted economics, parser enrichments,
 and context rollups when required.
 
+When the economics vector format changes, that backfill rewrites every
+session's vector once; later syncs are idempotent. A read-only archive cannot
+run it, and the served `/api/analytics/token-economics` reads only persisted
+vectors, so it reports zeros until the archive is writable and one sync has
+run. CLI reads recompute live and are correct immediately.
+
 Costs are materialized at ingest. A rebuild uses the pricing table in the new
 Decant version and can therefore change historical estimates even when the
 source logs did not change.

--- a/src/buckets.ts
+++ b/src/buckets.ts
@@ -58,6 +58,12 @@ export function toolBucket(
   if (CODE_TOOLS.has(normalized)) {
     return "code";
   }
+  // The mcp__ test is redundant with the fallthrough below and is kept only to
+  // state the intent: every MCP tool is context. That is also why this is not
+  // where MCP retrieval cost is separated out -- the bucket erases which server
+  // produced the volume. Retrieval is attributed by server in
+  // token-economics.ts (totals.retrieval), which decomposes the phase totals
+  // without moving anything out of this bucket.
   if (CONTEXT_TOOLS.has(normalized) || name.startsWith("mcp__")) {
     return "context";
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,7 +43,7 @@ import {
   toolUsage,
   totals,
 } from "./stats.ts";
-import { tokenEconomics } from "./token-economics.ts";
+import { type TokenEconomics, tokenEconomics } from "./token-economics.ts";
 import {
   DEFAULT_DEBOUNCE_MS,
   DEFAULT_SYNC_INTERVAL_MS,
@@ -909,11 +909,18 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
       "break tokens, cost, agent time, and user wait into context, planning, code, and " +
         "communicating, then into orientation and implementation",
     )
-    .action(() =>
+    .option(
+      "--exclude-mcp-server <slug>",
+      "report this MCP server's tool volume as retrieval instead of phase spend (repeatable)",
+      collectOption,
+      [] as string[],
+    )
+    .action((commandOptions: { excludeMcpServer?: string[] }) =>
       run(() => {
         const archive = readArchive();
+        const excludeMcpServers = commandOptions.excludeMcpServer ?? [];
         try {
-          const row = tokenEconomics(archive.db);
+          const row = tokenEconomics(archive.db, null, { excludeMcpServers });
           output(row, () =>
             row.buckets
               .map(
@@ -948,7 +955,10 @@ export async function runCli(argv: string[], options: CliRunOptions = {}): Promi
                         );
                       })
                       .join(""),
-              ),
+              )
+              // Only when a set was named: with none, retrieval is zero and
+              // these rows would repeat the orientation row for no reason.
+              .concat(retrievalRows(row, excludeMcpServers)),
           );
         } finally {
           closeDb(archive.db);
@@ -1247,6 +1257,32 @@ function parseNumber(value: string): number {
 
 function optionalInteger(value: string | undefined): number | undefined {
   return value == null ? undefined : parseInteger(value);
+}
+
+/** The three numbers a study has to publish together: orientation all-in, the
+ * named servers' slice of it, and what is left. Reporting any one alone either
+ * flatters or penalizes the retrieval tool. All three are shares of the same
+ * archive total, so the last two add back to the first. */
+function retrievalRows(economics: TokenEconomics, excluded: string[]): string {
+  const retrieval = economics.totals.retrieval;
+  if (excluded.length === 0 || retrieval == null) {
+    return "";
+  }
+  const total = economics.totals.estimated_cost_usd;
+  const allIn = economics.totals.phases?.orientation.estimated_cost_usd ?? 0;
+  return (
+    [
+      ["orientation_all_in", allIn] as const,
+      ["orientation_retrieval", retrieval.attributed.orientation.estimated_cost_usd] as const,
+      ["orientation_remainder", retrieval.remainder.orientation.estimated_cost_usd] as const,
+    ] as const
+  )
+    .map(
+      ([label, cost]) =>
+        `${label}\t-\t-\t${cost.toFixed(4)}\t-\t` +
+        `${formatPercent(total > 0 ? cost / total : 0)}\n`,
+    )
+    .join("");
 }
 
 function collectOption(value: string, previous: string[]): string[] {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1259,28 +1259,34 @@ function optionalInteger(value: string | undefined): number | undefined {
   return value == null ? undefined : parseInteger(value);
 }
 
-/** The three numbers a study has to publish together: orientation all-in, the
- * named servers' slice of it, and what is left. Reporting any one alone either
- * flatters or penalizes the retrieval tool. All three are shares of the same
- * archive total, so the last two add back to the first. */
+/** Splits the `orientation` row above into the named servers' share and what is
+ * left, so a study can read all three numbers it must publish together off one
+ * invocation. The all-in figure is not reprinted: it IS the `orientation` row.
+ *
+ * Every column is filled rather than dashed, because these two rows sum to that
+ * row field by field -- printing `-` for tokens and time invites the reader to
+ * conclude the retrieval slice measures something narrower than it does. The
+ * percentages share the `orientation` row's denominator (the archive total), so
+ * the column adds up down the table. */
 function retrievalRows(economics: TokenEconomics, excluded: string[]): string {
   const retrieval = economics.totals.retrieval;
   if (excluded.length === 0 || retrieval == null) {
     return "";
   }
   const total = economics.totals.estimated_cost_usd;
-  const allIn = economics.totals.phases?.orientation.estimated_cost_usd ?? 0;
   return (
     [
-      ["orientation_all_in", allIn] as const,
-      ["orientation_retrieval", retrieval.attributed.orientation.estimated_cost_usd] as const,
-      ["orientation_remainder", retrieval.remainder.orientation.estimated_cost_usd] as const,
+      ["orientation_retrieval", retrieval.attributed.orientation] as const,
+      ["orientation_remainder", retrieval.remainder.orientation] as const,
     ] as const
   )
     .map(
-      ([label, cost]) =>
-        `${label}\t-\t-\t${cost.toFixed(4)}\t-\t` +
-        `${formatPercent(total > 0 ? cost / total : 0)}\n`,
+      ([label, amounts]) =>
+        `${label}\t${formatNumber(amounts.generation_tokens)}\t` +
+        `${formatNumber(amounts.context_window_tokens)}\t` +
+        `${amounts.estimated_cost_usd.toFixed(4)}\t` +
+        `${formatDuration(amounts.active_ms)}\t` +
+        `${formatPercent(total > 0 ? amounts.estimated_cost_usd / total : 0)}\n`,
     )
     .join("");
 }

--- a/src/economics-cache.ts
+++ b/src/economics-cache.ts
@@ -5,6 +5,7 @@ import {
   economicsVectorMatchesFilter,
   type SessionEconomicsVector,
   type TokenEconomics,
+  type TokenEconomicsOptions,
 } from "./token-economics.ts";
 import { workerError, workerUrl } from "./worker-runtime.ts";
 
@@ -48,7 +49,10 @@ export class EconomicsCache {
     this.#options = options;
   }
 
-  async get(filter?: DateFilter | null): Promise<TokenEconomics> {
+  /** The cached vectors carry every MCP server's volume unconditionally, so an
+   * exclusion set is applied at aggregation and never becomes part of the
+   * cache key. */
+  async get(filter?: DateFilter | null, options?: TokenEconomicsOptions): Promise<TokenEconomics> {
     if (this.#vectors == null) {
       await (this.#building ?? this.#rebuild());
     } else if (this.#dataVersion() !== this.#builtDataVersion) {
@@ -59,6 +63,7 @@ export class EconomicsCache {
     const vectors = this.#vectors ?? [];
     return aggregateEconomicsVectors(
       vectors.filter((vector) => economicsVectorMatchesFilter(vector, filter)),
+      options,
     );
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -425,7 +425,9 @@ export async function handleRequest(
     const sessionEconomicsMatch = url.pathname.match(/^\/api\/sessions\/(\d+)\/token-economics$/);
     if (request.method === "GET" && sessionEconomicsMatch != null) {
       return withDb(config, context, (db) => {
-        const economics = tokenEconomicsForSession(db, Number(sessionEconomicsMatch[1]));
+        const economics = tokenEconomicsForSession(db, Number(sessionEconomicsMatch[1]), {
+          excludeMcpServers: url.searchParams.getAll("exclude_mcp_server"),
+        });
         return economics == null ? sessionNotFound(db) : json(economics);
       });
     }
@@ -563,10 +565,17 @@ export async function handleRequest(
       return withDb(config, context, (db) => json(modelSparklines(db, dateFilter)));
     }
     if (request.method === "GET" && url.pathname === "/api/analytics/token-economics") {
+      // Repeatable, unlike every other analytics filter: an exclusion set is a
+      // list of server slugs, so getAll rather than get.
+      const economicsOptions = {
+        excludeMcpServers: url.searchParams.getAll("exclude_mcp_server"),
+      };
       if (context.economics != null) {
-        return json(await context.economics.get(dateFilter));
+        return json(await context.economics.get(dateFilter, economicsOptions));
       }
-      return withDb(config, context, (db) => json(tokenEconomics(db, dateFilter)));
+      return withDb(config, context, (db) =>
+        json(tokenEconomics(db, dateFilter, economicsOptions)),
+      );
     }
     if (request.method === "GET" && url.pathname === "/api/analytics/now") {
       return withDb(config, context, (db) =>

--- a/src/token-economics.ts
+++ b/src/token-economics.ts
@@ -10,13 +10,17 @@ import { defaultPricing, estimateCostParts } from "./cost.ts";
 import { type DateFilter, sessionDatePredicate, whereClause } from "./date-filter.ts";
 import { withImmediateTransaction } from "./db.ts";
 import { sessionUserStatePredicateForDatabase } from "./session-user-state.ts";
+import { classifyTool } from "./tools.ts";
 
 const CHARS_PER_TOKEN = 4;
 const encoder = new TextEncoder();
 // Bump when vector semantics change so the next sync rebuilds derived rows.
-// Version 2 includes corrected wall-clock attribution plus the billed-input
-// and waiting-on-user fields required by the current activity model.
-export const SESSION_ECONOMICS_FORMAT_VERSION = 2;
+// Version 3 adds the per-MCP-server retrieval slice; version 2 added corrected
+// wall-clock attribution plus the billed-input and waiting-on-user fields.
+// No schema migration: the new data is more JSON inside vector_json. Reads
+// recompute live until the next sync backfills, so nobody is served a vector
+// whose retrieval slice is missing.
+export const SESSION_ECONOMICS_FORMAT_VERSION = 3;
 
 // Cap every inter-message gap so long model, tool, or human pauses do not
 // dominate the timing breakdown. Mirrors the ACTIVE_GAP_CAP_SECONDS used for
@@ -37,6 +41,32 @@ export interface PhaseAmounts {
   active_ms: number;
   // This phase's share of the enclosing object's estimated_cost_usd, 0-1.
   cost_share: number;
+}
+
+/** MCP retrieval volume, split out of the phase totals it currently hides
+ * inside. Every MCP tool is bucketed `context` (see toolBucket), so a retrieval
+ * server that runs at session start lands in orientation -- the metric charges
+ * the intervention with the cost it is meant to remove. This decomposes that
+ * number without changing it. */
+export interface RetrievalEconomics {
+  /** Server slugs the caller named. Empty by default, and echoed back so a
+   * published figure carries its own exclusion set. */
+  excluded_servers: string[];
+  /** Always present and independent of `excluded_servers`, keyed by the raw
+   * MCP slug: any reader can re-derive the pair below for any allowlist,
+   * including one Decant did not choose. Two registrations of one product
+   * (`dosu` and `claude_ai_Dosu`) are distinct keys. */
+  by_server: Record<string, Record<Phase, PhaseAmounts>>;
+  /** The declared price of the named servers, by phase. */
+  attributed: Record<Phase, PhaseAmounts>;
+  /** `totals.phases` minus `attributed`, by phase, clamped at zero. */
+  remainder: Record<Phase, PhaseAmounts>;
+}
+
+export interface TokenEconomicsOptions {
+  /** Raw MCP server slugs to report as retrieval instead of phase spend.
+   * Defaults to empty, which leaves every reported number unchanged. */
+  excludeMcpServers?: readonly string[];
 }
 
 export interface TokenEconomicsBucket {
@@ -73,6 +103,9 @@ export interface TokenEconomics {
     // All timing captured from block-bearing messages: agent time plus waiting.
     attributed_ms: number;
     phases?: Record<Phase, PhaseAmounts>;
+    // A decomposition of `phases`, never a replacement: `phases` still means
+    // all spend in that phase, retrieval included.
+    retrieval?: RetrievalEconomics;
   };
 }
 
@@ -106,17 +139,20 @@ interface BlockRow {
 interface ResultRow {
   session_id: number;
   tool_name: string | null;
+  // Written at ingest from classifyTool, so it agrees with the in-process
+  // parse the block paths use. Null for every non-MCP tool.
+  mcp_server: string | null;
   input: string | null;
   bytes: number;
   call_seq: number | null;
 }
 
-interface MutableBucket {
+/** The sums a phase split is computed from. Shared by activity buckets and by
+ * the MCP retrieval slice so both render through the same phasesFor(). */
+interface PhaseTotals {
   generation: number;
   contextWindow: number;
   cost: number;
-  toolCalls: number;
-  sessions: Set<number>;
   // Orientation-phase portions (pre-first-edit). Implementation = total - these.
   // genOrientation feeds windowOrientation the same way generation feeds
   // contextWindow, so the phase cost split mirrors the whole-bucket formula.
@@ -124,10 +160,15 @@ interface MutableBucket {
   genOrientation: number;
   windowOrientation: number;
   costOrientation: number;
-  // Wall-clock ms attributed to this bucket, and the orientation-phase portion
+  // Wall-clock ms attributed here, and the orientation-phase portion
   // (pre-first-edit). Implementation = activeMs - activeMsOrientation.
   activeMs: number;
   activeMsOrientation: number;
+}
+
+interface MutableBucket extends PhaseTotals {
+  toolCalls: number;
+  sessions: Set<number>;
 }
 
 interface MutableLatency {
@@ -188,9 +229,26 @@ export interface SessionEconomicsVector {
       active_ms_orientation: number;
     }
   >;
+  /** Volume produced by MCP tool calls, keyed by raw server slug. A strict
+   * subset of `buckets` -- never an extra bucket -- so aggregation can price
+   * it with the same denominators and subtract it from the phase totals. */
+  retrieval: Record<string, RetrievalVectorPart>;
 }
 
-export function tokenEconomics(db: Database, filter?: DateFilter | null): TokenEconomics {
+interface RetrievalVectorPart {
+  generation: number;
+  generation_orientation: number;
+  context_window: number;
+  context_window_orientation: number;
+  active_ms: number;
+  active_ms_orientation: number;
+}
+
+export function tokenEconomics(
+  db: Database,
+  filter?: DateFilter | null,
+  options?: TokenEconomicsOptions,
+): TokenEconomics {
   const date = sessionDatePredicate("s", filter);
   const visible = {
     sql: [date.sql, sessionUserStatePredicateForDatabase(db, "s")]
@@ -206,6 +264,7 @@ export function tokenEconomics(db: Database, filter?: DateFilter | null): TokenE
        )`,
       visible.params,
     ),
+    options,
   );
 }
 
@@ -248,8 +307,10 @@ export function economicsVectorMatchesFilter(
 
 export function aggregateEconomicsVectors(
   vectors: Iterable<SessionEconomicsVector>,
+  options?: TokenEconomicsOptions,
 ): TokenEconomics {
   const buckets = emptyBuckets();
+  const servers = new Map<string, PhaseTotals>();
   let inputCost = 0;
   let outputCost = 0;
   let waitingOnUserMs = 0;
@@ -274,11 +335,20 @@ export function aggregateEconomicsVectors(
         entry.sessions.add(vector.id);
       }
     }
+    for (const [server, part] of Object.entries(vector.retrieval ?? {})) {
+      const entry = serverEntry(servers, server);
+      entry.generation += part.generation;
+      entry.contextWindow += part.context_window;
+      entry.genOrientation += part.generation_orientation;
+      entry.windowOrientation += part.context_window_orientation;
+      entry.activeMs += part.active_ms;
+      entry.activeMsOrientation += part.active_ms_orientation;
+    }
   }
 
   const totalGeneration = sumBuckets(buckets, "generation");
   const totalWindow = sumBuckets(buckets, "contextWindow");
-  for (const entry of buckets.values()) {
+  for (const entry of [...buckets.values(), ...servers.values()]) {
     // Generation is part of the window; mirror it into the orientation portion
     // so the phase cost split uses the same window basis as the whole bucket.
     entry.contextWindow += entry.generation;
@@ -286,7 +356,11 @@ export function aggregateEconomicsVectors(
   }
   const totalWindowWithGeneration = sumBuckets(buckets, "contextWindow");
   const windowBasis = totalWindowWithGeneration || totalWindow;
-  for (const entry of buckets.values()) {
+  // The retrieval slice is already inside the bucket sums above, so it folds
+  // and prices exactly like a bucket without ever entering a denominator.
+  // Using different denominators here would leave attributed + remainder
+  // unable to reconcile against the phases they decompose.
+  for (const entry of [...buckets.values(), ...servers.values()]) {
     entry.cost =
       outputCost * share(entry.generation, totalGeneration) +
       inputCost * share(entry.contextWindow, windowBasis);
@@ -294,10 +368,14 @@ export function aggregateEconomicsVectors(
       outputCost * share(entry.genOrientation, totalGeneration) +
       inputCost * share(entry.windowOrientation, windowBasis);
   }
-  return finish(buckets, inputCost, outputCost, waitingOnUserMs);
+  return finish(buckets, inputCost, outputCost, waitingOnUserMs, servers, options);
 }
 
-export function tokenEconomicsForSession(db: Database, sessionId: number): TokenEconomics | null {
+export function tokenEconomicsForSession(
+  db: Database,
+  sessionId: number,
+  options?: TokenEconomicsOptions,
+): TokenEconomics | null {
   const scopeCte = `WITH RECURSIVE scoped_session(id) AS (
     SELECT id FROM session WHERE id = ?1
     UNION ALL
@@ -311,7 +389,7 @@ export function tokenEconomicsForSession(db: Database, sessionId: number): Token
   }
   const cached = cachedVectorsForScope(db, scopeCte, [sessionId]);
   const vectors = cached.length === expected ? cached : vectorsForScope(db, scopeCte, [sessionId]);
-  return aggregateEconomicsVectors(withBilledInputWindow(vectors));
+  return aggregateEconomicsVectors(withBilledInputWindow(vectors), options);
 }
 
 /** Session panels retain their billed-input Window total while using the same
@@ -344,7 +422,27 @@ function withBilledInputWindow(vectors: SessionEconomicsVector[]): SessionEconom
         touched: part.touched || allocatedInput > 0,
       };
     }
-    return { ...vector, buckets };
+    // The retrieval slice has to take the same ride, or a session panel would
+    // price retrieval against a pre-allocation window while pricing the phases
+    // it decomposes against a post-allocation one, and the two would not
+    // reconcile. Allocating by each server's share of the whole run is
+    // identical to allocating to its bucket first and splitting inside it,
+    // because the bucket's own allocation is already weight-proportional.
+    const retrieval = {} as SessionEconomicsVector["retrieval"];
+    for (const [server, part] of Object.entries(vector.retrieval ?? {})) {
+      const weight = part.generation + part.context_window;
+      const allocatedInput =
+        totalWeight > 0 ? vector.billed_input_tokens * (weight / totalWeight) : 0;
+      const orientationWeight = part.generation_orientation + part.context_window_orientation;
+      const orientationShare = weight > 0 ? orientationWeight / weight : 0;
+      retrieval[server] = {
+        ...part,
+        context_window: part.context_window + allocatedInput,
+        context_window_orientation:
+          part.context_window_orientation + allocatedInput * orientationShare,
+      };
+    }
+    return { ...vector, buckets, retrieval };
   });
 }
 
@@ -484,9 +582,25 @@ function parseEconomicsVector(raw: string): SessionEconomicsVector | null {
       typeof vector.billed_input_tokens !== "number" ||
       typeof vector.waiting_on_user_ms !== "number" ||
       vector.buckets == null ||
-      typeof vector.buckets !== "object"
+      typeof vector.buckets !== "object" ||
+      vector.retrieval == null ||
+      typeof vector.retrieval !== "object" ||
+      Array.isArray(vector.retrieval)
     ) {
       return null;
+    }
+    for (const part of Object.values(vector.retrieval)) {
+      if (
+        part == null ||
+        typeof part.generation !== "number" ||
+        typeof part.context_window !== "number" ||
+        typeof part.generation_orientation !== "number" ||
+        typeof part.context_window_orientation !== "number" ||
+        typeof part.active_ms !== "number" ||
+        typeof part.active_ms_orientation !== "number"
+      ) {
+        return null;
+      }
     }
     for (const bucket of ACTIVITY_BUCKETS) {
       const part = vector.buckets[bucket];
@@ -572,12 +686,18 @@ function vectorsForScope(
 
   const vectorBySession = new Map<
     number,
-    { session: SessionRow; buckets: PerSessionBuckets; latency: MutableLatency }
+    {
+      session: SessionRow;
+      buckets: PerSessionBuckets;
+      servers: PerSessionServers;
+      latency: MutableLatency;
+    }
   >();
   for (const session of sessions) {
     vectorBySession.set(session.id, {
       session,
       buckets: emptyBuckets(),
+      servers: new Map(),
       latency: emptyLatency(),
     });
   }
@@ -592,20 +712,33 @@ function vectorsForScope(
   for (const [sessionId, sessionBlocks] of blocksBySession) {
     const vector = vectorBySession.get(sessionId);
     if (vector != null) {
-      allocateGeneration([vector.session], sessionBlocks, vector.buckets, boundaries);
-      allocateLatency(sessionId, sessionBlocks, vector.buckets, boundaries, vector.latency);
+      allocateGeneration(
+        [vector.session],
+        sessionBlocks,
+        vector.buckets,
+        boundaries,
+        vector.servers,
+      );
+      allocateLatency(
+        sessionId,
+        sessionBlocks,
+        vector.buckets,
+        boundaries,
+        vector.latency,
+        vector.servers,
+      );
     }
   }
   for (const vector of vectorBySession.values()) {
     if (!blocksBySession.has(vector.session.id)) {
-      allocateGeneration([vector.session], [], vector.buckets, boundaries);
+      allocateGeneration([vector.session], [], vector.buckets, boundaries, vector.servers);
     }
   }
 
   const results = economicsRows<ResultRow>(
     db,
     `${scopeCte}
-       SELECT t.session_id, t.tool_name, t.input,
+       SELECT t.session_id, t.tool_name, t.mcp_server, t.input,
               COALESCE(t.output_bytes, length(CAST(rb.tool_result AS BLOB)), 0) AS bytes,
               cm.seq AS call_seq
        FROM scoped_session fs
@@ -628,9 +761,14 @@ function vectorsForScope(
     entry.sessions.add(row.session_id);
     // A tool result belongs to orientation if its call happened before the
     // session's first edit. Unplaceable calls (no call block) default to
-    // implementation so orientation is never overstated.
-    if (phaseOf(boundaries, row.session_id, row.call_seq) === "orientation") {
+    // implementation so orientation is never overstated -- which also makes
+    // orientation retrieval a lower bound.
+    const phase = phaseOf(boundaries, row.session_id, row.call_seq);
+    if (phase === "orientation") {
       entry.windowOrientation += tokens;
+    }
+    if (row.mcp_server != null && vector != null) {
+      addServerWindow(vector.servers, row.mcp_server, tokens, phase);
     }
   }
 
@@ -662,6 +800,17 @@ function vectorsForScope(
         active_ms_orientation: entry?.activeMsOrientation ?? 0,
       };
     }
+    const retrieval = {} as SessionEconomicsVector["retrieval"];
+    for (const [server, entry] of mutable?.servers ?? []) {
+      retrieval[server] = {
+        generation: entry.generation,
+        generation_orientation: entry.genOrientation,
+        context_window: entry.contextWindow,
+        context_window_orientation: entry.windowOrientation,
+        active_ms: entry.activeMs,
+        active_ms_orientation: entry.activeMsOrientation,
+      };
+    }
     return {
       id: session.id,
       started_at: session.started_at,
@@ -673,11 +822,16 @@ function vectorsForScope(
         session.total_cache_creation_tokens,
       waiting_on_user_ms: mutable?.latency.waitingOnUserMs ?? 0,
       buckets,
+      retrieval,
     };
   });
 }
 
 type PerSessionBuckets = Map<ActivityBucket, MutableBucket>;
+/** Keyed by the raw MCP slug from classifyTool. A slug is not a display name:
+ * `dosu` and `claude_ai_Dosu` are two registrations of one product and stay
+ * two keys, so a caller can exclude exactly what it means to exclude. */
+type PerSessionServers = Map<string, PhaseTotals>;
 
 /** First-edit boundary per session: the message seq of the first file-editing
  * tool_use. Messages with seq < boundary are orientation; the edit's own
@@ -714,6 +868,7 @@ function allocateGeneration(
   blocks: BlockRow[],
   buckets: Map<ActivityBucket, MutableBucket>,
   boundaries: Map<number, number>,
+  servers: PerSessionServers,
 ): void {
   const blocksBySession = groupBy(blocks, (block) => block.session_id);
   for (const session of sessions) {
@@ -733,7 +888,7 @@ function allocateGeneration(
       for (const [messageId, outputTokens] of messageOutput) {
         const rows = messageBlocks.get(messageId) ?? [];
         const phase = phaseOf(boundaries, session.id, rows[0]?.seq);
-        allocateOutput(session.id, outputTokens, rows, buckets, phase);
+        allocateOutput(session.id, outputTokens, rows, buckets, phase, servers);
       }
       continue;
     }
@@ -771,6 +926,7 @@ function allocateGeneration(
       assistantBlocks,
       buckets,
       boundaries,
+      servers,
     );
   }
 }
@@ -787,6 +943,7 @@ function allocateLatency(
   buckets: Map<ActivityBucket, MutableBucket>,
   boundaries: Map<number, number>,
   latency: MutableLatency,
+  servers: PerSessionServers,
 ): void {
   let previous: number | null = null;
   for (const message of orderedMessages(blocks)) {
@@ -802,6 +959,7 @@ function allocateLatency(
         buckets,
         phaseOf(boundaries, sessionId, message.seq),
         latency,
+        servers,
       );
     }
     previous = at;
@@ -837,6 +995,7 @@ function distributeLatency(
   buckets: Map<ActivityBucket, MutableBucket>,
   phase: Phase,
   latency: MutableLatency,
+  servers: PerSessionServers,
 ): void {
   if (ms <= 0 || blocks.length === 0) {
     return;
@@ -855,6 +1014,7 @@ function distributeLatency(
       shareMs,
       phase,
     );
+    addServerLatency(servers, serverOf(item.block), shareMs, phase);
   }
 }
 
@@ -912,6 +1072,7 @@ function allocateOutput(
   blocks: BlockRow[],
   buckets: Map<ActivityBucket, MutableBucket>,
   phase: Phase,
+  servers: PerSessionServers,
 ): void {
   const hasThinking = blocks.some((block) => block.type === "thinking");
   const visible = blocks
@@ -925,6 +1086,7 @@ function allocateOutput(
     blocks.filter((block) => block.type !== "thinking"),
     buckets,
     phase,
+    servers,
   );
 }
 
@@ -935,6 +1097,7 @@ function distributeVisible(
   blocks: BlockRow[],
   buckets: Map<ActivityBucket, MutableBucket>,
   phase: Phase,
+  servers: PerSessionServers,
 ): void {
   if (tokens <= 0 || blocks.length === 0) {
     return;
@@ -942,13 +1105,15 @@ function distributeVisible(
   const weighted = blocks.map((block) => ({ block, weight: Math.max(1, blockSize(block)) }));
   const totalWeight = weighted.reduce((sum, item) => sum + item.weight, 0);
   for (const item of weighted) {
+    const amount = tokens * (item.weight / totalWeight);
     addBucket(
       buckets,
       blockBucket(item.block.type, item.block.tool_name, item.block.tool_input),
-      tokens * (item.weight / totalWeight),
+      amount,
       sessionId,
       phase,
     );
+    addServerGeneration(servers, serverOf(item.block), amount, phase);
   }
 }
 
@@ -960,6 +1125,7 @@ function distribute(
   blocks: BlockRow[],
   buckets: Map<ActivityBucket, MutableBucket>,
   boundaries: Map<number, number>,
+  servers: PerSessionServers,
 ): void {
   if (tokens <= 0 || blocks.length === 0) {
     return;
@@ -970,13 +1136,16 @@ function distribute(
   }));
   const totalWeight = weighted.reduce((sum, item) => sum + item.weight, 0);
   for (const item of weighted) {
+    const amount = tokens * (item.weight / totalWeight);
+    const phase = phaseOf(boundaries, sessionId, item.block.seq);
     addBucket(
       buckets,
       blockBucket(item.block.type, item.block.tool_name, item.block.tool_input),
-      tokens * (item.weight / totalWeight),
+      amount,
       sessionId,
-      phaseOf(boundaries, sessionId, item.block.seq),
+      phase,
     );
+    addServerGeneration(servers, serverOf(item.block), amount, phase);
   }
 }
 
@@ -1005,6 +1174,90 @@ function addBucket(
   entry.sessions.add(sessionId);
 }
 
+/** The MCP server behind a block, or null for a builtin or a non-tool block.
+ * Uses the raw logged tool name: localToolName splits on "." and would corrupt
+ * a slug. classifyTool is the same parser ingest stamps tool_call.mcp_server
+ * with, and Codex normalizes its MCP calls to mcp__<server>__<tool>, so one
+ * parser covers both sources. */
+function serverOf(block: BlockRow): string | null {
+  const name = block.tool_name;
+  if (name == null || name === "") {
+    return null;
+  }
+  return classifyTool(name).mcpServer;
+}
+
+function serverEntry(servers: Map<string, PhaseTotals>, server: string): PhaseTotals {
+  const existing = servers.get(server);
+  if (existing != null) {
+    return existing;
+  }
+  const created = emptyPhaseTotals();
+  servers.set(server, created);
+  return created;
+}
+
+function emptyPhaseTotals(): PhaseTotals {
+  return {
+    generation: 0,
+    contextWindow: 0,
+    cost: 0,
+    genOrientation: 0,
+    windowOrientation: 0,
+    costOrientation: 0,
+    activeMs: 0,
+    activeMsOrientation: 0,
+  };
+}
+
+function addServerGeneration(
+  servers: PerSessionServers,
+  server: string | null,
+  tokens: number,
+  phase: Phase,
+): void {
+  if (server == null || tokens <= 0) {
+    return;
+  }
+  const entry = serverEntry(servers, server);
+  entry.generation += tokens;
+  if (phase === "orientation") {
+    entry.genOrientation += tokens;
+  }
+}
+
+function addServerWindow(
+  servers: PerSessionServers,
+  server: string,
+  tokens: number,
+  phase: Phase,
+): void {
+  if (tokens <= 0) {
+    return;
+  }
+  const entry = serverEntry(servers, server);
+  entry.contextWindow += tokens;
+  if (phase === "orientation") {
+    entry.windowOrientation += tokens;
+  }
+}
+
+function addServerLatency(
+  servers: PerSessionServers,
+  server: string | null,
+  ms: number,
+  phase: Phase,
+): void {
+  if (server == null || ms <= 0) {
+    return;
+  }
+  const entry = serverEntry(servers, server);
+  entry.activeMs += ms;
+  if (phase === "orientation") {
+    entry.activeMsOrientation += ms;
+  }
+}
+
 function emptyBuckets(): Map<ActivityBucket, MutableBucket> {
   return new Map(
     ACTIVITY_BUCKETS.map((bucket) => [
@@ -1029,7 +1282,7 @@ function emptyLatency(): MutableLatency {
   return { waitingOnUserMs: 0 };
 }
 
-function phasesFor(entry: MutableBucket | undefined): Record<Phase, PhaseAmounts> {
+function phasesFor(entry: PhaseTotals | undefined): Record<Phase, PhaseAmounts> {
   const gen = entry?.generation ?? 0;
   const win = entry?.contextWindow ?? 0;
   const cost = entry?.cost ?? 0;
@@ -1060,7 +1313,9 @@ function finish(
   buckets: Map<ActivityBucket, MutableBucket>,
   inputCost: number,
   outputCost: number,
-  waitingOnUserMs = 0,
+  waitingOnUserMs: number,
+  servers: Map<string, PhaseTotals>,
+  options: TokenEconomicsOptions | undefined,
 ): TokenEconomics {
   const totalCost = sumBuckets(buckets, "cost");
   const rows: TokenEconomicsBucket[] = ACTIVITY_BUCKETS.map((bucket) => {
@@ -1097,7 +1352,96 @@ function finish(
   orientationTotal.cost_share = share(orientationTotal.estimated_cost_usd, totalCost);
   implementationTotal.cost_share = share(implementationTotal.estimated_cost_usd, totalCost);
   totals.phases = { orientation: orientationTotal, implementation: implementationTotal };
+  totals.retrieval = retrievalFor(servers, totals.phases, options);
   return { buckets: rows, totals };
+}
+
+/** Decompose the phase totals into the named servers' share and what is left,
+ * without touching the phase totals themselves. `by_server` is emitted whether
+ * or not anything was named, so the pair below can be re-derived downstream
+ * for any allowlist. */
+function retrievalFor(
+  servers: Map<string, PhaseTotals>,
+  phases: Record<Phase, PhaseAmounts>,
+  options: TokenEconomicsOptions | undefined,
+): RetrievalEconomics {
+  const excludedServers: string[] = [];
+  for (const slug of options?.excludeMcpServers ?? []) {
+    if (slug !== "" && !excludedServers.includes(slug)) {
+      excludedServers.push(slug);
+    }
+  }
+  const byServer: Record<string, Record<Phase, PhaseAmounts>> = {};
+  for (const server of [...servers.keys()].sort()) {
+    byServer[server] = phasesFor(servers.get(server));
+  }
+  // Sum the raw totals before rounding, the way a bucket is rounded once at
+  // the end. Summing already-rounded per-server rows would let attributed
+  // drift past the phase it is subtracted from.
+  const named = emptyPhaseTotals();
+  for (const server of excludedServers) {
+    const entry = servers.get(server);
+    if (entry == null) {
+      continue;
+    }
+    named.generation += entry.generation;
+    named.contextWindow += entry.contextWindow;
+    named.cost += entry.cost;
+    named.genOrientation += entry.genOrientation;
+    named.windowOrientation += entry.windowOrientation;
+    named.costOrientation += entry.costOrientation;
+    named.activeMs += entry.activeMs;
+    named.activeMsOrientation += entry.activeMsOrientation;
+  }
+  const attributed = phasesFor(named);
+  // Rounding on the two sides is independent, so a difference can land at -0
+  // or -1; PhaseAmounts declares every field minimum: 0.
+  const orientationCost = Math.max(
+    0,
+    phases.orientation.estimated_cost_usd - attributed.orientation.estimated_cost_usd,
+  );
+  const implementationCost = Math.max(
+    0,
+    phases.implementation.estimated_cost_usd - attributed.implementation.estimated_cost_usd,
+  );
+  const remainderCost = orientationCost + implementationCost;
+  return {
+    excluded_servers: excludedServers,
+    by_server: byServer,
+    attributed,
+    remainder: {
+      orientation: remainderAmounts(
+        phases.orientation,
+        attributed.orientation,
+        orientationCost,
+        share(orientationCost, remainderCost),
+      ),
+      implementation: remainderAmounts(
+        phases.implementation,
+        attributed.implementation,
+        implementationCost,
+        share(implementationCost, remainderCost),
+      ),
+    },
+  };
+}
+
+function remainderAmounts(
+  phase: PhaseAmounts,
+  attributed: PhaseAmounts,
+  cost: number,
+  costShare: number,
+): PhaseAmounts {
+  return {
+    generation_tokens: Math.max(0, phase.generation_tokens - attributed.generation_tokens),
+    context_window_tokens: Math.max(
+      0,
+      phase.context_window_tokens - attributed.context_window_tokens,
+    ),
+    estimated_cost_usd: cost,
+    active_ms: Math.max(0, phase.active_ms - attributed.active_ms),
+    cost_share: costShare,
+  };
 }
 
 function sumPhase(rows: TokenEconomicsBucket[], phase: Phase): PhaseAmounts {

--- a/test/api-contract.test.ts
+++ b/test/api-contract.test.ts
@@ -249,6 +249,20 @@ describe("local API OpenAPI contract", () => {
           body: { key: recommendationKey, source: "api-contract", note: "fixture-only" },
         },
       ];
+      // Extra requests against operations `cases` already covers, so the
+      // operationKeys equality below stays one entry per operation.
+      const variantCases: ContractCase[] = [
+        {
+          path: "/api/analytics/token-economics",
+          method: "get",
+          url: "/api/analytics/token-economics?exclude_mcp_server=dosu&exclude_mcp_server=claude_ai_Dosu",
+        },
+        {
+          path: "/api/sessions/{id}/token-economics",
+          method: "get",
+          url: `/api/sessions/${sessionId}/token-economics?exclude_mcp_server=github`,
+        },
+      ];
       const errorCases: ContractCase[] = [
         {
           path: "/api/health",
@@ -359,6 +373,14 @@ describe("local API OpenAPI contract", () => {
         "to",
         "tool",
       ]);
+      expect(parameterNames(document, "/api/analytics/token-economics", "get")).toEqual([
+        "exclude_mcp_server",
+        "from",
+        "to",
+      ]);
+      expect(parameterNames(document, "/api/sessions/{id}/token-economics", "get")).toEqual([
+        "exclude_mcp_server",
+      ]);
       expect(requestPropertyNames(document, "/api/search", "post")).toContain("include_total");
       expect(requestPropertyNames(document, "/api/sessions/{id}/state", "post")).toEqual(["state"]);
       expect(operationDescription(document, "/api/sessions", "get")).toContain(
@@ -386,7 +408,7 @@ describe("local API OpenAPI contract", () => {
       ]);
       const validators = new Map<string, ValidateFunction>();
 
-      for (const contractCase of [...cases, ...errorCases]) {
+      for (const contractCase of [...cases, ...variantCases, ...errorCases]) {
         const expectedStatus = contractCase.status ?? 200;
         const expectedMediaType = contractCase.mediaType ?? "application/json";
         const response =
@@ -503,6 +525,16 @@ function seed(config: Config): void {
     1,
     2,
     "contract-codex",
+  );
+  // Gives totals.retrieval.by_server real entries: an empty map satisfies its
+  // additionalProperties schema without ever exercising it.
+  upsertSession(
+    db,
+    parseClaudeSession("contract-claude-mcp", fixture("claude", "mcp.jsonl")),
+    "/synthetic/claude-mcp.jsonl",
+    1,
+    2,
+    "contract-claude-mcp",
   );
   regenerate(db);
   db.close();

--- a/test/api-contract.test.ts
+++ b/test/api-contract.test.ts
@@ -25,6 +25,19 @@ interface ContractCase {
   mediaType?: "application/json" | "text/event-stream" | "text/html";
   requestValid?: boolean;
   response?: () => Response | Promise<Response>;
+  /** Behavioural check on the decoded body, for cases where the response
+   * schema cannot see whether a request parameter reached the handler. */
+  assert?: (value: unknown) => void;
+}
+
+interface RetrievalBody {
+  totals: {
+    retrieval: {
+      excluded_servers: string[];
+      by_server: Record<string, unknown>;
+      attributed: { orientation: { estimated_cost_usd: number } };
+    };
+  };
 }
 
 interface OpenApiOperation {
@@ -56,7 +69,7 @@ describe("local API OpenAPI contract", () => {
     const priorConfigDir = process.env.DECANT_CONFIG_DIR;
     process.env.DECANT_CONFIG_DIR = join(root, "config");
     const config = fixtureConfig(root);
-    seed(config);
+    const mcpSessionId = seed(config);
     const server = serve({
       config,
       hostname: "127.0.0.1",
@@ -251,16 +264,36 @@ describe("local API OpenAPI contract", () => {
       ];
       // Extra requests against operations `cases` already covers, so the
       // operationKeys equality below stays one entry per operation.
+      //
+      // These carry behavioural assertions because Ajv cannot see whether
+      // exclude_mcp_server reached the handler at all: `excluded_servers: []`
+      // and `["github"]` are both schema-valid, and an all-zero `attributed`
+      // is schema-valid too. Replacing either route's wiring with a literal
+      // `[]` leaves the whole schema-only suite green.
+      //
+      // Two parameters, with the volume-bearing slug SECOND, so a regression
+      // from getAll() to get() -- which yields a bare string, iterated as
+      // characters -- fails both assertions rather than neither.
+      const assertExclusionApplied =
+        (expected: string[]) =>
+        (value: unknown): void => {
+          const retrieval = (value as RetrievalBody).totals.retrieval;
+          expect(retrieval.excluded_servers).toEqual(expected);
+          expect(retrieval.attributed.orientation.estimated_cost_usd).toBeGreaterThan(0);
+          expect(Object.keys(retrieval.by_server)).toContain("github");
+        };
       const variantCases: ContractCase[] = [
         {
           path: "/api/analytics/token-economics",
           method: "get",
-          url: "/api/analytics/token-economics?exclude_mcp_server=dosu&exclude_mcp_server=claude_ai_Dosu",
+          url: "/api/analytics/token-economics?exclude_mcp_server=claude_ai_Dosu&exclude_mcp_server=github",
+          assert: assertExclusionApplied(["claude_ai_Dosu", "github"]),
         },
         {
           path: "/api/sessions/{id}/token-economics",
           method: "get",
-          url: `/api/sessions/${sessionId}/token-economics?exclude_mcp_server=github`,
+          url: `/api/sessions/${mcpSessionId}/token-economics?exclude_mcp_server=claude_ai_Dosu&exclude_mcp_server=github`,
+          assert: assertExclusionApplied(["claude_ai_Dosu", "github"]),
         },
       ];
       const errorCases: ContractCase[] = [
@@ -443,6 +476,7 @@ describe("local API OpenAPI contract", () => {
             : expectedMediaType === "text/event-stream"
               ? await firstStreamChunk(response)
               : await response.text();
+        contractCase.assert?.(value);
         if (contractCase.expectedCode != null) {
           expect(value).toMatchObject({ code: contractCase.expectedCode });
         }
@@ -506,7 +540,9 @@ function fixtureConfig(root: string): Config {
   };
 }
 
-function seed(config: Config): void {
+/** Returns the row id of the MCP-bearing session, which is the only one whose
+ * economics carry a non-zero retrieval slice. */
+function seed(config: Config): number {
   const db = openDb(config.dbPath);
   const fixture = (tool: "claude" | "codex", name: string): string =>
     readFileSync(join(import.meta.dir, "..", "fixtures", tool, name), "utf8");
@@ -528,7 +564,7 @@ function seed(config: Config): void {
   );
   // Gives totals.retrieval.by_server real entries: an empty map satisfies its
   // additionalProperties schema without ever exercising it.
-  upsertSession(
+  const mcpSessionId = upsertSession(
     db,
     parseClaudeSession("contract-claude-mcp", fixture("claude", "mcp.jsonl")),
     "/synthetic/claude-mcp.jsonl",
@@ -538,6 +574,7 @@ function seed(config: Config): void {
   );
   regenerate(db);
   db.close();
+  return mcpSessionId;
 }
 
 async function fetchJson(url: string): Promise<unknown> {

--- a/test/buckets.test.ts
+++ b/test/buckets.test.ts
@@ -14,6 +14,16 @@ describe("activity bucket classifier", () => {
     expect(toolBucket("UnknownFutureTool")).toBe("context");
   });
 
+  test("keeps every MCP tool in context so retrieval accounting stays additive", () => {
+    // Retrieval cost is reported by server in totals.retrieval, which subtracts
+    // from the phase totals. That only works while MCP volume is inside a
+    // bucket rather than beside one, so these stay context on purpose.
+    expect(toolBucket("mcp__dosu__read_knowledge")).toBe("context");
+    expect(toolBucket("mcp__claude_ai_Dosu__read_knowledge")).toBe("context");
+    expect(blockBucket("tool_use", "mcp__dosu__read_knowledge")).toBe("context");
+    expect(blockBucket("tool_result", "mcp__dosu__read_knowledge")).toBe("context");
+  });
+
   test("classifies Bash by command head and git subcommand", () => {
     expect(bashBucket("rg auth src")).toBe("context");
     expect(bashBucket("/bin/cat README.md")).toBe("context");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -167,6 +167,63 @@ describe("runCli", () => {
     // in formatPercent still prints a plausible "0.7%", so only the magnitude of
     // the sum catches it.
     expect((phasePercents[0] ?? 0) + (phasePercents[1] ?? 0)).toBeCloseTo(100, 1);
+    // Nothing is named by default, so the retrieval rows stay off and the
+    // human table is byte-identical to what it printed before the flag existed.
+    expect(humanTokens.stdout).not.toContain("orientation_retrieval");
+
+    const excluded = await runCli([...base, "tokens", "--exclude-mcp-server", "github"]);
+    expect(excluded.code).toBe(0);
+    const jsonExcluded = JSON.parse(excluded.stdout) as {
+      totals: {
+        phases: { orientation: { estimated_cost_usd: number } };
+        retrieval: {
+          excluded_servers: string[];
+          by_server: Record<string, unknown>;
+          attributed: { orientation: { estimated_cost_usd: number } };
+          remainder: { orientation: { estimated_cost_usd: number } };
+        };
+      };
+    };
+    // Reparsed from stdout rather than reusing jsonTokens: the toMatchObject
+    // above emptied its `totals` in place.
+    const baseline = JSON.parse(tokens.stdout) as typeof jsonExcluded;
+    expect(jsonExcluded.totals.phases).toEqual(baseline.totals.phases);
+    expect(jsonExcluded.totals.retrieval.excluded_servers).toEqual(["github"]);
+    expect(Object.keys(baseline.totals.retrieval.by_server)).toContain("github");
+    expect(jsonExcluded.totals.retrieval.attributed.orientation.estimated_cost_usd).toBeGreaterThan(
+      0,
+    );
+
+    const humanExcluded = await runCli([
+      "--db",
+      dbPath,
+      "--no-sync",
+      "tokens",
+      "--exclude-mcp-server",
+      "github",
+    ]);
+    expect(humanExcluded).toMatchObject({ code: 0, stderr: "" });
+    const retrievalCosts = Object.fromEntries(
+      [
+        ...humanExcluded.stdout.matchAll(
+          /^(orientation_all_in|orientation_retrieval|orientation_remainder)\t-\t-\t([\d.]+)\t-\t[\d.]+%$/gm,
+        ),
+      ].map((match) => [match[1] as string, Number(match[2])]),
+    );
+    expect(Object.keys(retrievalCosts).sort()).toEqual([
+      "orientation_all_in",
+      "orientation_remainder",
+      "orientation_retrieval",
+    ]);
+    // The two halves add back to the all-in number a report already prints.
+    expect(
+      (retrievalCosts.orientation_retrieval ?? 0) + (retrievalCosts.orientation_remainder ?? 0),
+    ).toBeCloseTo(retrievalCosts.orientation_all_in ?? 0, 4);
+    expect(retrievalCosts.orientation_retrieval).toBeGreaterThan(0);
+    // The new labels must not be read as phase rows by anything parsing this.
+    expect([
+      ...humanExcluded.stdout.matchAll(/^(?:orientation|implementation)\t.*\t([\d.]+)%$/gm),
+    ]).toHaveLength(2);
 
     const search = await runCli([...base, "search", "auth", "--limit", "5"]);
     expect(search.code).toBe(0);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -203,23 +203,32 @@ describe("runCli", () => {
       "github",
     ]);
     expect(humanExcluded).toMatchObject({ code: 0, stderr: "" });
-    const retrievalCosts = Object.fromEntries(
-      [
-        ...humanExcluded.stdout.matchAll(
-          /^(orientation_all_in|orientation_retrieval|orientation_remainder)\t-\t-\t([\d.]+)\t-\t[\d.]+%$/gm,
-        ),
-      ].map((match) => [match[1] as string, Number(match[2])]),
-    );
-    expect(Object.keys(retrievalCosts).sort()).toEqual([
-      "orientation_all_in",
-      "orientation_remainder",
-      "orientation_retrieval",
-    ]);
-    // The two halves add back to the all-in number a report already prints.
-    expect(
-      (retrievalCosts.orientation_retrieval ?? 0) + (retrievalCosts.orientation_remainder ?? 0),
-    ).toBeCloseTo(retrievalCosts.orientation_all_in ?? 0, 4);
-    expect(retrievalCosts.orientation_retrieval).toBeGreaterThan(0);
+    // All-in is NOT reprinted as its own row: the `orientation` row already is
+    // that number, and printing it twice reads as a narrower measurement.
+    expect(humanExcluded.stdout).not.toContain("orientation_all_in");
+    const numericRow = (label: string): number[] => {
+      const match = new RegExp(
+        `^${label}\\t(\\d+)\\t(\\d+)\\t([\\d.]+)\\t(.+?)\\t([\\d.]+)%$`,
+        "m",
+      ).exec(humanExcluded.stdout);
+      if (match == null) {
+        throw new Error(`${label} row missing from:\n${humanExcluded.stdout}`);
+      }
+      return [match[1], match[2], match[3], match[5]].map((part) => Number(part));
+    };
+    const orientation = numericRow("orientation");
+    const attributed = numericRow("orientation_retrieval");
+    const remainder = numericRow("orientation_remainder");
+    expect(attributed[2]).toBeGreaterThan(0);
+    // Every printed column is a decomposition of the `orientation` row above:
+    // generation, context window, cost, and percent all add back to it. That is
+    // what makes the two rows self-evidently a split rather than a subset.
+    for (const column of [0, 1, 2, 3]) {
+      expect((attributed[column] ?? 0) + (remainder[column] ?? 0)).toBeCloseTo(
+        orientation[column] ?? 0,
+        column === 2 ? 4 : 1,
+      );
+    }
     // The new labels must not be read as phase rows by anything parsing this.
     expect([
       ...humanExcluded.stdout.matchAll(/^(?:orientation|implementation)\t.*\t([\d.]+)%$/gm),

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -239,10 +239,7 @@ describe("runCli", () => {
     // All-in is NOT reprinted as its own row: the `orientation` row already is
     // that number, and printing it twice reads as a narrower measurement.
     expect(humanExcluded.stdout).not.toContain("orientation_all_in");
-    // Captures all five columns but returns only the two token ones. The cost,
-    // time and percent groups are matched so the row shape stays pinned, and
-    // deliberately not summed -- see the payload assertions above.
-    const tokenColumns = (label: string): number[] => {
+    const printedRow = (label: string): { tokens: number[]; cost: string; pct: string } => {
       const match = new RegExp(
         `^${label}\\t(\\d+)\\t(\\d+)\\t([\\d.]+)\\t(.+?)\\t([\\d.]+)%$`,
         "m",
@@ -250,18 +247,34 @@ describe("runCli", () => {
       if (match == null) {
         throw new Error(`${label} row missing from:\n${humanExcluded.stdout}`);
       }
-      return [match[1], match[2]].map((part) => Number(part));
+      return {
+        tokens: [match[1], match[2]].map((part) => Number(part)),
+        cost: match[3] as string,
+        pct: `${match[5]}%`,
+      };
     };
-    const orientation = tokenColumns("orientation");
-    const attributed = tokenColumns("orientation_retrieval");
-    const remainder = tokenColumns("orientation_remainder");
+    const orientation = printedRow("orientation");
+    const attributed = printedRow("orientation_retrieval");
+    const remainder = printedRow("orientation_remainder");
     // The printed token columns reconcile digit for digit, and not by luck:
     // phasesFor rounds these to integers before printing, the integers sum
     // exactly, and formatNumber is String(Math.round(...)) over an already
     // integral value. Exact equality, not a tolerance.
     for (const column of [0, 1]) {
-      expect((attributed[column] ?? 0) + (remainder[column] ?? 0)).toBe(orientation[column] ?? 0);
+      expect((attributed.tokens[column] ?? 0) + (remainder.tokens[column] ?? 0)).toBe(
+        orientation.tokens[column] ?? 0,
+      );
     }
+    // Cost and percent are pinned per row, each against ITS OWN payload field's
+    // formatted form. This is a rendering-fidelity check, not a reconciliation
+    // claim: it sums nothing across rows, so it asserts none of the digit-level
+    // agreement the methodology withdraws, while still catching a renderer slip
+    // that prints another row's figure in this row's cell.
+    const printedPercent = (cost: number): string => `${(100 * archiveShare(cost)).toFixed(1)}%`;
+    expect(attributed.cost).toBe(attributedJson.estimated_cost_usd.toFixed(4));
+    expect(remainder.cost).toBe(remainderJson.estimated_cost_usd.toFixed(4));
+    expect(attributed.pct).toBe(printedPercent(attributedJson.estimated_cost_usd));
+    expect(remainder.pct).toBe(printedPercent(remainderJson.estimated_cost_usd));
     // The new labels must not be read as phase rows by anything parsing this.
     expect([
       ...humanExcluded.stdout.matchAll(/^(?:orientation|implementation)\t.*\t([\d.]+)%$/gm),

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -173,14 +173,21 @@ describe("runCli", () => {
 
     const excluded = await runCli([...base, "tokens", "--exclude-mcp-server", "github"]);
     expect(excluded.code).toBe(0);
+    interface PhaseAmountsJson {
+      generation_tokens: number;
+      context_window_tokens: number;
+      estimated_cost_usd: number;
+      active_ms: number;
+    }
     const jsonExcluded = JSON.parse(excluded.stdout) as {
       totals: {
-        phases: { orientation: { estimated_cost_usd: number } };
+        estimated_cost_usd: number;
+        phases: { orientation: PhaseAmountsJson };
         retrieval: {
           excluded_servers: string[];
           by_server: Record<string, unknown>;
-          attributed: { orientation: { estimated_cost_usd: number } };
-          remainder: { orientation: { estimated_cost_usd: number } };
+          attributed: { orientation: PhaseAmountsJson };
+          remainder: { orientation: PhaseAmountsJson };
         };
       };
     };
@@ -194,6 +201,32 @@ describe("runCli", () => {
       0,
     );
 
+    // Exact reconciliation is asserted on the PAYLOAD, never on the rendered
+    // table. docs/analytics-methodology.md ("Which denominator each cost_share
+    // uses") states that cost, time and percent are each rounded per row, so a
+    // printed pair can differ from the printed parent by one unit in its last
+    // displayed place. Asserting a printed-cost or printed-time sum would
+    // contradict the documentation and is a landmine on any other archive --
+    // do not re-add one. The two token columns are checked below, where the
+    // guarantee is real.
+    const wholeJson = jsonExcluded.totals.phases.orientation;
+    const attributedJson = jsonExcluded.totals.retrieval.attributed.orientation;
+    const remainderJson = jsonExcluded.totals.retrieval.remainder.orientation;
+    for (const field of ["generation_tokens", "context_window_tokens", "active_ms"] as const) {
+      expect(attributedJson[field] + remainderJson[field]).toBe(wholeJson[field]);
+    }
+    expect(attributedJson.estimated_cost_usd + remainderJson.estimated_cost_usd).toBeCloseTo(
+      wholeJson.estimated_cost_usd,
+      12,
+    );
+    // The percent column the table prints is cost over the archive total, so
+    // its exact form reconciles here too.
+    const archiveShare = (cost: number): number => cost / jsonExcluded.totals.estimated_cost_usd;
+    expect(
+      archiveShare(attributedJson.estimated_cost_usd) +
+        archiveShare(remainderJson.estimated_cost_usd),
+    ).toBeCloseTo(archiveShare(wholeJson.estimated_cost_usd), 12);
+
     const humanExcluded = await runCli([
       "--db",
       dbPath,
@@ -206,7 +239,10 @@ describe("runCli", () => {
     // All-in is NOT reprinted as its own row: the `orientation` row already is
     // that number, and printing it twice reads as a narrower measurement.
     expect(humanExcluded.stdout).not.toContain("orientation_all_in");
-    const numericRow = (label: string): number[] => {
+    // Captures all five columns but returns only the two token ones. The cost,
+    // time and percent groups are matched so the row shape stays pinned, and
+    // deliberately not summed -- see the payload assertions above.
+    const tokenColumns = (label: string): number[] => {
       const match = new RegExp(
         `^${label}\\t(\\d+)\\t(\\d+)\\t([\\d.]+)\\t(.+?)\\t([\\d.]+)%$`,
         "m",
@@ -214,20 +250,17 @@ describe("runCli", () => {
       if (match == null) {
         throw new Error(`${label} row missing from:\n${humanExcluded.stdout}`);
       }
-      return [match[1], match[2], match[3], match[5]].map((part) => Number(part));
+      return [match[1], match[2]].map((part) => Number(part));
     };
-    const orientation = numericRow("orientation");
-    const attributed = numericRow("orientation_retrieval");
-    const remainder = numericRow("orientation_remainder");
-    expect(attributed[2]).toBeGreaterThan(0);
-    // Every printed column is a decomposition of the `orientation` row above:
-    // generation, context window, cost, and percent all add back to it. That is
-    // what makes the two rows self-evidently a split rather than a subset.
-    for (const column of [0, 1, 2, 3]) {
-      expect((attributed[column] ?? 0) + (remainder[column] ?? 0)).toBeCloseTo(
-        orientation[column] ?? 0,
-        column === 2 ? 4 : 1,
-      );
+    const orientation = tokenColumns("orientation");
+    const attributed = tokenColumns("orientation_retrieval");
+    const remainder = tokenColumns("orientation_remainder");
+    // The printed token columns reconcile digit for digit, and not by luck:
+    // phasesFor rounds these to integers before printing, the integers sum
+    // exactly, and formatNumber is String(Math.round(...)) over an already
+    // integral value. Exact equality, not a tolerance.
+    for (const column of [0, 1]) {
+      expect((attributed[column] ?? 0) + (remainder[column] ?? 0)).toBe(orientation[column] ?? 0);
     }
     // The new labels must not be read as phase rows by anything parsing this.
     expect([

--- a/test/economics-cache.test.ts
+++ b/test/economics-cache.test.ts
@@ -76,6 +76,38 @@ describe("economics cache", () => {
     db.close();
   });
 
+  test("passes the exclusion set through to aggregation without rebuilding", async () => {
+    const dbPath = seededDbPath();
+    const db = openDb(dbPath);
+    upsertSession(
+      db,
+      parseClaudeSession("sess-mcp-claude", fixture("claude", "mcp.jsonl")),
+      "/x/mcp.jsonl",
+      1,
+      2,
+      "claude",
+    );
+    const counter = { calls: 0 };
+    const cache = new EconomicsCache({
+      dbPath,
+      db,
+      computeVectors: countingComputeVectors(counter),
+    });
+
+    const none = await cache.get();
+    const excluded = await cache.get(null, { excludeMcpServers: ["github"] });
+    expect(none).toEqual(tokenEconomics(db));
+    expect(excluded).toEqual(tokenEconomics(db, null, { excludeMcpServers: ["github"] }));
+    expect(excluded.totals.phases).toEqual(none.totals.phases);
+    expect(excluded.totals.retrieval?.attributed.orientation.estimated_cost_usd).toBeGreaterThan(0);
+    expect(none.totals.retrieval?.attributed.orientation.estimated_cost_usd).toBe(0);
+    // Vectors carry every server unconditionally, so a second exclusion set is
+    // answered from the same computation rather than a rebuild.
+    expect(counter.calls).toBe(1);
+    cache.dispose();
+    db.close();
+  });
+
   test("detects external writes, serves stale, then rebuilds and notifies", async () => {
     const dbPath = seededDbPath();
     const db = openDb(dbPath);

--- a/test/token-economics.test.ts
+++ b/test/token-economics.test.ts
@@ -9,6 +9,7 @@ import { upsertSession } from "../src/ingest.ts";
 import { setSessionUserState } from "../src/session-user-state.ts";
 import { parseClaudeSession } from "../src/sources/claude.ts";
 import { parseCodexSession } from "../src/sources/codex.ts";
+import type { PhaseAmounts, TokenEconomics } from "../src/token-economics.ts";
 import {
   aggregateEconomicsVectors,
   computeSessionEconomicsVectors,
@@ -300,6 +301,444 @@ describe("token economics", () => {
     db.close();
   });
 
+  test("an empty exclusion set leaves every reported number unchanged", () => {
+    const db = freshDb();
+    upsertSession(
+      db,
+      parseClaudeSession("sess-mcp-claude", fixture("claude", "mcp.jsonl")),
+      "/x/mcp.jsonl",
+      1,
+      2,
+      "claude",
+    );
+    upsertSession(
+      db,
+      parseClaudeSession("sess-enr-claude", fixture("claude", "enriched.jsonl")),
+      "/x/claude.jsonl",
+      1,
+      2,
+      "claude",
+    );
+
+    const before = tokenEconomics(db);
+    const after = tokenEconomics(db, null, { excludeMcpServers: [] });
+    // The default exclusion set is empty, so the headline numbers a report
+    // already prints must not move when a caller opts into the parameter.
+    expect(after.totals.phases).toEqual(before.totals.phases);
+    expect(after.buckets).toEqual(before.buckets);
+    // by_server ships regardless, so any reader can re-derive the split for an
+    // allowlist Decant did not pick.
+    expect(after.totals.retrieval?.excluded_servers).toEqual([]);
+    expect(before.totals.retrieval?.excluded_servers).toEqual([]);
+    expect(Object.keys(after.totals.retrieval?.by_server ?? {})).toContain("github");
+    db.close();
+  });
+
+  test("reports orientation retrieval separately without moving it out of context", () => {
+    const db = freshDb();
+    upsertSession(
+      db,
+      parseClaudeSession("sess-mcp-claude", fixture("claude", "mcp.jsonl")),
+      "/x/mcp.jsonl",
+      1,
+      2,
+      "claude",
+    );
+
+    const plain = tokenEconomics(db);
+    const split = tokenEconomics(db, null, { excludeMcpServers: ["github"] });
+    // The MCP call still lives in context, and orientation still means all
+    // pre-edit spend. Only the extra block below reports the slice.
+    expect(split.buckets).toEqual(plain.buckets);
+    expect(split.totals.phases).toEqual(plain.totals.phases);
+    const retrieval = split.totals.retrieval as NonNullable<typeof split.totals.retrieval>;
+    expect(retrieval.attributed.orientation.estimated_cost_usd).toBeGreaterThan(0);
+    expect(retrieval.attributed.orientation.context_window_tokens).toBeGreaterThan(0);
+    expect(retrieval.remainder.orientation.estimated_cost_usd).toBeGreaterThan(0);
+    // The retrieval slice is a subset of context, never an extra bucket.
+    const context = split.buckets.find((row) => row.bucket === "context");
+    expect(retrieval.attributed.orientation.context_window_tokens).toBeLessThanOrEqual(
+      context?.phases?.orientation.context_window_tokens ?? 0,
+    );
+    db.close();
+  });
+
+  test("primary, retrieval, and net orientation reconcile", () => {
+    const db = freshDb();
+    upsertSession(
+      db,
+      parseClaudeSession("sess-mcp-claude", fixture("claude", "mcp.jsonl")),
+      "/x/mcp.jsonl",
+      1,
+      2,
+      "claude",
+    );
+    upsertSession(
+      db,
+      parseCodexSession("sess-mcp-codex", fixture("codex", "mcp.jsonl"), new Map()),
+      "/x/codex-mcp.jsonl",
+      1,
+      2,
+      "codex",
+    );
+    upsertSession(
+      db,
+      parseClaudeSession("sess-enr-claude", fixture("claude", "enriched.jsonl")),
+      "/x/claude.jsonl",
+      1,
+      2,
+      "claude",
+    );
+
+    const economics = tokenEconomics(db, null, {
+      excludeMcpServers: ["github", "dosu", "context7"],
+    });
+    const { phases, retrieval } = economics.totals as {
+      phases: NonNullable<TokenEconomics["totals"]["phases"]>;
+      retrieval: NonNullable<TokenEconomics["totals"]["retrieval"]>;
+    };
+    for (const phase of ["orientation", "implementation"] as const) {
+      const whole = phases[phase];
+      const part = retrieval.attributed[phase];
+      const rest = retrieval.remainder[phase];
+      expect(part.generation_tokens + rest.generation_tokens).toBe(whole.generation_tokens);
+      expect(part.context_window_tokens + rest.context_window_tokens).toBe(
+        whole.context_window_tokens,
+      );
+      expect(part.active_ms + rest.active_ms).toBe(whole.active_ms);
+      expect(part.estimated_cost_usd + rest.estimated_cost_usd).toBeCloseTo(
+        whole.estimated_cost_usd,
+        12,
+      );
+    }
+    // remainder's cost_share is the corrected headline: the orientation share
+    // once the named servers' spend is taken out of both halves.
+    expect(retrieval.remainder.orientation.cost_share).toBeLessThan(phases.orientation.cost_share);
+    expect(
+      retrieval.remainder.orientation.cost_share + retrieval.remainder.implementation.cost_share,
+    ).toBeCloseTo(1, 12);
+    db.close();
+  });
+
+  test("decomposes retrieval by server so any exclusion set can be re-derived", () => {
+    const db = freshDb();
+    upsertSession(
+      db,
+      parseClaudeSession("sess-mcp-claude", fixture("claude", "mcp.jsonl")),
+      "/x/mcp.jsonl",
+      1,
+      2,
+      "claude",
+    );
+    upsertSession(
+      db,
+      parseCodexSession("sess-mcp-codex", fixture("codex", "mcp.jsonl"), new Map()),
+      "/x/codex-mcp.jsonl",
+      1,
+      2,
+      "codex",
+    );
+
+    // by_server ships whether or not anything was named, and does not move when
+    // the exclusion set changes -- that is what makes an outside allowlist
+    // derivable from a published payload.
+    const none = tokenEconomics(db).totals.retrieval as NonNullable<
+      TokenEconomics["totals"]["retrieval"]
+    >;
+    const some = tokenEconomics(db, null, { excludeMcpServers: ["exa"] }).totals
+      .retrieval as NonNullable<TokenEconomics["totals"]["retrieval"]>;
+    expect(some.by_server).toEqual(none.by_server);
+    expect(Object.keys(none.by_server).sort()).toEqual([
+      "codex_apps",
+      "context7",
+      "dosu",
+      "exa",
+      "github",
+      "node_repl",
+    ]);
+    expect(none.attributed.orientation.estimated_cost_usd).toBe(0);
+
+    const chosen = ["dosu", "github", "context7"];
+    const reported = tokenEconomics(db, null, { excludeMcpServers: chosen }).totals
+      .retrieval as NonNullable<TokenEconomics["totals"]["retrieval"]>;
+    const rederived = chosen.reduce(
+      (sum, server) => sum + (none.by_server[server]?.orientation.estimated_cost_usd ?? 0),
+      0,
+    );
+    expect(reported.attributed.orientation.estimated_cost_usd).toBeCloseTo(rederived, 12);
+    db.close();
+  });
+
+  test("excludes only the named servers", () => {
+    const db = freshDb();
+    upsertSession(
+      db,
+      parseCodexSession("sess-mcp-codex", fixture("codex", "mcp.jsonl"), new Map()),
+      "/x/codex-mcp.jsonl",
+      1,
+      2,
+      "codex",
+    );
+
+    const retrieval = tokenEconomics(db, null, {
+      excludeMcpServers: ["dosu", "dosu", "", "not-installed"],
+    }).totals.retrieval as NonNullable<TokenEconomics["totals"]["retrieval"]>;
+    // Duplicates and blanks collapse, an unknown slug contributes nothing, and
+    // the set is echoed back so a published figure carries it.
+    expect(retrieval.excluded_servers).toEqual(["dosu", "not-installed"]);
+    expect(retrieval.attributed.orientation).toEqual(
+      retrieval.by_server.dosu?.orientation as PhaseAmounts,
+    );
+    // The unqualified Codex namespace is a different tool, not another
+    // registration of dosu, so it is not swept in by the slug.
+    expect(Object.keys(retrieval.by_server)).not.toContain("dosu__unqualified_tool");
+    expect(retrieval.by_server.exa?.orientation.context_window_tokens).toBeGreaterThan(0);
+    db.close();
+  });
+
+  test("attributes retrieval that happens after the first edit to implementation", () => {
+    const db = freshDb();
+    const content = [
+      JSON.stringify({
+        type: "assistant",
+        uuid: "a1",
+        parentUuid: null,
+        sessionId: "sess-mcp-phases",
+        timestamp: "2026-05-07T09:00:00.000Z",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-7",
+          usage: { input_tokens: 400, output_tokens: 100 },
+          content: [
+            { type: "tool_use", id: "toolu_mcp_a", name: "mcp__dosu__read_knowledge", input: {} },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        uuid: "u1",
+        parentUuid: "a1",
+        sessionId: "sess-mcp-phases",
+        timestamp: "2026-05-07T09:00:10.000Z",
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_mcp_a", content: "prior decisions here" },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        uuid: "a2",
+        parentUuid: "u1",
+        sessionId: "sess-mcp-phases",
+        timestamp: "2026-05-07T09:00:20.000Z",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-7",
+          usage: { input_tokens: 500, output_tokens: 120 },
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_edit",
+              name: "Edit",
+              input: { file_path: "/proj/src/auth.rs", old_string: "a", new_string: "b" },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        uuid: "u2",
+        parentUuid: "a2",
+        sessionId: "sess-mcp-phases",
+        timestamp: "2026-05-07T09:00:30.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_edit", content: "ok" }],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        uuid: "a3",
+        parentUuid: "u2",
+        sessionId: "sess-mcp-phases",
+        timestamp: "2026-05-07T09:00:40.000Z",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-7",
+          usage: { input_tokens: 600, output_tokens: 140 },
+          content: [
+            { type: "tool_use", id: "toolu_mcp_b", name: "mcp__dosu__read_knowledge", input: {} },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        uuid: "u3",
+        parentUuid: "a3",
+        sessionId: "sess-mcp-phases",
+        timestamp: "2026-05-07T09:00:50.000Z",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_mcp_b",
+              content: "a much longer follow-up answer than the first one",
+            },
+          ],
+        },
+      }),
+    ].join("\n");
+    upsertSession(
+      db,
+      parseClaudeSession("sess-mcp-phases", `${content}\n`),
+      "/x/mcp-phases.jsonl",
+      1,
+      2,
+      "claude",
+    );
+
+    const retrieval = tokenEconomics(db, null, { excludeMcpServers: ["dosu"] }).totals
+      .retrieval as NonNullable<TokenEconomics["totals"]["retrieval"]>;
+    // The phase split is real: the same server lands on both sides of the
+    // first edit, so retrieval is not silently all-orientation.
+    expect(retrieval.attributed.orientation.context_window_tokens).toBeGreaterThan(0);
+    expect(retrieval.attributed.implementation.context_window_tokens).toBeGreaterThan(0);
+    expect(retrieval.attributed.orientation.generation_tokens).toBeGreaterThan(0);
+    expect(retrieval.attributed.implementation.generation_tokens).toBeGreaterThan(0);
+    db.close();
+  });
+
+  test("per-session retrieval reconciles against the billed-input window", () => {
+    const db = freshDb();
+    const sessionId = upsertSession(
+      db,
+      parseClaudeSession("sess-mcp-claude", fixture("claude", "mcp.jsonl")),
+      "/x/mcp.jsonl",
+      1,
+      2,
+      "claude",
+    );
+
+    const scoped = tokenEconomicsForSession(db, sessionId, {
+      excludeMcpServers: ["github"],
+    }) as TokenEconomics;
+    const { phases, retrieval } = scoped.totals as {
+      phases: NonNullable<TokenEconomics["totals"]["phases"]>;
+      retrieval: NonNullable<TokenEconomics["totals"]["retrieval"]>;
+    };
+    for (const phase of ["orientation", "implementation"] as const) {
+      expect(
+        retrieval.attributed[phase].context_window_tokens +
+          retrieval.remainder[phase].context_window_tokens,
+      ).toBe(phases[phase].context_window_tokens);
+      expect(
+        retrieval.attributed[phase].estimated_cost_usd +
+          retrieval.remainder[phase].estimated_cost_usd,
+      ).toBeCloseTo(phases[phase].estimated_cost_usd, 12);
+    }
+    // A session panel inflates every window by its share of the run's billed
+    // input. If the retrieval slice skipped that allocation it would be priced
+    // against a smaller window than the phases it decomposes, and this ratio
+    // would collapse toward the un-inflated archive-wide one.
+    const archive = tokenEconomics(db, null, { excludeMcpServers: ["github"] }).totals
+      .retrieval as NonNullable<TokenEconomics["totals"]["retrieval"]>;
+    const scopedWindow = retrieval.attributed.orientation.context_window_tokens;
+    const archiveWindow = archive.attributed.orientation.context_window_tokens;
+    expect(scopedWindow).toBeGreaterThan(archiveWindow);
+    expect(scopedWindow / phases.orientation.context_window_tokens).toBeCloseTo(
+      archiveWindow /
+        (tokenEconomics(db).totals.phases as NonNullable<TokenEconomics["totals"]["phases"]>)
+          .orientation.context_window_tokens,
+      2,
+    );
+    db.close();
+  });
+
+  test("attributes Codex MCP calls to their server", () => {
+    const db = freshDb();
+    // Codex reports MCP work as event-only mcp_tool_call_end records with no
+    // matching response_item, so this path is the only one a Codex archive has.
+    const content = [
+      JSON.stringify({
+        type: "session_meta",
+        timestamp: "2026-05-08T09:00:00.000Z",
+        payload: {
+          id: "sess-codex-event-mcp",
+          cwd: "/Users/dev/proj",
+          originator: "codex_cli_rs",
+          cli_version: "0.116.0",
+          source: "cli",
+          model_provider: "openai",
+        },
+      }),
+      JSON.stringify({
+        type: "turn_context",
+        timestamp: "2026-05-08T09:00:01.000Z",
+        payload: { cwd: "/Users/dev/proj", model: "gpt-5.4", effort: "medium" },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        timestamp: "2026-05-08T09:00:02.000Z",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Check durable project context" }],
+        },
+      }),
+      JSON.stringify({
+        type: "event_msg",
+        timestamp: "2026-05-08T09:00:06.000Z",
+        payload: {
+          type: "mcp_tool_call_end",
+          call_id: "77777777-8888-4999-8aaa-bbbbbbbbbbbb",
+          invocation: { server: "dosu", tool: "read_knowledge", arguments: { query: "synthetic" } },
+          duration: { secs: 2, nanos: 0 },
+          result: {
+            Ok: { content: [{ type: "text", text: "synthetic knowledge for the event path" }] },
+          },
+        },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        timestamp: "2026-05-08T09:00:08.000Z",
+        payload: {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Context checked." }],
+        },
+      }),
+    ].join("\n");
+    upsertSession(
+      db,
+      parseCodexSession("sess-codex-event-mcp", `${content}\n`, new Map()),
+      "/x/codex-event-mcp.jsonl",
+      1,
+      2,
+      "codex",
+    );
+
+    const economics = tokenEconomics(db, null, { excludeMcpServers: ["dosu"] });
+    const { phases, retrieval } = economics.totals as {
+      phases: NonNullable<TokenEconomics["totals"]["phases"]>;
+      retrieval: NonNullable<TokenEconomics["totals"]["retrieval"]>;
+    };
+    // Codex normalizes the invocation to mcp__<server>__<tool>, so the same
+    // parser that reads Claude names attributes it.
+    expect(Object.keys(retrieval.by_server)).toEqual(["dosu"]);
+    expect(retrieval.attributed.orientation.active_ms).toBeGreaterThan(0);
+    // The one MCP result is this run's whole context-window footprint, so it
+    // is also the whole orientation window: full attribution, nothing left.
+    expect(retrieval.attributed.orientation.context_window_tokens).toBe(
+      phases.orientation.context_window_tokens,
+    );
+    expect(retrieval.attributed.orientation.context_window_tokens).toBeGreaterThan(0);
+    expect(retrieval.remainder.orientation.context_window_tokens).toBe(0);
+    db.close();
+  });
+
   test("persists versioned vectors and serves economics without scanning transcript rows", () => {
     const db = freshDb();
     const sessionId = upsertSession(
@@ -310,8 +749,19 @@ describe("token economics", () => {
       2,
       "claude",
     );
+    upsertSession(
+      db,
+      parseClaudeSession("sess-mcp-claude", fixture("claude", "mcp.jsonl")),
+      "/x/mcp.jsonl",
+      1,
+      2,
+      "claude",
+    );
     const expected = tokenEconomicsForSession(db, sessionId);
     const expectedAggregate = tokenEconomics(db);
+    const expectedRetrieval = tokenEconomics(db, null, { excludeMcpServers: ["github"] }).totals
+      .retrieval;
+    expect(expectedRetrieval?.attributed.orientation.estimated_cost_usd).toBeGreaterThan(0);
     const stored = db
       .query(
         "SELECT format_version, json_valid(vector_json) AS valid FROM session_economics WHERE session_id = ?1",
@@ -327,6 +777,11 @@ describe("token economics", () => {
     `);
     expect(tokenEconomicsForSession(db, sessionId)).toEqual(expected);
     expect(tokenEconomics(db)).toEqual(expectedAggregate);
+    // The per-server slice is genuinely persisted, not re-derived from the
+    // tool_call rows this test just deleted.
+    expect(tokenEconomics(db, null, { excludeMcpServers: ["github"] }).totals.retrieval).toEqual(
+      expectedRetrieval as NonNullable<typeof expectedRetrieval>,
+    );
     db.close();
   });
 
@@ -390,6 +845,12 @@ describe("token economics", () => {
 
     db.query(
       "UPDATE session_economics SET vector_json = json_remove(vector_json, '$.billed_input_tokens') WHERE session_id = ?1",
+    ).run(sessionId);
+    expect(materializeMissingSessionEconomics(db)).toBe(1);
+    expect(tokenEconomicsForSession(db, sessionId)).not.toBeNull();
+
+    db.query(
+      "UPDATE session_economics SET vector_json = json_remove(vector_json, '$.retrieval') WHERE session_id = ?1",
     ).run(sessionId);
     expect(materializeMissingSessionEconomics(db)).toBe(1);
     expect(tokenEconomicsForSession(db, sessionId)).not.toBeNull();

--- a/test/token-economics.test.ts
+++ b/test/token-economics.test.ts
@@ -489,8 +489,16 @@ describe("token economics", () => {
     expect(retrieval.attributed.orientation).toEqual(
       retrieval.by_server.dosu?.orientation as PhaseAmounts,
     );
-    // The unqualified Codex namespace is a different tool, not another
-    // registration of dosu, so it is not swept in by the slug.
+    // The unqualified Codex namespace (`dosu__unqualified_tool`, no `mcp__`
+    // prefix) is a builtin, not another registration of dosu. Pinning exact
+    // volume is what makes that load-bearing: a naive `split("__")[0]` parser
+    // yields the key "dosu" too, so an absent-key assertion cannot fail under
+    // either implementation, and the window cannot discriminate because that
+    // call has no output bytes. Its 1000ms of latency is the only witness.
+    //   window: (16 + 57) result bytes / 4 chars-per-token = 18
+    //   active: the two mcp__dosu__read_knowledge calls only, not 6000
+    expect(retrieval.by_server.dosu?.orientation.context_window_tokens).toBe(18);
+    expect(retrieval.by_server.dosu?.orientation.active_ms).toBe(5000);
     expect(Object.keys(retrieval.by_server)).not.toContain("dosu__unqualified_tool");
     expect(retrieval.by_server.exa?.orientation.context_window_tokens).toBeGreaterThan(0);
     db.close();
@@ -710,6 +718,25 @@ describe("token economics", () => {
           content: [{ type: "output_text", text: "Context checked." }],
         },
       }),
+      // Without this the session has no output tokens, and the Codex
+      // generation path below never runs -- the test would pin window and
+      // latency only, and silently pass with generation attribution removed.
+      JSON.stringify({
+        type: "event_msg",
+        timestamp: "2026-05-08T09:00:09.000Z",
+        payload: {
+          type: "token_count",
+          info: {
+            total_token_usage: {
+              input_tokens: 900,
+              cached_input_tokens: 300,
+              output_tokens: 400,
+              reasoning_output_tokens: 40,
+              total_tokens: 1340,
+            },
+          },
+        },
+      }),
     ].join("\n");
     upsertSession(
       db,
@@ -729,13 +756,26 @@ describe("token economics", () => {
     // parser that reads Claude names attributes it.
     expect(Object.keys(retrieval.by_server)).toEqual(["dosu"]);
     expect(retrieval.attributed.orientation.active_ms).toBeGreaterThan(0);
-    // The one MCP result is this run's whole context-window footprint, so it
-    // is also the whole orientation window: full attribution, nothing left.
-    expect(retrieval.attributed.orientation.context_window_tokens).toBe(
-      phases.orientation.context_window_tokens,
-    );
     expect(retrieval.attributed.orientation.context_window_tokens).toBeGreaterThan(0);
-    expect(retrieval.remainder.orientation.context_window_tokens).toBe(0);
+    // Codex takes a different generation path from Claude: allocateGeneration
+    // short-circuits on session.tool === "codex" and routes the aggregate lump
+    // through distribute(), so distributeVisible() -- the path the Claude tests
+    // cover -- never runs here. Without this assertion, dropping server
+    // attribution from distribute() leaves the whole suite green while Codex
+    // MCP generation silently reports zero.
+    expect(retrieval.attributed.orientation.generation_tokens).toBeGreaterThan(0);
+    // The assistant's own text is not retrieval, so both sides stay non-zero.
+    expect(retrieval.remainder.orientation.generation_tokens).toBeGreaterThan(0);
+    for (const phase of ["orientation", "implementation"] as const) {
+      expect(
+        retrieval.attributed[phase].generation_tokens +
+          retrieval.remainder[phase].generation_tokens,
+      ).toBe(phases[phase].generation_tokens);
+      expect(
+        retrieval.attributed[phase].context_window_tokens +
+          retrieval.remainder[phase].context_window_tokens,
+      ).toBe(phases[phase].context_window_tokens);
+    }
     db.close();
   });
 


### PR DESCRIPTION
## What

Orientation is all spend before the first file edit. An MCP retrieval server runs at session start — so its tokens land inside that number, and the metric counts a retrieval tool's own cost as part of the waste that tool is supposed to remove.

There is no favourable direction of bias here: if orientation falls, retrieval merely displaced reads; if it rises, the instrument says the tool made things worse. And the source is Apache-2.0, so anyone can find it.

This makes the retrieval slice reportable separately, so a study can state all three quantities honestly.

## Stacked on `teedole/orientation-split`

Targets that branch, not `main` — it consumes `PhaseAmounts.cost_share`. GitHub will retarget automatically once the parent merges. The diff here is the retrieval work only.

## How

```
totals.retrieval = { excluded_servers, by_server, attributed, remainder }
```

- **`by_server` ships unconditionally** and is exclusion-set-independent, so any reader can re-derive the split for any allowlist — including one Decant's authors did not choose. That property, not the choice of default, is what makes the source auditable rather than embarrassing.
- **The default exclusion set is empty.** `totals.phases` stays byte-identical to today and includes retrieval cost. A vendor-authored tool that excluded its own vendor by default would reproduce the original defect in the flattering direction.
- **`remainder`, not `excluding` or `net`.** Negative-space names go stale when the excluded set changes; "net" is ambiguous.
- **`totals.phases` is never narrowed.** Siblings only.

`src/buckets.ts:61`'s `mcp__` clause is dead code (line 64 returns `"context"` anyway) and is deliberately **left in place with a comment** — removing it would look like the fix and invite a reviewer to conclude the problem was solved there.

## Verification

971 tests pass; `tsc` and `biome` clean.

Byte-identity was proven by extraction, not assertion: both commits were checked out into separate trees, the same archive built under each, and the output compared — exact **36,575-byte match** with `retrieval` removed, covering archive-wide and per-session paths. A sweep of **all 63 non-empty exclusion subsets × 9 scopes** found `phases`, `buckets` and `by_server` byte-identical across every one, with `attributed + remainder == phases` holding across **1,134 phase checks**.

The cache upgrade path was verified end to end: an archive built with parent code (`format_version = 2`) read under this branch returns correct numbers **immediately** via live recompute, before any backfill.

Four mutations initially left the suite fully green and are now closed: both server routes ignoring `exclude_mcp_server`; Codex generation attribution (deleting it understated Codex MCP cost by **131×**); `classifyTool` replaced with a naive parser; and a negative-case assertion that could not fail under either implementation.

## Notes for merge

- **Bumps `SESSION_ECONOMICS_FORMAT_VERSION` 2 → 3.** The first sync after upgrade rebuilds every economics vector once. `INGEST_PIPELINE_REVISION` is deliberately untouched — no parser or normalized row changes, and bumping it would force a full re-parse for zero benefit. No schema migration; `LATEST_SCHEMA_VERSION` stays 23.
- **On a read-only archive**, `refreshDerivedMetadata` skips the backfill, so the analytics endpoint returns zeros until the archive is writable. Every prior format bump had this property; this change fires it again.
- **No UI or generated-report surface** for the slice yet — CLI and HTTP API deliver all three numbers plus `by_server`, and the UI still renders the all-in figure, which is itself one of the three. Until a follow-up lands, the auditability payoff is CLI/API-only.

## Known, deferred

- The `remainder` clamps are unreachable on any known input (the brief asked for the clamp, not a clamp test).
- **Printed cost, time and percent are each rounded per row**, so a printed pair can differ from the parent by one unit in its last displayed place — a second, $0.0001, or 0.1%. The underlying payload is exact and the docs direct readers to `--json` for exact figures. Only the two token columns reconcile digit for digit in the printed table, and that is pinned.
- **The rendered duration cell is not pinned per-cell.** A slip confined to `formatDuration` would pass the suite, because only whole-object slips move the token columns. The value itself is pinned twice at exact equality (`test/token-economics.test.ts:408` at the library level, `test/cli.test.ts:216` through the CLI payload) — it is only the rendered cell that is uncovered, and time is not one of the three numbers a study publishes. Deliberately not fixed here: covering it means exporting a module-private formatter as a source change on an otherwise test-only branch. **If `src/cli.ts` is opened again for any other reason, exporting `formatDuration` plus two symmetric assertions closes the file's last per-cell hole in about three lines.**
