### PR TITLE
fix: add current GPT-6 Astra token pricing

### DIFF
--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -1,11 +1,14 @@
 # Pricing estimates
 
 Decant estimates token costs at ingest using published first-party API rates.
-The seed table was last verified on September 2, 2026 against:
+Anthropic and current OpenAI coding-agent rates were last verified on
+September 9, 2026 against the sources below. Legacy OpenAI rates retain their
+September 2, 2026 verification, and Gemini rates were checked September 5, 2026.
 
 - [Anthropic model and prompt-cache pricing](https://platform.claude.com/docs/en/about-claude/pricing)
 - [OpenAI API pricing](https://developers.openai.com/api/docs/pricing)
 - [OpenAI model pages](https://developers.openai.com/api/docs/models)
+- [OpenAI GPT-6 Astra pricing](https://developers.openai.com/api/docs/models/gpt-6-astra)
 - [OpenAI Codex pricing](https://developers.openai.com/codex/pricing)
 - [OpenAI model deprecations](https://developers.openai.com/api/docs/deprecations)
 - [OpenAI GPT-3.5 Turbo launch pricing](https://openai.com/index/introducing-chatgpt-and-whisper-apis/)
@@ -27,6 +30,7 @@ provider does not publish a first-party API token price for that model slug.
 | Claude Sonnet 4.6, 4.5, 4 | $3.00 | $0.30 | $3.75 / $6.00 | $15.00 |
 | Claude Haiku 4.5 | $1.00 | $0.10 | $1.25 / $2.00 | $5.00 |
 | Claude Haiku 3.5 | $0.80 | $0.08 | $1.00 / $1.60 | $4.00 |
+| GPT-6 Astra | $10.00 | $1.00 | $12.50 | $50.00 |
 | GPT-5.6 Sol, GPT-5.6, Daybreak Blue | $4.00 | $0.40 | $5.00 | $20.00 |
 | GPT-5.6 Terra | $2.00 | $0.20 | $2.50 | $12.00 |
 | GPT-5.6 Luna | $0.20 | $0.02 | $0.25 | $1.20 |
@@ -52,8 +56,8 @@ provider does not publish a first-party API token price for that model slug.
 | Gemini image, TTS, live, transcribe, native-audio, computer-use variants | — | — | — | — |
 
 Claude's two cache-write figures are the 5-minute and 1-hour rates. OpenAI
-cache writes before GPT-5.6 have no additional fee; GPT-5.6 reports and bills
-cache writes at 1.25 times the uncached-input rate. Gemini bills cache storage
+cache writes before GPT-5.6 have no additional fee; GPT-5.6 and GPT-6 Astra
+bill cache writes at 1.25 times the uncached-input rate. Gemini bills cache storage
 by the token-hour, so Decant maps the equivalent write charge to approximately
 the input rate for typical session-length holds.
 

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -66,6 +66,7 @@ export function defaultPricing(): Map<string, Price> {
     ["claude-sonnet", claudePrice(3.0, 15.0)],
     ["claude-haiku", claudePrice(1.0, 5.0)],
     ["claude-haiku-3.5", claudePrice(0.8, 4.0)],
+    ["gpt-6-astra", openAiPrice(10.0, 1.0, 50.0, 1.25)],
     ["gpt-5.6-sol", openAiPrice(4.0, 0.4, 20.0, 1.25)],
     ["gpt-5.6-terra", openAiPrice(2.0, 0.2, 12.0, 1.25)],
     ["gpt-5.6-luna", openAiPrice(0.2, 0.02, 1.2, 1.25)],
@@ -208,6 +209,7 @@ function canonicalModel(raw: string): string | null {
   }
 
   for (const key of [
+    "gpt-6-astra",
     "gpt-5.6-cyber",
     "gpt-5.6-sol",
     "gpt-5.6-terra",

--- a/test/cost.test.ts
+++ b/test/cost.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { defaultPricing, estimateCost, isPriceable, type Price } from "../src/cost.ts";
+import {
+  defaultPricing,
+  estimateCost,
+  estimateCostParts,
+  isPriceable,
+  type Price,
+} from "../src/cost.ts";
 import { emptyUsage, type TokenUsage } from "../src/model.ts";
 
 // Ports cost.rs tests verbatim — these are the spec for model normalization
@@ -132,6 +138,28 @@ describe("estimateCost", () => {
     expect(estimateCost("gpt-5.4-pro", u, pricing)).toBeCloseTo(210.0, 6);
     expect(estimateCost("gpt-5.5", u, pricing)).toBeCloseTo(35.0, 6);
     expect(estimateCost("gpt-5.5-pro", u, pricing)).toBeCloseTo(210.0, 6);
+  });
+
+  test("Astra prices input, output, cache reads, and cache writes separately", () => {
+    const pricing = defaultPricing();
+    const usage = {
+      ...usage1m(),
+      cacheRead: 2_000_000,
+      cacheCreation: 3_000_000,
+      cacheCreation1h: 1_000_000,
+    };
+    for (const model of ["gpt-6-astra", "openai/gpt-6-astra", "OpenAI:GPT-6-ASTRA"]) {
+      expect(isPriceable(model)).toBe(true);
+      expect(estimateCostParts(model, usage, pricing)).toEqual({
+        input: 10,
+        output: 50,
+        cacheRead: 2,
+        cacheCreation: 37.5,
+      });
+      expect(estimateCost(model, usage, pricing)).toBeCloseTo(99.5, 6);
+    }
+    expect(isPriceable("gpt-6")).toBe(false);
+    expect(isPriceable("gpt-6-unpublished")).toBe(false);
   });
 
   test("gpt-5.6 uses the published input, cache, and output rates", () => {

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -1465,6 +1465,36 @@ describe("sync", () => {
     db.close();
   });
 
+  test("ingests Astra costs and seeds its published cache-write rate", () => {
+    const dir = freshCase();
+    const config: IngestConfig = {
+      claudeDir: join(dir, "claude"),
+      codexDir: join(dir, "codex"),
+    };
+    write(
+      join(config.codexDir, "sessions", "rollout-astra.jsonl"),
+      fixture("codex", "sample.jsonl").replace('"gpt-5.4"', '"gpt-6-astra"'),
+    );
+    const db = openFreshDb(dir);
+    expect(sync(db, config)).toMatchObject({ ingested: 1, failed: 0 });
+    const session = db.query("SELECT model, estimated_cost_usd FROM session").get() as {
+      model: string;
+      estimated_cost_usd: number;
+    };
+    expect(session.model).toBe("gpt-6-astra");
+    // 500 uncached input, 400 cached input, and 150 output tokens.
+    expect(session.estimated_cost_usd).toBeCloseTo(0.0129, 8);
+    expect(
+      db
+        .query(
+          "SELECT cache_write_per_mtok, cache_write_1h_per_mtok FROM model_pricing WHERE model = 'gpt-6-astra'",
+        )
+        .get(),
+    ).toEqual({ cache_write_per_mtok: 12.5, cache_write_1h_per_mtok: 12.5 });
+    expect(sync(db, config)).toMatchObject({ ingested: 0, skipped: 1 });
+    db.close();
+  });
+
   test("backfills effort for an unchanged source once after the schema upgrade", () => {
     const dir = freshCase();
     const config: IngestConfig = {


### PR DESCRIPTION
GPT-6 Astra sessions previously received a zero-dollar estimate because Decant did not recognize the model. Add its published standard API rates per million tokens: $10 input, $1 cached input, $12.50 cache writes, and $50 output, including OpenAI-prefixed model IDs.

Rechecked Anthropic's current model table and OpenAI's GPT-5.6 rates on September 9, 2026. Those existing rates remain current. The pricing guide records the verification date, links Astra's official model page, and explains its cache-write charge. Existing stored session costs still require an archive rebuild to recalculate.

Validation covers cost components, model normalization, unrecognized GPT-6 IDs, and synthetic Codex ingest with persisted costs and pricing seeds. The full `just check` gate includes tests, type checking, lint, and native distribution smoke.

Sources

- https://developers.openai.com/api/docs/models/gpt-6-astra
- https://developers.openai.com/api/docs/pricing
- https://platform.claude.com/docs/en/about-claude/pricing
