### PR TITLE
fix: refresh stored costs with current model pricing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,9 +73,9 @@ A change is ready when:
 3. **Runtime stays local-first.** Do not add outbound network calls, hosted
    service dependencies, or LLM calls. The only runtime networking is the local
    UI and API served by `decant serve`, bound to loopback by default.
-4. **Costs are computed at ingest.** `estimateCost` in `src/cost.ts` is applied
-   when a session is written. Pricing changes do not rewrite historical rows,
-   so users must rebuild the archive to recompute them.
+4. **Costs reflect current pricing.** `estimateCost` in `src/cost.ts` is applied
+   when a session is written. Every sync reconciles stored session and activity
+   costs with current rates, preserving transcripts and user state.
 5. **Schema constants are the source of truth.** Use `LATEST_SCHEMA_VERSION` in
    `src/db.ts` rather than copying the current number into documentation.
    Unsupported older archives are rebuild-only. A migration is frozen once

--- a/docs/analytics-methodology.md
+++ b/docs/analytics-methodology.md
@@ -67,11 +67,12 @@ content, so input is stored net of cache reads, and thought tokens are
 reported outside the candidate count, so they are folded into output and also
 recorded as reported reasoning.
 
-Costs use the pricing table that existed when the session was ingested. They
-are estimates of standard API token rates, not a reconstruction of a ChatGPT
-subscription, Codex credits, discounts, or provider invoices. Updating
-[pricing](pricing.md) does not rewrite historical rows; rebuild the archive to
-re-estimate them.
+Costs use the current [pricing table](pricing.md). Every sync reconciles
+stored session and activity costs, so historical estimates can change when
+rates or pricing logic change. These are estimates of standard API token rates,
+not a reconstruction of a ChatGPT subscription, Codex credits, discounts, or
+provider invoices. Usage from unsupported models is retained, but aggregate
+dollar totals exclude their unknown costs.
 
 ## Activity buckets
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1548,6 +1548,10 @@ components:
       type: object
       required: [scanned, ingested, skipped, issues, issuesByCode, failed, cancelled]
       properties:
+        repriced:
+          type: integer
+          minimum: 1
+          description: Sessions whose stored cost or activity cost components were refreshed. Omitted when unchanged.
         scanned:
           type: integer
           minimum: 0

--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -81,6 +81,10 @@ the structured stderr log retains the diagnostic.
 `DECANT_NO_SYNC` and `--no-sync` suppress Decant-initiated startup, watch, and
 sweep syncs. They do not disable `POST /api/sync`.
 
+Sync responses include `repriced` when stored session or activity costs changed.
+A repricing-only sync also invalidates server economics caches and emits
+`archive_updated`, even when `ingested` is zero.
+
 Session archive/delete state is local metadata. Archiving hides a session from
 default lists, searches, and aggregate statistics. The `include_archived`
 parameter on session-list and statistics operations opts it back into those

--- a/docs/data-lifecycle.md
+++ b/docs/data-lifecycle.md
@@ -232,9 +232,11 @@ archives migrate to the current baseline on open; older archives are
 rebuild-only. The next sync backfills persisted economics, parser enrichments,
 and context rollups when required.
 
-Costs are materialized at ingest. A rebuild uses the pricing table in the new
-Decant version and can therefore change historical estimates even when the
-source logs did not change.
+Costs are materialized at ingest and reconciled with current pricing on every
+sync. This includes unchanged and archived sessions, even when their source
+files are no longer available. Session costs and cached activity cost components
+update in one transaction. Recommendations and server caches refresh after
+repricing. No archive rebuild is needed, and user state is preserved.
 
 Local state that does not come from provider logs belongs to the archive. That
 includes recommendation status, session archive overrides, and deletion

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -95,6 +95,9 @@ show whether an individual request crossed that threshold, so these estimates
 use short-context rates and may be low for qualifying requests. Claude 4.6 and
 later include their full context window at the standard rate.
 
-Costs are stored on the session row when the transcript is ingested. Updating
-the seed table does not rewrite historical rows; rebuild the archive to
-re-estimate existing sessions with a newer pricing table.
+Costs are stored when transcripts are ingested and checked against current
+pricing on every sync, including unchanged and archived sessions. Sync updates
+stale session costs and persisted activity cost components together without
+rereading transcripts or replacing user metadata. Later syncs leave matching
+costs untouched. Aggregate dollar totals include only estimates for supported
+models.

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -1,11 +1,14 @@
 # Pricing estimates
 
 Decant estimates token costs at ingest using published first-party API rates.
