### PR TITLE
feat: refresh model pricing

### DIFF
--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -1,7 +1,7 @@
 # Pricing estimates
 
 Decant estimates token costs at ingest using published first-party API rates.
-The seed table was last verified on July 25, 2026 against:
+The seed table was last verified on September 2, 2026 against:
 
 - [Anthropic model and prompt-cache pricing](https://platform.claude.com/docs/en/about-claude/pricing)
 - [OpenAI API pricing](https://developers.openai.com/api/docs/pricing)
@@ -18,16 +18,18 @@ provider does not publish a first-party API token price for that model slug.
 
 | Provider models | Input | Cached input | Cache write | Output |
 | --- | ---: | ---: | ---: | ---: |
+| Claude Fable 5.1, Mythos 5.1 | $10.00 | $0.25 | $12.50 / $20.00 | $50.00 |
 | Claude Fable 5, Mythos 5 | $10.00 | $1.00 | $12.50 / $20.00 | $50.00 |
 | Claude Opus 5, 4.8, 4.7, 4.6, 4.5 | $5.00 | $0.50 | $6.25 / $10.00 | $25.00 |
 | Claude Opus 4.1, 4 | $15.00 | $1.50 | $18.75 / $30.00 | $75.00 |
-| Claude Sonnet 5 through August 31, 2026 | $2.00 | $0.20 | $2.50 / $4.00 | $10.00 |
+| Claude Sonnet 5 | $2.00 | $0.20 | $2.50 / $4.00 | $10.00 |
 | Claude Sonnet 4.6, 4.5, 4 | $3.00 | $0.30 | $3.75 / $6.00 | $15.00 |
 | Claude Haiku 4.5 | $1.00 | $0.10 | $1.25 / $2.00 | $5.00 |
 | Claude Haiku 3.5 | $0.80 | $0.08 | $1.00 / $1.60 | $4.00 |
-| GPT-5.6 Sol | $5.00 | $0.50 | $6.25 | $30.00 |
-| GPT-5.6 Terra | $2.50 | $0.25 | $3.125 | $15.00 |
-| GPT-5.6 Luna | $1.00 | $0.10 | $1.25 | $6.00 |
+| GPT-5.6 Sol, GPT-5.6, Daybreak Blue | $4.00 | $0.40 | $5.00 | $20.00 |
+| GPT-5.6 Terra | $2.00 | $0.20 | $2.50 | $12.00 |
+| GPT-5.6 Luna | $0.20 | $0.02 | $0.25 | $1.20 |
+| GPT-5.6 Cyber, Daybreak Red | $12.50 | $1.25 | $15.625 | $75.00 |
 | GPT-5.5 | $5.00 | $0.50 | no additional fee | $30.00 |
 | GPT-5.4 | $2.50 | $0.25 | no additional fee | $15.00 |
 | GPT-5.4 mini | $0.75 | $0.075 | no additional fee | $4.50 |
@@ -40,6 +42,12 @@ provider does not publish a first-party API token price for that model slug.
 Claude's two cache-write figures are the 5-minute and 1-hour rates. OpenAI
 cache writes before GPT-5.6 have no additional fee; GPT-5.6 reports and bills
 cache writes at 1.25 times the uncached-input rate.
+
+Anthropic made Claude Sonnet 5's $2.00 input and $10.00 output rates standard
+on September 1, 2026, so the previously announced increase did not take
+effect. Claude Fable 5.1 and Mythos 5.1 keep Fable 5's input, cache-write, and
+output rates but reduce cache reads from $1.00 to $0.25. OpenAI describes the
+current GPT-5.6 Sol rate as promotional through at least November 21, 2026.
 
 `codex-auto-review` is a hidden routing slug, not a public billable model ID.
 OpenAI does not document which underlying model or rate applies. Decant leaves
@@ -59,8 +67,9 @@ apply Batch, Flex, Priority, fast-mode, regional-processing, data-residency, or
 partner-cloud modifiers.
 
 OpenAI applies long-context rates above 272,000 prompt tokens for eligible API
-models. The Codex model catalog currently caps coding-agent context at 272,000
-tokens, so Decant's Codex sources do not cross that threshold. Claude 4.6 and
+models. Decant estimates costs from session-level token totals, which do not
+show whether an individual request crossed that threshold, so these estimates
+use short-context rates and may be low for qualifying requests. Claude 4.6 and
 later include their full context window at the standard rate.
 
 Costs are stored on the session row when the transcript is ingested. Updating

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -9,11 +9,15 @@ export interface Price {
   cacheWrite1hPerMtok: number;
 }
 
-function claudePrice(inputPerMtok: number, outputPerMtok: number): Price {
+function claudePrice(
+  inputPerMtok: number,
+  outputPerMtok: number,
+  cacheReadMultiplier = 0.1,
+): Price {
   return {
     inputPerMtok,
     outputPerMtok,
-    cacheReadPerMtok: inputPerMtok * 0.1,
+    cacheReadPerMtok: inputPerMtok * cacheReadMultiplier,
     cacheWritePerMtok: inputPerMtok * 1.25,
     cacheWrite1hPerMtok: inputPerMtok * 2.0,
   };
@@ -40,6 +44,7 @@ export function defaultPricing(): Map<string, Price> {
   // comes from usage.cache_creation.ephemeral_{5m,1h}_input_tokens. Rates and
   // exclusions were checked against the official sources in docs/pricing.md.
   return new Map<string, Price>([
+    ["claude-fable-5-1", claudePrice(10.0, 50.0, 0.025)],
     ["claude-fable", claudePrice(10.0, 50.0)],
     ["claude-opus", claudePrice(5.0, 25.0)],
     ["claude-opus-4.1", claudePrice(15.0, 75.0)],
@@ -48,9 +53,10 @@ export function defaultPricing(): Map<string, Price> {
     ["claude-sonnet", claudePrice(3.0, 15.0)],
     ["claude-haiku", claudePrice(1.0, 5.0)],
     ["claude-haiku-3.5", claudePrice(0.8, 4.0)],
-    ["gpt-5.6-sol", openAiPrice(5.0, 0.5, 30.0, 1.25)],
-    ["gpt-5.6-terra", openAiPrice(2.5, 0.25, 15.0, 1.25)],
-    ["gpt-5.6-luna", openAiPrice(1.0, 0.1, 6.0, 1.25)],
+    ["gpt-5.6-sol", openAiPrice(4.0, 0.4, 20.0, 1.25)],
+    ["gpt-5.6-terra", openAiPrice(2.0, 0.2, 12.0, 1.25)],
+    ["gpt-5.6-luna", openAiPrice(0.2, 0.02, 1.2, 1.25)],
+    ["gpt-5.6-cyber", openAiPrice(12.5, 1.25, 75.0, 1.25)],
     ["gpt-5.5", openAiPrice(5.0, 0.5, 30.0)],
     ["gpt-5.5-pro", openAiPrice(30.0, null, 180.0)],
     ["gpt-5.4", openAiPrice(2.5, 0.25, 15.0)],
@@ -114,6 +120,9 @@ function canonicalModel(raw: string): string | null {
     model === "fable"
   ) {
     if (model.includes("fable") || model.includes("mythos")) {
+      if (/(?:fable|mythos)-5(?:-|\.)1(?:$|-|\[)/.test(model)) {
+        return "claude-fable-5-1";
+      }
       return "claude-fable";
     }
     if (model.includes("opus")) {
@@ -164,7 +173,15 @@ function canonicalModel(raw: string): string | null {
     return null;
   }
 
+  if (model === "gpt-5.6" || model === "gpt-daybreak-blue-latest") {
+    return "gpt-5.6-sol";
+  }
+  if (model === "gpt-daybreak-red-latest") {
+    return "gpt-5.6-cyber";
+  }
+
   for (const key of [
+    "gpt-5.6-cyber",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
     "gpt-5.6-luna",

--- a/test/cost.test.ts
+++ b/test/cost.test.ts
@@ -113,9 +113,14 @@ describe("estimateCost", () => {
   test("gpt family is priced", () => {
     const pricing = defaultPricing();
     const u = usage1m();
-    expect(estimateCost("gpt-5.6-sol", u, pricing)).toBeCloseTo(35.0, 6);
-    expect(estimateCost("gpt-5.6-terra", u, pricing)).toBeCloseTo(17.5, 6);
-    expect(estimateCost("gpt-5.6-luna", u, pricing)).toBeCloseTo(7.0, 6);
+    expect(estimateCost("gpt-5.6-sol", u, pricing)).toBeCloseTo(24.0, 6);
+    expect(estimateCost("gpt-5.6", u, pricing)).toBeCloseTo(24.0, 6);
+    expect(estimateCost("openai/gpt-5.6", u, pricing)).toBeCloseTo(24.0, 6);
+    expect(estimateCost("gpt-daybreak-blue-latest", u, pricing)).toBeCloseTo(24.0, 6);
+    expect(estimateCost("gpt-5.6-terra", u, pricing)).toBeCloseTo(14.0, 6);
+    expect(estimateCost("gpt-5.6-luna", u, pricing)).toBeCloseTo(1.4, 6);
+    expect(estimateCost("gpt-5.6-cyber", u, pricing)).toBeCloseTo(87.5, 6);
+    expect(estimateCost("gpt-daybreak-red-latest", u, pricing)).toBeCloseTo(87.5, 6);
     expect(estimateCost("gpt-5", u, pricing)).toBeCloseTo(11.25, 6);
     expect(estimateCost("gpt-5.1", u, pricing)).toBeCloseTo(11.25, 6);
     expect(estimateCost("gpt-5-mini", u, pricing)).toBeCloseTo(2.25, 6);
@@ -129,9 +134,36 @@ describe("estimateCost", () => {
     expect(estimateCost("gpt-5.5-pro", u, pricing)).toBeCloseTo(210.0, 6);
   });
 
-  test("gpt-5.6 cache writes use the published 1.25x input rate", () => {
-    const usage = { ...emptyUsage(), cacheCreation: 1_000_000 };
-    expect(estimateCost("gpt-5.6-sol", usage, defaultPricing())).toBeCloseTo(6.25, 6);
+  test("gpt-5.6 uses the published input, cache, and output rates", () => {
+    const pricing = defaultPricing();
+    expect(pricing.get("gpt-5.6-sol")).toEqual({
+      inputPerMtok: 4,
+      outputPerMtok: 20,
+      cacheReadPerMtok: 0.4,
+      cacheWritePerMtok: 5,
+      cacheWrite1hPerMtok: 5,
+    });
+    expect(pricing.get("gpt-5.6-terra")).toEqual({
+      inputPerMtok: 2,
+      outputPerMtok: 12,
+      cacheReadPerMtok: 0.2,
+      cacheWritePerMtok: 2.5,
+      cacheWrite1hPerMtok: 2.5,
+    });
+    expect(pricing.get("gpt-5.6-luna")).toEqual({
+      inputPerMtok: 0.2,
+      outputPerMtok: 1.2,
+      cacheReadPerMtok: 0.02,
+      cacheWritePerMtok: 0.25,
+      cacheWrite1hPerMtok: 0.25,
+    });
+    expect(pricing.get("gpt-5.6-cyber")).toEqual({
+      inputPerMtok: 12.5,
+      outputPerMtok: 75,
+      cacheReadPerMtok: 1.25,
+      cacheWritePerMtok: 15.625,
+      cacheWrite1hPerMtok: 15.625,
+    });
   });
 
   test("published openai legacy and reasoning models are priced", () => {
@@ -207,6 +239,30 @@ describe("estimateCost", () => {
       expect(estimateCost(m, u, pricing)).toBeCloseTo(fable, 6);
     }
     expect(estimateCost("claude-mythos-5", u, pricing)).toBeCloseTo(fable, 6);
+  });
+
+  test("fable 5.1 and mythos 5.1 use their reduced cache-read rate", () => {
+    const pricing = defaultPricing();
+    expect(pricing.get("claude-fable-5-1")).toEqual({
+      inputPerMtok: 10,
+      outputPerMtok: 50,
+      cacheReadPerMtok: 0.25,
+      cacheWritePerMtok: 12.5,
+      cacheWrite1hPerMtok: 20,
+    });
+    const cacheRead = { ...emptyUsage(), cacheRead: 1_000_000 };
+    for (const model of [
+      "claude-fable-5-1",
+      "claude-fable-5.1",
+      "anthropic.claude-fable-5-1-v1:0",
+      "claude-mythos-5-1",
+      "claude-mythos-5.1",
+    ]) {
+      expect(estimateCost(model, cacheRead, pricing)).toBeCloseTo(0.25, 6);
+    }
+    expect(estimateCost("claude-fable-5", cacheRead, pricing)).toBeCloseTo(1.0, 6);
+    expect(estimateCost("claude-mythos-5", cacheRead, pricing)).toBeCloseTo(1.0, 6);
+    expect(estimateCost("claude-fable-5-10", cacheRead, pricing)).toBeCloseTo(1.0, 6);
   });
 
   test("fable input+output costs add up", () => {

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -1067,7 +1067,7 @@ describe("sync", () => {
           )
           .get() as { cache_write_per_mtok: number; cache_write_1h_per_mtok: number }
       ).cache_write_1h_per_mtok,
-    ).toBe(6.25);
+    ).toBe(5);
 
     // Simulate opening a migrated v9 archive whose transcripts are unchanged.
     db.exec("DELETE FROM session_economics");


### PR DESCRIPTION
## Summary

- add Claude Fable 5.1 and Mythos 5.1 pricing with the reduced cache-read rate
- update GPT-5.6 Sol, Terra, and Luna to current standard API rates
- add GPT-5.6 Cyber plus current Daybreak aliases and the GPT-5.6 Sol alias
- document the permanent Claude Sonnet 5 rate and the aggregate-cost long-context limitation

## Sources

- https://platform.claude.com/docs/en/about-claude/pricing
- https://developers.openai.com/api/docs/pricing

## Verification

- just check
- 958 tests passed
- TypeScript and Biome checks passed
- native darwin-arm64 distribution smoke passed