### PR TITLE
fix(ui): recover dashboard after transient outages

### DIFF
--- a/src/ui/api.ts
+++ b/src/ui/api.ts
@@ -31,7 +31,22 @@ export async function getJson<T>(
     headers.set("content-type", "application/json");
   }
   for (let attempt = 0; ; attempt += 1) {
-    const response = await fetcher(path, { ...init, headers });
+    const retryDelay = retryPolicy.delaysMs[attempt];
+    let response: Response;
+    try {
+      response = await fetcher(path, { ...init, headers });
+    } catch (error) {
+      if (
+        error instanceof TypeError &&
+        isSafeMethod(init?.method) &&
+        retryDelay != null &&
+        init?.signal?.aborted !== true
+      ) {
+        await retryPolicy.wait(retryDelay, init?.signal);
+        continue;
+      }
+      throw error;
+    }
     if (response.ok) {
       if (response.status === 204) {
         return undefined as T;
@@ -51,18 +66,17 @@ export async function getJson<T>(
     const code =
       typeof payload.code === "string" && payload.code !== "" ? payload.code : "request_failed";
     const { error: _error, code: _code, ...extras } = payload;
-    const retryDelay = retryPolicy.delaysMs[attempt];
-    if (
-      code === "archive_locked" &&
-      payload.retryable === true &&
-      retryDelay != null &&
-      init?.signal?.aborted !== true
-    ) {
+    if (payload.retryable === true && retryDelay != null && init?.signal?.aborted !== true) {
       await retryPolicy.wait(retryDelay, init?.signal);
       continue;
     }
     throw new ApiError(response.status, code, message, extras);
   }
+}
+
+function isSafeMethod(method: string | undefined): boolean {
+  const normalized = method?.toUpperCase() ?? "GET";
+  return normalized === "GET" || normalized === "HEAD";
 }
 
 const DEFAULT_RETRY_POLICY: ApiRetryPolicy = {

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -826,6 +826,7 @@ function App() {
   const syncCompleteTimerRef = useRef<number | null>(null);
   const liveDisconnectTimerRef = useRef<number | null>(null);
   const liveDroppedRef = useRef(false);
+  const failedSlicesRef = useRef<DataSlice[]>([]);
   const dateQuery = dateRangeQuery(dateRangeSelection);
   const sessionProject = sessionProjectFilter(path);
   const includeArchivedSessions = sessionIncludesArchived(path);
@@ -900,7 +901,9 @@ function App() {
     const sliceKey = (slice: DataSlice): string =>
       SLICE_LOADERS[slice].dateScoped ? `${dateQuery}|${reloadKey}` : `${reloadKey}`;
     const needed = slicesForView(activeView);
-    setFailedSlices((current) => current.filter((slice) => needed.includes(slice)));
+    const relevantFailures = failedSlicesRef.current.filter((slice) => needed.includes(slice));
+    failedSlicesRef.current = relevantFailures;
+    setFailedSlices(relevantFailures);
     const missing = needed.filter(
       (slice) => loadedSlicesRef.current.get(slice) !== sliceKey(slice),
     );
@@ -918,7 +921,9 @@ function App() {
         for (const slice of settled.loaded) {
           loadedSlicesRef.current.set(slice, sliceKey(slice));
         }
-        setFailedSlices(settled.failures.map((failure) => failure.slice));
+        const failures = settled.failures.map((failure) => failure.slice);
+        failedSlicesRef.current = failures;
+        setFailedSlices(failures);
       })
       .finally(() => {
         if (!cancelled && missing.includes("recommendations")) {
@@ -938,7 +943,11 @@ function App() {
     const markConnected = () => {
       if (liveDroppedRef.current) {
         liveDroppedRef.current = false;
-        setArchiveUpdateAvailable(true);
+        if (failedSlicesRef.current.length > 0) {
+          requestRefresh();
+        } else {
+          setArchiveUpdateAvailable(true);
+        }
       }
       if (liveDisconnectTimerRef.current != null) {
         window.clearTimeout(liveDisconnectTimerRef.current);
@@ -1014,6 +1023,7 @@ function App() {
         liveDisconnectTimerRef.current = null;
         if (events.readyState !== EventSource.OPEN) {
           setLiveDisconnected(true);
+          setLiveConnectionKey((key) => key + 1);
         }
       }, LIVE_DISCONNECT_GRACE_MS);
     };

--- a/test/ui-api.test.ts
+++ b/test/ui-api.test.ts
@@ -62,4 +62,79 @@ describe("getJson", () => {
     ).resolves.toEqual({ ok: true });
     expect(attempts).toBe(3);
   });
+
+  test("retries any response the server marks as transient", async () => {
+    let attempts = 0;
+    const fetcher = () => {
+      attempts += 1;
+      return Promise.resolve(
+        attempts === 1
+          ? Response.json(
+              { error: "still starting", code: "service_starting", retryable: true },
+              { status: 503 },
+            )
+          : Response.json({ ok: true }),
+      );
+    };
+
+    await expect(
+      getJson("/api/test", undefined, fetcher, {
+        delaysMs: [0],
+        wait: () => Promise.resolve(),
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(attempts).toBe(2);
+  });
+
+  test("retries transport failures for safe reads", async () => {
+    let attempts = 0;
+    const fetcher = () => {
+      attempts += 1;
+      return attempts === 1
+        ? Promise.reject(new TypeError("connection refused"))
+        : Promise.resolve(Response.json({ ok: true }));
+    };
+
+    await expect(
+      getJson("/api/test", undefined, fetcher, {
+        delaysMs: [0],
+        wait: () => Promise.resolve(),
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(attempts).toBe(2);
+  });
+
+  test("does not replay a write after a transport failure", async () => {
+    let attempts = 0;
+    const failure = new TypeError("connection reset after send");
+    const fetcher = () => {
+      attempts += 1;
+      return Promise.reject(failure);
+    };
+
+    await expect(
+      getJson("/api/sync", { method: "POST", body: "{}" }, fetcher, {
+        delaysMs: [0],
+        wait: () => Promise.resolve(),
+      }),
+    ).rejects.toBe(failure);
+    expect(attempts).toBe(1);
+  });
+
+  test("does not hide unexpected fetcher failures behind retries", async () => {
+    let attempts = 0;
+    const failure = new Error("fetch wrapper bug");
+    const fetcher = () => {
+      attempts += 1;
+      return Promise.reject(failure);
+    };
+
+    await expect(
+      getJson("/api/test", undefined, fetcher, {
+        delaysMs: [0],
+        wait: () => Promise.resolve(),
+      }),
+    ).rejects.toBe(failure);
+    expect(attempts).toBe(1);
+  });
 });

--- a/test/ui-recovery-report.test.ts
+++ b/test/ui-recovery-report.test.ts
@@ -56,18 +56,23 @@ describe("coded UI recovery", () => {
     expect(main).toContain("activeFailedSlices.join");
     expect(main).toContain("slicesForView(activeView).includes(slice)");
     expect(main).toContain(
-      "setFailedSlices((current) => current.filter((slice) => needed.includes(slice)))",
+      "const relevantFailures = failedSlicesRef.current.filter((slice) => needed.includes(slice))",
     );
     expect(main).toContain("failed: { error: unknown; requestKey: string } | null");
     expect(main).toContain('active === "Sessions" && sessionPageState.error != null');
   });
 
-  test("queues an explicit refresh after a dropped live connection recovers", () => {
+  test("refreshes failed slices on reconnect without replacing healthy data", () => {
     expect(main).toContain("const liveDroppedRef = useRef(false)");
+    expect(main).toContain("const failedSlicesRef = useRef<DataSlice[]>([])");
+    expect(main).toContain("failedSlicesRef.current = failures");
     expect(main).toMatch(
-      /if \(liveDroppedRef\.current\) \{\s*liveDroppedRef\.current = false;\s*setArchiveUpdateAvailable\(true\);/,
+      /if \(liveDroppedRef\.current\) \{\s*liveDroppedRef\.current = false;\s*if \(failedSlicesRef\.current\.length > 0\) \{\s*requestRefresh\(\);\s*\} else \{\s*setArchiveUpdateAvailable\(true\);/,
     );
     expect(main).toContain("liveDroppedRef.current = true");
+    expect(main).toMatch(
+      /if \(events\.readyState !== EventSource\.OPEN\) \{\s*setLiveDisconnected\(true\);\s*setLiveConnectionKey\(\(key\) => key \+ 1\);/,
+    );
   });
 
   test("preserves the archive update reason in server events", () => {


### PR DESCRIPTION
## Summary

- retry server-declared transient responses and safe read transport failures
- recreate terminal live-update connections and reload failed dashboard slices after recovery
- preserve healthy loaded data and avoid replaying writes after ambiguous network failures

## Root cause

Dashboard slice requests could fail while `decant serve` was starting or briefly unavailable. The live-update connection was expected to trigger a refresh when it recovered, but two gaps left the page stuck:

- the client only retried the `archive_locked` response instead of all server-declared retryable responses
- Chromium treats an initial EventSource HTTP 503 as terminal, so its built-in reconnect never ran

## Review fixes

- added an app-level EventSource replacement after the existing disconnect grace period
- reload failed slices on reconnection while retaining the non-disruptive update prompt for healthy pages
- restrict ambiguous transport retries to GET and HEAD requests
- surface unexpected non-TypeError fetcher failures immediately

## Validation

- `just check` (957 tests, TypeScript, Biome, native darwin-arm64 distribution smoke)
- real Chrome fault test with a synthetic archive and loopback proxy: reproduced the ten-slice 503 failure, restored the server, and verified both warnings clear without user action