-The seed table was last verified on September 2, 2026 against:
+Anthropic and current OpenAI coding-agent rates were last verified on
+September 9, 2026 against the sources below. Legacy OpenAI rates retain their
+September 2, 2026 verification, and Gemini rates were checked September 5, 2026.
 
 - [Anthropic model and prompt-cache pricing](https://platform.claude.com/docs/en/about-claude/pricing)
 - [OpenAI API pricing](https://developers.openai.com/api/docs/pricing)
 - [OpenAI model pages](https://developers.openai.com/api/docs/models)
+- [OpenAI GPT-6 Astra pricing](https://developers.openai.com/api/docs/models/gpt-6-astra)
 - [OpenAI Codex pricing](https://developers.openai.com/codex/pricing)
 - [OpenAI model deprecations](https://developers.openai.com/api/docs/deprecations)
 - [OpenAI GPT-3.5 Turbo launch pricing](https://openai.com/index/introducing-chatgpt-and-whisper-apis/)
@@ -27,6 +30,7 @@ provider does not publish a first-party API token price for that model slug.
 | Claude Sonnet 4.6, 4.5, 4 | $3.00 | $0.30 | $3.75 / $6.00 | $15.00 |
 | Claude Haiku 4.5 | $1.00 | $0.10 | $1.25 / $2.00 | $5.00 |
 | Claude Haiku 3.5 | $0.80 | $0.08 | $1.00 / $1.60 | $4.00 |
+| GPT-6 Astra | $10.00 | $1.00 | $12.50 | $50.00 |
 | GPT-5.6 Sol, GPT-5.6, Daybreak Blue | $4.00 | $0.40 | $5.00 | $20.00 |
 | GPT-5.6 Terra | $2.00 | $0.20 | $2.50 | $12.00 |
 | GPT-5.6 Luna | $0.20 | $0.02 | $0.25 | $1.20 |
@@ -52,8 +56,8 @@ provider does not publish a first-party API token price for that model slug.
 | Gemini image, TTS, live, transcribe, native-audio, computer-use variants | — | — | — | — |
 
 Claude's two cache-write figures are the 5-minute and 1-hour rates. OpenAI
-cache writes before GPT-5.6 have no additional fee; GPT-5.6 reports and bills
-cache writes at 1.25 times the uncached-input rate. Gemini bills cache storage
+cache writes before GPT-5.6 have no additional fee; GPT-5.6 and GPT-6 Astra
+bill cache writes at 1.25 times the uncached-input rate. Gemini bills cache storage
 by the token-hour, so Decant maps the equivalent write charge to approximately
 the input rate for typical session-length holds.
 

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -66,6 +66,7 @@ export function defaultPricing(): Map<string, Price> {
     ["claude-sonnet", claudePrice(3.0, 15.0)],
     ["claude-haiku", claudePrice(1.0, 5.0)],
     ["claude-haiku-3.5", claudePrice(0.8, 4.0)],
+    ["gpt-6-astra", openAiPrice(10.0, 1.0, 50.0, 1.25)],
     ["gpt-5.6-sol", openAiPrice(4.0, 0.4, 20.0, 1.25)],
     ["gpt-5.6-terra", openAiPrice(2.0, 0.2, 12.0, 1.25)],
     ["gpt-5.6-luna", openAiPrice(0.2, 0.02, 1.2, 1.25)],
@@ -208,6 +209,7 @@ function canonicalModel(raw: string): string | null {
   }
 
   for (const key of [
+    "gpt-6-astra",
     "gpt-5.6-cyber",
     "gpt-5.6-sol",
     "gpt-5.6-terra",

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -208,8 +208,11 @@ function canonicalModel(raw: string): string | null {
     return "gpt-5.6-cyber";
   }
 
+  if (model === "gpt-6-astra") {
+    return "gpt-6-astra";
+  }
+
   for (const key of [
-    "gpt-6-astra",
     "gpt-5.6-cyber",
     "gpt-5.6-sol",
     "gpt-5.6-terra",

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -37,6 +37,7 @@ import { parseGeminiSession } from "./sources/gemini.ts";
 import {
   materializeMissingSessionEconomics,
   materializeSessionEconomics,
+  refreshSessionCosts,
 } from "./token-economics.ts";
 import { classifyTool, previewHeadTail } from "./tools.ts";
 import { resolveWorktreeRoots } from "./worktree.ts";
@@ -56,6 +57,8 @@ export interface IngestConfig {
 export const INGEST_PIPELINE_REVISION = 2;
 
 export interface SyncReport {
+  /** Present when stored cost estimates changed without requiring re-ingest. */
+  repriced?: number;
   scanned: number;
   ingested: number;
   skipped: number;
@@ -159,9 +162,11 @@ export function sync(
   onProgress?: SyncProgressListener,
 ): SyncReport {
   seedModelPricing(db);
+  const repriced = refreshSessionCosts(db);
   const files = discover(config);
   const titles = codexTitles(config);
   const report: SyncReport = {
+    ...(repriced > 0 ? { repriced } : {}),
     scanned: files.length,
     ingested: 0,
     skipped: 0,
@@ -296,7 +301,7 @@ export function sync(
           LIMIT 1`,
       )
       .get() != null;
-  if (report.ingested > 0 || uncheckedRecommendationImpactLabels) {
+  if (report.ingested > 0 || repriced > 0 || uncheckedRecommendationImpactLabels) {
     regenerateRecommendations(db);
   }
   if (

--- a/src/server.ts
+++ b/src/server.ts
@@ -781,7 +781,7 @@ async function syncNow(
       `issues ${report.issues}, failed ${report.failed}`;
     syncStatus.ingested_count = report.ingested;
     publishServerEvent({ type: "sync", reason: "manual", report, status: { ...syncStatus } });
-    if (report.ingested > 0) {
+    if (report.ingested > 0 || (report.repriced ?? 0) > 0) {
       economics?.invalidate();
       publishServerEvent({
         type: "archive_updated",
@@ -1232,7 +1232,7 @@ function applyWatchEvent(event: WatchEvent, economics: EconomicsCache): void {
     syncStatus.ingested_count = event.status.ingested_count;
   }
   publishServerEvent(event);
-  if (event.type === "sync" && event.report.ingested > 0) {
+  if (event.type === "sync" && (event.report.ingested > 0 || (event.report.repriced ?? 0) > 0)) {
     economics.invalidate();
     publishServerEvent({
       type: "archive_updated",

--- a/src/token-economics.ts
+++ b/src/token-economics.ts
@@ -363,6 +363,65 @@ export function materializeSessionEconomics(db: Database, sessionId: number): bo
   return true;
 }
 
+/** Reprice stored usage without rereading transcripts or replacing user state.
+ * Check the components too: a rate change can leave the total unchanged. */
+export function refreshSessionCosts(db: Database): number {
+  return withImmediateTransaction(db, () => {
+    const pricing = defaultPricing();
+    const rows = economicsRows<
+      SessionRow & {
+        estimated_cost_usd: number;
+        format_version: number | null;
+        vector_json: string | null;
+      }
+    >(
+      db,
+      `SELECT s.id, s.model, s.estimated_cost_usd,
+               s.total_input_tokens, s.total_output_tokens, s.total_cache_read_tokens,
+               s.total_cache_creation_tokens, s.total_cache_creation_1h_tokens,
+               s.total_reasoning_tokens, e.format_version, e.vector_json
+             FROM session s LEFT JOIN session_economics e ON e.session_id = s.id`,
+    );
+    let refreshed = 0;
+    for (const row of rows) {
+      const parts = estimateCostParts(
+        row.model,
+        {
+          input: row.total_input_tokens,
+          output: row.total_output_tokens,
+          cacheRead: row.total_cache_read_tokens,
+          cacheCreation: row.total_cache_creation_tokens,
+          cacheCreation1h: row.total_cache_creation_1h_tokens,
+          reasoning: row.total_reasoning_tokens,
+        },
+        pricing,
+      );
+      const inputCost = parts.input + parts.cacheRead + parts.cacheCreation;
+      const total = parts.input + parts.output + parts.cacheRead + parts.cacheCreation;
+      const vector =
+        row.format_version === SESSION_ECONOMICS_FORMAT_VERSION && row.vector_json != null
+          ? parseEconomicsVector(row.vector_json)
+          : null;
+      const staleVector =
+        vector != null &&
+        vector.id === row.id &&
+        (vector.input_cost !== inputCost || vector.output_cost !== parts.output);
+      if (row.estimated_cost_usd === total && !staleVector) continue;
+      if (row.estimated_cost_usd !== total) {
+        runEconomicsStatement(db, "UPDATE session SET estimated_cost_usd = ?1 WHERE id = ?2", [
+          total,
+          row.id,
+        ]);
+      }
+      if (staleVector) {
+        storeEconomicsVector(db, { ...vector, input_cost: inputCost, output_cost: parts.output });
+      }
+      refreshed += 1;
+    }
+    return refreshed;
+  });
+}
+
 /** One-time upgrade/backfill path. Normal ingest writes vectors immediately;
  * sync also calls this so unchanged pre-v10 sessions become cached after upgrading. */
 export function materializeMissingSessionEconomics(db: Database): number {

--- a/test/api-contract.test.ts
+++ b/test/api-contract.test.ts
@@ -62,6 +62,7 @@ describe("local API OpenAPI contract", () => {
       hostname: "127.0.0.1",
       port: 0,
       syncRunner: async () => ({
+        repriced: 1,
         scanned: 0,
         ingested: 0,
         skipped: 0,

--- a/test/cost.test.ts
+++ b/test/cost.test.ts
@@ -160,6 +160,10 @@ describe("estimateCost", () => {
     }
     expect(isPriceable("gpt-6")).toBe(false);
     expect(isPriceable("gpt-6-unpublished")).toBe(false);
+    for (const model of ["gpt-6-astra-pro", "gpt-6-astral", "openai/gpt-6-astra-preview"]) {
+      expect(isPriceable(model)).toBe(false);
+      expect(estimateCost(model, usage, pricing)).toBe(0);
+    }
   });
 
   test("gpt-5.6 uses the published input, cache, and output rates", () => {

--- a/test/cost.test.ts
+++ b/test/cost.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { defaultPricing, estimateCost, isPriceable, type Price } from "../src/cost.ts";
+import {
+  defaultPricing,
+  estimateCost,
+  estimateCostParts,
+  isPriceable,
+  type Price,
+} from "../src/cost.ts";
 import { emptyUsage, type TokenUsage } from "../src/model.ts";
 
 // Ports cost.rs tests verbatim — these are the spec for model normalization
@@ -132,6 +138,28 @@ describe("estimateCost", () => {
     expect(estimateCost("gpt-5.4-pro", u, pricing)).toBeCloseTo(210.0, 6);
     expect(estimateCost("gpt-5.5", u, pricing)).toBeCloseTo(35.0, 6);
     expect(estimateCost("gpt-5.5-pro", u, pricing)).toBeCloseTo(210.0, 6);
+  });
+
+  test("Astra prices input, output, cache reads, and cache writes separately", () => {
+    const pricing = defaultPricing();
+    const usage = {
+      ...usage1m(),
+      cacheRead: 2_000_000,
+      cacheCreation: 3_000_000,
+      cacheCreation1h: 1_000_000,
+    };
+    for (const model of ["gpt-6-astra", "openai/gpt-6-astra", "OpenAI:GPT-6-ASTRA"]) {
+      expect(isPriceable(model)).toBe(true);
+      expect(estimateCostParts(model, usage, pricing)).toEqual({
+        input: 10,
+        output: 50,
+        cacheRead: 2,
+        cacheCreation: 37.5,
+      });
+      expect(estimateCost(model, usage, pricing)).toBeCloseTo(99.5, 6);
+    }
+    expect(isPriceable("gpt-6")).toBe(false);
+    expect(isPriceable("gpt-6-unpublished")).toBe(false);
   });
 
   test("gpt-5.6 uses the published input, cache, and output rates", () => {

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -18,6 +18,7 @@ import { setSessionUserState } from "../src/session-user-state.ts";
 import { parseClaudeSession } from "../src/sources/claude.ts";
 import { parseCodexSession } from "../src/sources/codex.ts";
 import { totals } from "../src/stats.ts";
+import { tokenEconomicsForSession } from "../src/token-economics.ts";
 import { ROW_QUERIES } from "./golden-rows.ts";
 
 const repoRoot = join(import.meta.dir, "..");
@@ -1492,6 +1493,71 @@ describe("sync", () => {
         .get(),
     ).toEqual({ cache_write_per_mtok: 12.5, cache_write_1h_per_mtok: 12.5 });
     expect(sync(db, config)).toMatchObject({ ingested: 0, skipped: 1 });
+    db.close();
+  });
+
+  test("reprices retained sessions and activity costs atomically without replacing user state", () => {
+    const dir = freshCase();
+    const config: IngestConfig = { claudeDir: join(dir, "claude"), codexDir: join(dir, "codex") };
+    const path = join(config.codexDir, "sessions", "rollout-astra.jsonl");
+    write(path, fixture("codex", "sample.jsonl").replace('"gpt-5.4"', '"gpt-6-astra"'));
+    const db = openFreshDb(dir);
+    sync(db, config);
+    const original = db.query("SELECT * FROM session").get() as {
+      id: number;
+      [key: string]: unknown;
+    };
+    setSessionUserState(db, original.id, "archived");
+    const state = db.query("SELECT * FROM session_user_state").all();
+    const messages = db.query("SELECT * FROM message").all();
+    const sources = db.query("SELECT * FROM ingest_source").all();
+    db.exec("UPDATE recommendation SET status = 'dismissed'");
+    const recommendations = db
+      .query("SELECT key, status FROM recommendation WHERE kind = 'catalog'")
+      .all();
+    db.exec("UPDATE session SET estimated_cost_usd = 0");
+    db.exec(
+      "UPDATE session_economics SET vector_json = json_set(vector_json, '$.input_cost', 0, '$.output_cost', 0)",
+    );
+    rmSync(path);
+
+    db.exec(
+      "CREATE TEMP TRIGGER reject_reprice BEFORE UPDATE ON session_economics BEGIN SELECT RAISE(ABORT, 'reprice failure'); END",
+    );
+    expect(() => sync(db, config)).toThrow("reprice failure");
+    expect(db.query("SELECT estimated_cost_usd FROM session").get()).toEqual({
+      estimated_cost_usd: 0,
+    });
+    db.exec("DROP TRIGGER reject_reprice");
+
+    expect(sync(db, config)).toMatchObject({ scanned: 0, ingested: 0, repriced: 1 });
+    expect(db.query("SELECT * FROM session").get()).toEqual(original);
+    expect(db.query("SELECT * FROM session_user_state").all()).toEqual(state);
+    expect(db.query("SELECT * FROM message").all()).toEqual(messages);
+    expect(db.query("SELECT * FROM ingest_source").all()).toEqual(sources);
+    expect(db.query("SELECT key, status FROM recommendation WHERE kind = 'catalog'").all()).toEqual(
+      recommendations,
+    );
+    const economics = tokenEconomicsForSession(db, original.id);
+    expect(economics?.totals.input_cost_usd).toBeCloseTo(0.0054, 8);
+    expect(economics?.totals.output_cost_usd).toBeCloseTo(0.0075, 8);
+
+    // A component-only error must be repaired even when the session total is correct.
+    db.exec(
+      "UPDATE session_economics SET vector_json = json_set(vector_json, '$.input_cost', 0.0129, '$.output_cost', 0)",
+    );
+    expect(sync(db, config).repriced).toBe(1);
+    expect(tokenEconomicsForSession(db, original.id)?.totals.output_cost_usd).toBeCloseTo(
+      0.0075,
+      8,
+    );
+    db.exec(
+      "CREATE TEMP TRIGGER reject_session_write BEFORE UPDATE ON session BEGIN SELECT RAISE(ABORT, 'unexpected session write'); END",
+    );
+    db.exec(
+      "CREATE TEMP TRIGGER reject_economics_write BEFORE UPDATE ON session_economics BEGIN SELECT RAISE(ABORT, 'unexpected economics write'); END",
+    );
+    expect(sync(db, config).repriced).toBeUndefined();
     db.close();
   });
 

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -1465,6 +1465,36 @@ describe("sync", () => {
     db.close();
   });
 
+  test("ingests Astra costs and seeds its published cache-write rate", () => {
+    const dir = freshCase();
+    const config: IngestConfig = {
+      claudeDir: join(dir, "claude"),
+      codexDir: join(dir, "codex"),
+    };
+    write(
+      join(config.codexDir, "sessions", "rollout-astra.jsonl"),
+      fixture("codex", "sample.jsonl").replace('"gpt-5.4"', '"gpt-6-astra"'),
+    );
+    const db = openFreshDb(dir);
+    expect(sync(db, config)).toMatchObject({ ingested: 1, failed: 0 });
+    const session = db.query("SELECT model, estimated_cost_usd FROM session").get() as {
+      model: string;
+      estimated_cost_usd: number;
+    };
+    expect(session.model).toBe("gpt-6-astra");
+    // 500 uncached input, 400 cached input, and 150 output tokens.
+    expect(session.estimated_cost_usd).toBeCloseTo(0.0129, 8);
+    expect(
+      db
+        .query(
+          "SELECT cache_write_per_mtok, cache_write_1h_per_mtok FROM model_pricing WHERE model = 'gpt-6-astra'",
+        )
+        .get(),
+    ).toEqual({ cache_write_per_mtok: 12.5, cache_write_1h_per_mtok: 12.5 });
+    expect(sync(db, config)).toMatchObject({ ingested: 0, skipped: 1 });
+    db.close();
+  });
+
   test("backfills effort for an unchanged source once after the schema upgrade", () => {
     const dir = freshCase();
     const config: IngestConfig = {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import type { Config } from "../src/config.ts";
 import { openDb } from "../src/db.ts";
+import { EconomicsCache } from "../src/economics-cache.ts";
 import { upsertSession } from "../src/ingest.ts";
 import { listSessions } from "../src/query.ts";
 import { regenerate } from "../src/recommendations.ts";
@@ -266,6 +267,60 @@ describe("server routes", () => {
     expect(frame).toContain('"reason":"manual"');
     expect(frame).toContain('"scanned":0');
     expect(frame).toContain('"total":0');
+  });
+
+  test("repricing-only sync refreshes cached economics and notifies clients", async () => {
+    const config = freshConfig();
+    const db = openDb(config.dbPath);
+    let builds = 0;
+    const economics = new EconomicsCache({
+      db,
+      dbPath: config.dbPath,
+      computeVectors: async () => {
+        builds += 1;
+        return [];
+      },
+    });
+    await economics.get();
+    const stream = await handleRequest(new Request("http://127.0.0.1:3000/api/events"), config);
+    const reader = stream.body?.getReader();
+    if (reader == null) throw new Error("missing SSE body");
+    await reader.read();
+    try {
+      const response = await handleRequest(
+        new Request("http://127.0.0.1:3000/api/sync", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "{}",
+        }),
+        config,
+        {
+          economics,
+          runSync: async () => ({
+            scanned: 0,
+            ingested: 0,
+            skipped: 0,
+            repriced: 1,
+            issues: 0,
+            issuesByCode: {},
+            failed: 0,
+            cancelled: false,
+          }),
+        },
+      );
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ ingested: 0, repriced: 1 });
+      await economics.settled();
+      expect(builds).toBe(2);
+      const frames =
+        new TextDecoder().decode((await reader.read()).value) +
+        new TextDecoder().decode((await reader.read()).value);
+      expect(frames).toContain("event: archive_updated");
+    } finally {
+      await reader.cancel();
+      await economics.dispose();
+      db.close();
+    }
   });
 
   test("events route terminates a failed manual sync with an error event", async () => {


### PR DESCRIPTION
Updating model prices previously left existing session costs and cached activity costs unchanged. Sync now reconciles both against the current calculator, including unchanged and archived sessions whose source files are unavailable. Stale session costs and activity cost components update in one transaction, recommendations refresh, and the server invalidates economics caches and notifies clients even when no transcript was ingested. Matching costs are left untouched, and transcripts and user metadata are preserved.

Adds GPT-6 Astra's published standard rates per million tokens: $10 input, $1 cached input, $12.50 cache writes, and $50 output. Its published ID and OpenAI-prefixed forms are recognized; unpublished Astra variants remain unpriced. Anthropic and GPT-5.6 rates were rechecked on September 9, 2026 and remain current.

The sync API reports an optional `repriced` count, with the OpenAPI contract and lifecycle, pricing, and methodology documentation updated. There are no UI changes.

Validation: `just check` passed with 1,041 tests, TypeScript, Biome, and the native distribution smoke. Regression coverage includes missing source files, archived user state, recommendation status, transaction rollback, component-only discrepancies, idempotence, repricing-only server cache invalidation, and the API contract.

Sources

- https://developers.openai.com/api/docs/models/gpt-6-astra
- https://developers.openai.com/api/docs/pricing
- https://platform.claude.com/docs/en/about-claude/pricing
