### PR TITLE
fix(ui): remove per-badge backdrop blur that made dense tables checkerboard

### DIFF
--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2806,8 +2806,6 @@ select {
   border-radius: var(--radius-sm);
   background: var(--bg-components-badge-default);
   color: var(--fg-secondary);
-  backdrop-filter: blur(2px);
-  -webkit-backdrop-filter: blur(2px);
   font: var(--text-primary-xs-medium);
   padding: var(--space-4) var(--space-8);
   white-space: nowrap;
@@ -4709,6 +4707,12 @@ mark {
   to {
     background-position: -100% 0;
   }
+}
+
+/* Fifty rows of shimmering gradients repaint on the main thread every frame,
+   right when a first-load fling needs raster headroom. */
+.session-row-skeleton .skeleton-line {
+  animation: none;
 }
 
 .session-detail-skeleton .thread-header {

--- a/test/ui-loading-state.test.ts
+++ b/test/ui-loading-state.test.ts
@@ -99,6 +99,10 @@ describe("session loading state", () => {
 });
 
 describe("session table skeleton", () => {
+  test("keeps the reserved rows static so a first-load fling has raster headroom", () => {
+    expect(styles).toContain(".session-row-skeleton .skeleton-line {\n  animation: none;\n}");
+  });
+
   test("reserves all fifty row slots before the first page settles", () => {
     expect(main).toContain("{ length: SESSION_PAGE_SIZE }");
     expect(main).toContain("const loading = enabled && cached == null && currentError == null");

--- a/test/ui-restyle-contract.test.ts
+++ b/test/ui-restyle-contract.test.ts
@@ -108,6 +108,27 @@ describe("restyle contract", () => {
     }
   });
 
+  test("backdrop blur stays on transient overlays, never on per-row chrome", () => {
+    // Every backdrop-filter is its own compositor render surface, resampled on each
+    // frame it intersects. Fifty rows of blurred badges made fast flings checkerboard.
+    const badge = /^\s*\.badge\s*\{([^}]*)\}/m.exec(styles)?.[1] ?? "";
+    expect(badge).toContain("background: var(--bg-components-badge-default)");
+    expect(badge).not.toContain("backdrop-filter");
+
+    const overlays = new Set([
+      ".command-palette-backdrop",
+      ".command-palette",
+      ".share-review-backdrop",
+      ".overflow-menu-popover",
+      ".sidebar-backdrop.is-open",
+    ]);
+    const blurred = [...styles.matchAll(/([^{}]+)\{([^{}]*backdrop-filter[^{}]*)\}/g)].map(
+      (match) => match[1]?.trim().split("\n").at(-1)?.trim() ?? "",
+    );
+    expect(blurred.length).toBeGreaterThan(0);
+    expect(blurred.filter((selector) => !overlays.has(selector))).toEqual([]);
+  });
+
   test("the display serif is only asked for a weight that ships", () => {
     const weightTokens = new Map(
       [...styles.matchAll(/--font-weight-(\w+):\s*(\d+);/g)].map((match) => [


### PR DESCRIPTION
## What this fixes

Fast trackpad flings over dense tables (Sessions at 50 rows, Files at 100 rows) showed a rolling paint band and blank tiles, worst right after a cold load.

## Root cause

Every `.badge` has carried `backdrop-filter: blur(2px)` since the Venice restyle in #100. Chromium gives each backdrop-filter element its own compositor render surface and resamples the backdrop on every frame it intersects. Three badges per row put 150 render surfaces inside a roughly 3000px scrolling panel that also clips with a 16px radius. During a sub-second fling raster fell behind and the compositor drew blank tiles.

#106 already removed the same property from the sticky topbar for the same reason. The badge rule was missed.

The badge background is a 12% alpha token sitting on a flat panel color, so the blur never had a visible effect in tables. Badges look the same in light and dark without it.

## What changed

- Dropped both backdrop-filter declarations from `.badge`. Blur stays on the transient overlays only (command palette, overflow menu, share review backdrop, mobile sidebar backdrop).
- Made the sessions skeleton static. It still reserves all fifty rows for layout stability, but 550 shimmering gradients no longer repaint on the main thread during the first-load fling.
- Added a contract test that allowlists backdrop-filter to those overlay selectors, and one that keeps the sessions skeleton static.

No TSX changes. Row count, pagination, containment, and hover behavior are untouched.

## Ruled out along the way

Row virtualization, a 25-row page, removing `contain: layout paint`, separated table borders, hover suppression during scroll, and stripping brand SVGs from rows were all tried in an earlier session and did not fix it. They treated symptoms.

## Testing

- Trackpad verification on macOS Chrome at DPR 2. Steady-state flings and cold-load flings on /sessions are clean with these two changes. An in-page A/B that only disabled the badge blur was already a clear improvement.
- Light and dark theme badge appearance checked on /sessions. /files renders 100 rows with zero backdrop-filter elements.
- `bun test` 1003 pass, `bunx tsc --noEmit` clean, `bunx biome check .` clean.

Diagnostic note for next time. A requestAnimationFrame scroll probe cannot see checkerboarding because the compositor draws blank tiles without delaying the main thread. Scan computed styles for backdrop-filter, filter, will-change, and animation on per-row elements before reaching for virtualization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
